### PR TITLE
feat(ui): shift+up/down on a remote group header reorders it on the remote

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1440,6 +1440,11 @@ func handleAdd(profile string, args []string) {
 		return nil
 	})
 
+	// --create-dir is what the TUI's remote new-session dialog forwards after
+	// the user confirms creating a missing directory on the server; the local
+	// dialog asks the same question and calls os.MkdirAll itself.
+	createDir := fs.Bool("create-dir", false, "Create the project directory when it does not exist (like mkdir -p)")
+
 	// Sandbox flags
 	sandbox := fs.Bool("sandbox", false, "Run session in Docker sandbox")
 	sandboxImage := fs.String("sandbox-image", "", "Docker image for sandbox (overrides config default)")
@@ -1725,6 +1730,13 @@ func handleAdd(profile string, args []string) {
 		path = localPlaceholder
 	} else {
 		info, err := os.Stat(path)
+		if err != nil && *createDir {
+			if mkErr := os.MkdirAll(path, 0o755); mkErr != nil {
+				fmt.Printf("Error: failed to create directory %s: %v\n", path, mkErr)
+				os.Exit(1)
+			}
+			info, err = os.Stat(path)
+		}
 		if err != nil {
 			fmt.Printf("Error: path does not exist: %s\n", path)
 			os.Exit(1)

--- a/cmd/agent-deck/remote_exec.go
+++ b/cmd/agent-deck/remote_exec.go
@@ -39,6 +39,13 @@ func remoteCommandArgs(args []string) ([]string, error) {
 			if len(args) > 1 && args[1] == "attach" {
 				return append([]string(nil), args...), nil
 			}
+		case "group":
+			if len(args) > 1 {
+				switch args[1] {
+				case "list", "reorder":
+					return append([]string(nil), args...), nil
+				}
+			}
 		}
 	}
 	return nil, fmt.Errorf("unsupported remote command %q; run 'agent-deck remote' for supported commands", strings.Join(args, " "))

--- a/cmd/agent-deck/remote_exec_test.go
+++ b/cmd/agent-deck/remote_exec_test.go
@@ -103,6 +103,7 @@ func TestRemoteCommandParity(t *testing.T) {
 		{"session", "stop", "missing", "--json"}, {"session", "restart", "missing", "--json"},
 		{"worktree", "info", "missing", "--json"}, {"mcp", "attach", "missing", "none", "--json"},
 		{"skill", "attach", "missing", "none"},
+		{"group", "list", "--json"}, {"group", "reorder", "missing", "--up", "--json"},
 	} {
 		t.Run(strings.Join(args, "_"), func(t *testing.T) {
 			local, localErr, localCode := run(remote, "", args...)
@@ -130,7 +131,7 @@ func TestRemoteCommandParity(t *testing.T) {
 	if out, _, _ := run(controller, "", "list", "--json"); strings.Contains(out, title) {
 		t.Fatalf("remote add wrote controller registry: %s", out)
 	}
-	for _, args := range [][]string{{"version"}, {"session", "remove", title}, {"remote", "list"}, {"--help"}} {
+	for _, args := range [][]string{{"version"}, {"session", "remove", title}, {"remote", "list"}, {"--help"}, {"group", "delete", "work"}} {
 		sentinel := filepath.Join(remote, "unsupported-ssh-called")
 		write(filepath.Join(shim, "sentinel"), "#!/bin/sh\nprintf called > '"+sentinel+"'\n", 0700)
 		write(filepath.Join(controller, ".config", "agent-deck", "config.toml"), fmt.Sprintf("[remotes.lab]\nhost = 'test-host'\nagent_deck_path = '%s'\n", filepath.Join(shim, "sentinel")), 0600)

--- a/docs/REMOTE-COMMANDS.md
+++ b/docs/REMOTE-COMMANDS.md
@@ -49,6 +49,7 @@ Pressing `n` on a remote group or session opens the same new-session dialog as f
 | Docker sandbox | `-sandbox`; the image comes from the server's config |
 | Worktree | `-w <branch>`; the worktree and, when missing, the branch are created in the server's repository. An auto-filled branch travels as the bare slug and the server applies its own `[worktree].branch_prefix` once; a branch you type is sent as entered |
 | Codex and Gemini YOLO | `--yolo` |
+| A path that does not exist on the server | the server refuses the create; the TUI then asks "create this directory on remote `<name>`?" and, only if you confirm, retries with `--create-dir` so the server runs the equivalent of `mkdir -p`. A remote running an agent-deck older than `--create-dir` refuses the retry with an unknown-flag error; create the directory there by hand |
 
 Because the server applies its own defaults, the dialog opens with these options cleared for a remote target instead of pre-filled from your local `config.toml`; a local `[claude].dangerous_mode` or `default_model` never reaches a remote unless you set it in the dialog.
 

--- a/docs/REMOTE-COMMANDS.md
+++ b/docs/REMOTE-COMMANDS.md
@@ -28,6 +28,8 @@ Run the same command through `remote lab`. Output, JSON fields, diagnostics and 
 | `worktree cleanup --json` | `remote lab worktree cleanup --json` |
 | `mcp attach task memory` | `remote lab mcp attach task memory` |
 | `skill attach task review` | `remote lab skill attach task review` |
+| `group list --json` | `remote lab group list --json` |
+| `group reorder work --up` | `remote lab group reorder work --up` |
 
 Prefix every entry with `agent-deck`. The full `session show/output/send` forms also work remotely. Interactive attach uses the existing `agent-deck remote attach lab task` command. Other commands are rejected before execution; there is no local fallback. Interactive options such as `session start --attach` need a terminal and are better run from an SSH login.
 
@@ -58,3 +60,7 @@ Fields the remote `add` cannot express are refused with a message in the dialog 
 Remote-management commands such as `remote list` and `remote remove lab` operate on your local configuration. New remote names cannot match those command names. For an existing conflicting name, use the explicit execution form, for example `remote exec remove list --json`; ambiguous shorthand refuses to act. Rename the conflicting entry in your configuration before using the matching management command.
 
 If a worktree operation needs an approved repository setup script, pass `--allow-repo-scripts` after the remote name. The server applies that explicit consent. Normal cleanup confirmation still applies to destructive cleanup.
+
+## Reordering remote groups from the TUI
+
+Shift+Up/Down (and the K/J aliases) on a remote group header run `group reorder <path> --up|--down` on that remote, the same command its own TUI runs, so the new order is stored in the remote's state DB and is shown to everyone who lists that remote. Remote group headers follow the order the remote reports in `group list --json`; the footer says when the remote refused because the group is already first or last among its siblings. A remote running an agent-deck older than `group list --json` keeps listing its groups by name. Sessions inside a remote group keep their local, per-viewer order. The remote host header itself follows the `[remotes]` order in `config.toml`.

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -258,7 +258,13 @@ func (r *SSHRunner) run(ctx context.Context, args ...string) ([]byte, error) {
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("ssh command failed: %w: %s", err, stderr.String())
+		// The remote CLI reports refusals such as "path does not exist" on
+		// stdout; fall back to it so the failure is not a bare exit status.
+		detail := stderr.String()
+		if strings.TrimSpace(detail) == "" {
+			detail = strings.TrimSpace(stdout.String())
+		}
+		return nil, fmt.Errorf("ssh command failed: %w: %s", err, detail)
 	}
 
 	return stdout.Bytes(), nil
@@ -1127,6 +1133,21 @@ type RemoteAddOptions struct {
 	// WorktreeBranch creates the session in a git worktree for this branch on
 	// the server (-w); the branch is created there when it does not exist.
 	WorktreeBranch string
+	// CreateDir asks the server to create a missing Path (--create-dir). The
+	// TUI sets it only after the server reported the path missing and the
+	// user confirmed; a remote too old for the flag refuses the command.
+	CreateDir bool
+}
+
+// remoteMissingPathMarker is the text the remote `add` prints when its
+// project directory does not exist (see the add command's os.Stat check).
+const remoteMissingPathMarker = "path does not exist"
+
+// IsRemotePathMissing reports whether a remote create failed because the
+// project directory does not exist on the server, so the caller can offer to
+// create it and retry with RemoteAddOptions.CreateDir.
+func IsRemotePathMissing(err error) bool {
+	return err != nil && strings.Contains(err.Error(), remoteMissingPathMarker)
 }
 
 // remoteAddArgs builds the `agent-deck add` argument list for creating a
@@ -1186,6 +1207,9 @@ func remoteAddArgs(o RemoteAddOptions) ([]string, error) {
 	}
 	if b := strings.TrimSpace(o.WorktreeBranch); b != "" {
 		args = append(args, "-w", b)
+	}
+	if o.CreateDir {
+		args = append(args, "--create-dir")
 	}
 	if p := strings.TrimSpace(o.Path); p != "" && p != "." {
 		args = append(args, p)

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -14,7 +14,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -710,7 +709,11 @@ type groupListEntryJSON struct {
 // buckets (which can only ever contain groups that currently hold sessions),
 // the remote's group list includes EMPTY groups, so the local move dialog (M
 // key on a remote session) can still offer a folder after every session has
-// been moved out of it. Paths are normalized, deduped and sorted.
+// been moved out of it. Paths are normalized and deduped, and they keep the
+// order the remote listed them in: that listing is the remote's own group
+// order (siblings by their persisted Order, a parent before its children),
+// which is what the TUI renders remote group headers in and what
+// ReorderGroup changes.
 //
 // Returns nil with no error when the remote returns empty output (older
 // agent-deck builds that predate the JSON shape); callers fall back to the
@@ -735,7 +738,8 @@ func (r *SSHRunner) FetchGroupPaths(ctx context.Context) ([]string, error) {
 }
 
 // parseGroupListPaths flattens the recursive group tree from `group list
-// --json` into normalized, deduped, sorted group paths. Extracted as a pure
+// --json` into normalized, deduped group paths in the remote's own order (a
+// pre-order walk: parent, then its children as listed). Extracted as a pure
 // function so the parsing is unit-testable without an SSH round-trip.
 func parseGroupListPaths(parsed groupListJSON) []string {
 	seen := make(map[string]bool)
@@ -752,8 +756,59 @@ func parseGroupListPaths(parsed groupListJSON) []string {
 		}
 	}
 	walk(parsed.Groups)
-	sort.Strings(paths)
 	return paths
+}
+
+// remoteGroupReorderArgs builds the argv for moving one remote group among
+// its siblings: `group reorder <path> --up|--down --json`. delta < 0 moves
+// up, anything else moves down. The full path is passed, which the remote
+// resolves exactly, so two groups sharing a leaf name in different parents
+// cannot be confused.
+func remoteGroupReorderArgs(groupPath string, delta int) []string {
+	direction := "--down"
+	if delta < 0 {
+		direction = "--up"
+	}
+	return []string{"group", "reorder", groupPath, direction, "--json"}
+}
+
+// groupReorderResultJSON is the payload of `group reorder --json`.
+type groupReorderResultJSON struct {
+	FromPosition int `json:"from_position"`
+	ToPosition   int `json:"to_position"`
+}
+
+// ReorderGroup moves one group of the remote up (delta < 0) or down among its
+// siblings by running `agent-deck group reorder` there, the same command the
+// remote's own TUI runs for shift+up/down on a group header. The order is
+// persisted in the remote's state DB, so every viewer of that remote sees it.
+//
+// The returned bool reports whether the remote actually changed the position:
+// the remote refuses silently when the group is already at the edge of its
+// siblings, and the caller must not announce a move that did not happen. An
+// older remote whose reorder prints no JSON is treated as moved, since it
+// exited 0.
+func (r *SSHRunner) ReorderGroup(ctx context.Context, groupPath string, delta int) (bool, error) {
+	output, err := r.Run(ctx, remoteGroupReorderArgs(groupPath, delta)...)
+	if err != nil {
+		return false, err
+	}
+	return parseGroupReorderMoved(output), nil
+}
+
+// parseGroupReorderMoved reads the from/to positions out of a `group reorder
+// --json` payload. Output that is not JSON reports true: the command exited 0
+// and nothing says the group stayed put.
+func parseGroupReorderMoved(output []byte) bool {
+	trimmed := bytes.TrimSpace(output)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return true
+	}
+	var parsed groupReorderResultJSON
+	if err := json.Unmarshal(trimmed, &parsed); err != nil {
+		return true
+	}
+	return parsed.FromPosition != parsed.ToPosition
 }
 
 // FetchCostSummary retrieves the remote agent-deck's cost summary as JSON.

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -14,6 +14,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -684,6 +685,69 @@ func (r *SSHRunner) FetchSessionPane(ctx context.Context, sessionID string) (str
 	}
 
 	return parseRemoteSessionOutput(output)
+}
+
+// groupListJSON mirrors the subset of `agent-deck group list --json` output
+// the TUI needs: the recursive group path tree. Counts and status are
+// ignored — a group with zero sessions is still a valid move/create target.
+type groupListJSON struct {
+	Groups []groupListEntryJSON `json:"groups"`
+}
+
+type groupListEntryJSON struct {
+	Path     string               `json:"path"`
+	Children []groupListEntryJSON `json:"children,omitempty"`
+}
+
+// FetchGroupPaths retrieves the remote's full group path list from its own
+// state DB via `agent-deck group list --json`. Unlike session-derived group
+// buckets (which can only ever contain groups that currently hold sessions),
+// the remote's group list includes EMPTY groups, so the local move dialog (M
+// key on a remote session) can still offer a folder after every session has
+// been moved out of it. Paths are normalized, deduped and sorted.
+//
+// Returns nil with no error when the remote returns empty output (older
+// agent-deck builds that predate the JSON shape); callers fall back to the
+// groups observed on the fetched sessions.
+func (r *SSHRunner) FetchGroupPaths(ctx context.Context) ([]string, error) {
+	output, err := r.Run(ctx, "group", "list", "--json")
+	if err != nil {
+		return nil, err
+	}
+
+	trimmed := bytes.TrimSpace(output)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return nil, nil
+	}
+
+	var parsed groupListJSON
+	if err := json.Unmarshal(trimmed, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse remote group list: %w", err)
+	}
+
+	return parseGroupListPaths(parsed), nil
+}
+
+// parseGroupListPaths flattens the recursive group tree from `group list
+// --json` into normalized, deduped, sorted group paths. Extracted as a pure
+// function so the parsing is unit-testable without an SSH round-trip.
+func parseGroupListPaths(parsed groupListJSON) []string {
+	seen := make(map[string]bool)
+	var paths []string
+	var walk func(entries []groupListEntryJSON)
+	walk = func(entries []groupListEntryJSON) {
+		for _, e := range entries {
+			p := strings.Trim(strings.TrimSpace(e.Path), "/")
+			if p != "" && !seen[p] {
+				seen[p] = true
+				paths = append(paths, p)
+			}
+			walk(e.Children)
+		}
+	}
+	walk(parsed.Groups)
+	sort.Strings(paths)
+	return paths
 }
 
 // FetchCostSummary retrieves the remote agent-deck's cost summary as JSON.

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -572,5 +573,69 @@ func TestSSHRunnerCreateSessionWithOptions_RefusedValueNeverContactsRemote(t *te
 	}
 	if calls != 0 {
 		t.Fatalf("remote contacted %d times for a refused value, want 0", calls)
+	}
+}
+
+// TestParseGroupListPaths pins the group-list flattener that backs
+// SSHRunner.FetchGroupPaths: `group list --json` returns a recursive tree
+// whose paths (including EMPTY groups — session_count 0) must all surface,
+// deduped and sorted, for the remote move/create dialogs.
+func TestParseGroupListPaths(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "empty list",
+			input: `{"groups":[],"total_groups":0,"total_sessions":0}`,
+			want:  []string{},
+		},
+		{
+			name: "flat groups incl. an empty one",
+			input: `{"groups":[
+				{"name":"emptytest","path":"emptytest","session_count":0},
+				{"name":"work","path":"work","session_count":3}
+			],"total_groups":2,"total_sessions":3}`,
+			want: []string{"emptytest", "work"},
+		},
+		{
+			name: "nested children flattened with full paths",
+			input: `{"groups":[
+				{"name":"my-sessions","path":"my-sessions","session_count":7,
+				 "children":[
+					{"name":"done","path":"my-sessions/done","session_count":6,
+					 "children":[
+						{"name":"deep","path":"my-sessions/done/deep","session_count":0}
+					 ]}
+				 ]}
+			],"total_groups":3,"total_sessions":7}`,
+			want: []string{"my-sessions", "my-sessions/done", "my-sessions/done/deep"},
+		},
+		{
+			name: "slashes and whitespace normalized",
+			input: `{"groups":[
+				{"name":"a","path":"/a/","session_count":0}
+			],"total_groups":1,"total_sessions":0}`,
+			want: []string{"a"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var parsed groupListJSON
+			if err := json.Unmarshal([]byte(tt.input), &parsed); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			got := parseGroupListPaths(parsed)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseGroupListPaths = %v, want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("parseGroupListPaths[%d] = %q, want %q (all: %v)", i, got[i], tt.want[i], got)
+				}
+			}
+		})
 	}
 }

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -584,7 +584,8 @@ func TestSSHRunnerCreateSessionWithOptions_RefusedValueNeverContactsRemote(t *te
 // TestParseGroupListPaths pins the group-list flattener that backs
 // SSHRunner.FetchGroupPaths: `group list --json` returns a recursive tree
 // whose paths (including EMPTY groups — session_count 0) must all surface,
-// deduped and sorted, for the remote move/create dialogs.
+// deduped and in the remote's own order (siblings as listed, a parent before
+// its children), for the remote move/create dialogs and the group headers.
 func TestParseGroupListPaths(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -624,6 +625,21 @@ func TestParseGroupListPaths(t *testing.T) {
 			],"total_groups":1,"total_sessions":0}`,
 			want: []string{"a"},
 		},
+		{
+			// The remote lists siblings by their persisted Order, which is
+			// not name order once someone has reordered them; that order is
+			// the whole point of the list and must survive the flattening.
+			name: "remote order kept, not re-sorted by name",
+			input: `{"groups":[
+				{"name":"work","path":"work","session_count":1,
+				 "children":[
+					{"name":"zeta","path":"work/zeta","session_count":0},
+					{"name":"alpha","path":"work/alpha","session_count":0}
+				 ]},
+				{"name":"archive","path":"archive","session_count":0}
+			],"total_groups":4,"total_sessions":1}`,
+			want: []string{"work", "work/zeta", "work/alpha", "archive"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -656,5 +672,31 @@ func TestIsRemotePathMissing(t *testing.T) {
 	}
 	if IsRemotePathMissing(nil) {
 		t.Fatal("nil error treated as a missing path")
+	}
+}
+
+// The TUI forwards shift+up/down on a remote group header as `group reorder`
+// with the full path, and reads the remote's from/to positions back so a
+// refused edge move is never announced as a move.
+func TestRemoteGroupReorderArgsAndResult(t *testing.T) {
+	if got := strings.Join(remoteGroupReorderArgs("work/api", -1), " "); got != "group reorder work/api --up --json" {
+		t.Fatalf("up args = %q", got)
+	}
+	if got := strings.Join(remoteGroupReorderArgs("work", 1), " "); got != "group reorder work --down --json" {
+		t.Fatalf("down args = %q", got)
+	}
+	for _, tc := range []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{"moved", `{"success":true,"name":"work","path":"work","from_position":1,"to_position":0}`, true},
+		{"already at edge", `{"success":true,"name":"work","path":"work","from_position":0,"to_position":0}`, false},
+		{"older remote, human output", "✓ Reordered group 'work': position 1 → 0\n", true},
+		{"empty output", "", true},
+	} {
+		if got := parseGroupReorderMoved([]byte(tc.output)); got != tc.want {
+			t.Errorf("%s: parseGroupReorderMoved = %v, want %v", tc.name, got, tc.want)
+		}
 	}
 }

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -197,6 +197,11 @@ func TestRemoteAddArgs(t *testing.T) {
 			want: []string{"add", "--json", "-t", "fix", "-c", "codex", "/srv/project"},
 		},
 		{
+			name: "create a missing remote directory only after confirmation",
+			opts: RemoteAddOptions{Tool: "codex", Title: "fix", Path: "/srv/new", CreateDir: true},
+			want: []string{"add", "--json", "-t", "fix", "-c", "codex", "--create-dir", "/srv/new"},
+		},
+		{
 			name: "tool without title auto-names via --quick",
 			opts: RemoteAddOptions{Tool: "pi"},
 			want: []string{"add", "--json", "--quick", "-c", "pi"},
@@ -637,5 +642,19 @@ func TestParseGroupListPaths(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// The remote `add` reports a missing project directory on stdout; the TUI
+// recognises that refusal to offer creating the directory, and nothing else.
+func TestIsRemotePathMissing(t *testing.T) {
+	if !IsRemotePathMissing(errors.New("ssh command failed: exit status 1: Error: path does not exist: /srv/new")) {
+		t.Fatal("missing-path refusal not recognised")
+	}
+	if IsRemotePathMissing(errors.New("ssh command failed: exit status 255: connection refused")) {
+		t.Fatal("unrelated failure treated as a missing path")
+	}
+	if IsRemotePathMissing(nil) {
+		t.Fatal("nil error treated as a missing path")
 	}
 }

--- a/internal/ui/confirm_dialog.go
+++ b/internal/ui/confirm_dialog.go
@@ -260,6 +260,19 @@ func (c *ConfirmDialog) GetPendingSession() (name, path, command, groupPath stri
 	return c.pendingSessionName, c.pendingSessionPath, c.pendingSessionCommand, c.pendingSessionGroupPath, c.pendingToolOptionsJSON, c.pendingClaudeExtraArgs, c.pendingClaudeStartQuery, c.pendingClaudeAccount, c.pendingLaunchModelID, c.pendingParentSessionID, c.pendingParentProjectPath
 }
 
+// ShowCreateRemoteDirectory asks whether to create a directory the remote
+// reported missing (see session.IsRemotePathMissing) and retry the create
+// there with --create-dir. The pending dialog values stay on Home.
+func (c *ConfirmDialog) ShowCreateRemoteDirectory(remoteName, path string) {
+	c.visible = true
+	c.confirmType = ConfirmCreateDirectory
+	c.targetID = path
+	c.targetName = path
+	c.remoteName = remoteName
+	c.buttonCount = 2
+	c.focusedButton = 1
+}
+
 // Hide hides the dialog.
 func (c *ConfirmDialog) Hide() {
 	c.visible = false
@@ -477,6 +490,9 @@ func (c *ConfirmDialog) View() string {
 	case ConfirmCreateDirectory:
 		title = "📁  Directory Not Found"
 		warning = fmt.Sprintf("The path does not exist:\n\n  %s", c.targetName)
+		if c.remoteName != "" {
+			warning = fmt.Sprintf("The path does not exist on remote %s:\n\n  %s", c.remoteName, c.targetName)
+		}
 		details = "Create this directory and start the session?"
 		borderColor = ColorAccent
 		buttonRow := lipgloss.JoinHorizontal(lipgloss.Center,

--- a/internal/ui/group_dialog.go
+++ b/internal/ui/group_dialog.go
@@ -38,6 +38,12 @@ type GroupDialog struct {
 	// Tab toggle between Root and Subgroup modes (Issue #111)
 	contextParentPath string // Original cursor context parent path (for toggling back)
 	contextParentName string // Original cursor context parent name (for toggling back)
+
+	// remoteName is non-empty when the dialog was opened on a REMOTE row
+	// (g key on a remote session/group header). The group is then created in
+	// the remote's own state DB via SSH instead of the local group tree; the
+	// create handler in home.go uses RemoteName() to pick the routing.
+	remoteName string
 }
 
 // NewGroupDialog creates a new group dialog
@@ -64,7 +70,8 @@ func NewGroupDialog() *GroupDialog {
 func (g *GroupDialog) Show() {
 	g.visible = true
 	g.mode = GroupDialogCreate
-	g.groupPath = "" // No parent = root level
+	g.remoteName = "" // local
+	g.groupPath = ""  // No parent = root level
 	g.parentName = ""
 	g.validationErr = ""
 	g.nameInput.SetValue("")
@@ -77,6 +84,7 @@ func (g *GroupDialog) Show() {
 func (g *GroupDialog) ShowCreateSubgroup(parentPath, parentName string) {
 	g.visible = true
 	g.mode = GroupDialogCreate
+	g.remoteName = ""        // local
 	g.groupPath = parentPath // Parent path for the new subgroup
 	g.parentName = parentName
 	g.validationErr = ""
@@ -92,6 +100,7 @@ func (g *GroupDialog) ShowCreateSubgroup(parentPath, parentName string) {
 func (g *GroupDialog) ShowCreateWithContext(parentPath, parentName string) {
 	g.visible = true
 	g.mode = GroupDialogCreate
+	g.remoteName = "" // local
 	g.contextParentPath = parentPath
 	g.contextParentName = parentName
 	g.validationErr = ""
@@ -119,6 +128,57 @@ func (g *GroupDialog) ShowCreateWithContextDefaultRoot(parentPath, parentName st
 	g.mode = GroupDialogCreate
 	g.contextParentPath = parentPath
 	g.contextParentName = parentName
+	g.remoteName = "" // local
+	g.validationErr = ""
+	g.nameInput.SetValue("")
+	g.nameInput.CursorEnd() // Issue #604
+	g.resetPathInput()
+	g.focusName()
+
+	// Default to root mode, Tab toggles to subgroup
+	g.groupPath = ""
+	g.parentName = ""
+}
+
+// ShowCreateRemoteWithContext opens the create dialog for a REMOTE context
+// (g key on a remote group header): the new group is created on the remote
+// host via SSH (see home.go createRemoteGroup), with parentPath set to the
+// header's own group path so the remote creates a subgroup under it. Pass an
+// empty parentPath for the level-0 host header (root-level remote group).
+func (g *GroupDialog) ShowCreateRemoteWithContext(parentPath, parentName, remoteName string) {
+	g.visible = true
+	g.mode = GroupDialogCreate
+	g.contextParentPath = parentPath
+	g.contextParentName = parentName
+	g.remoteName = remoteName
+	g.validationErr = ""
+	g.nameInput.SetValue("")
+	g.nameInput.CursorEnd() // Issue #604
+	g.resetPathInput()
+	g.focusName()
+
+	if parentPath != "" {
+		// Default to subgroup mode
+		g.groupPath = parentPath
+		g.parentName = parentName
+	} else {
+		// Root mode, no toggle
+		g.groupPath = ""
+		g.parentName = ""
+	}
+}
+
+// ShowCreateRemoteWithContextDefaultRoot is the remote counterpart of
+// ShowCreateWithContextDefaultRoot: opens the create dialog defaulting to
+// root mode on the remote, storing the cursor context so Tab can toggle to
+// subgroup mode under the session's current group. The created group is
+// routed to the remote's own state DB (home.go createRemoteGroup).
+func (g *GroupDialog) ShowCreateRemoteWithContextDefaultRoot(parentPath, parentName, remoteName string) {
+	g.visible = true
+	g.mode = GroupDialogCreate
+	g.contextParentPath = parentPath
+	g.contextParentName = parentName
+	g.remoteName = remoteName
 	g.validationErr = ""
 	g.nameInput.SetValue("")
 	g.nameInput.CursorEnd() // Issue #604
@@ -157,6 +217,7 @@ func (g *GroupDialog) ToggleRootSubgroup() {
 func (g *GroupDialog) ShowRename(currentPath, currentName string) {
 	g.visible = true
 	g.mode = GroupDialogRename
+	g.remoteName = "" // not a create
 	g.groupPath = currentPath
 	g.validationErr = ""
 	g.nameInput.SetValue(currentName)
@@ -170,6 +231,7 @@ func (g *GroupDialog) ShowRename(currentPath, currentName string) {
 func (g *GroupDialog) ShowMove(groupPaths []string) {
 	g.visible = true
 	g.mode = GroupDialogMove
+	g.remoteName = "" // not a create; reset any stale remote create context
 	g.validationErr = ""
 	g.groupPaths = groupPaths
 	g.selected = 0
@@ -179,6 +241,7 @@ func (g *GroupDialog) ShowMove(groupPaths []string) {
 func (g *GroupDialog) ShowRenameSession(sessionID, currentName string) {
 	g.visible = true
 	g.mode = GroupDialogRenameSession
+	g.remoteName = "" // not a create
 	g.sessionID = sessionID
 	g.validationErr = ""
 	g.nameInput.SetValue(currentName)
@@ -193,9 +256,17 @@ func (g *GroupDialog) GetSessionID() string {
 	return g.sessionID
 }
 
+// RemoteName returns the remote the create dialog is scoped to (g key on a
+// remote row), or "" when the dialog creates a LOCAL group. The create
+// handler routes to the remote's own state DB via SSH when non-empty.
+func (g *GroupDialog) RemoteName() string {
+	return g.remoteName
+}
+
 // Hide hides the dialog
 func (g *GroupDialog) Hide() {
 	g.visible = false
+	g.remoteName = ""
 	g.nameInput.Blur()
 }
 
@@ -399,6 +470,15 @@ func (g *GroupDialog) View() string {
 		} else {
 			title = "Create New Group"
 			content = fields
+		}
+
+		// Remote create (g on a remote row): make the routing explicit so the
+		// user knows the group will be created on the remote host, not locally.
+		if g.remoteName != "" {
+			remoteInfo := lipgloss.NewStyle().
+				Foreground(ColorCyan).
+				Render("Remote: " + g.remoteName)
+			content = remoteInfo + "\n\n" + content
 		}
 
 		// Add Root/Subgroup toggle indicator when Tab toggle is available

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -624,9 +624,15 @@ type Home struct {
 	uiStateSaveTicks     int      // Counter for periodic UI state saves in tick handler
 
 	// Remote sessions (Phase 2: Agent-Deck Remotes)
-	remoteSessions     map[string][]session.RemoteSessionInfo // remoteName -> sessions
-	remoteFromCache    map[string]bool                        // remoteName -> data is a startup cache snapshot, not live yet
-	remoteFetchedAt    map[string]time.Time                   // remoteName -> when its sessions last came from a live fetch
+	remoteSessions map[string][]session.RemoteSessionInfo // remoteName -> sessions
+	// remoteGroups holds each remote's FULL group path list as reported by
+	// its own state DB (`agent-deck group list --json`, fetched on the same
+	// fleet poll). Unlike session-derived buckets it includes EMPTY groups,
+	// so the M move dialog can still offer a remote folder after every
+	// session has been moved out of it. Guarded by remoteSessionsMu.
+	remoteGroups       map[string][]string  // remoteName -> sorted group paths (incl. empty groups)
+	remoteFromCache    map[string]bool      // remoteName -> data is a startup cache snapshot, not live yet
+	remoteFetchedAt    map[string]time.Time // remoteName -> when its sessions last came from a live fetch
 	remoteSessionsMu   sync.RWMutex
 	lastRemoteFetch    time.Time // When remote sessions were last fetched
 	remotesFetchActive bool      // Prevents overlapping fetches
@@ -1396,6 +1402,14 @@ type remoteSessionsFetchedMsg struct {
 	sessions map[string][]session.RemoteSessionInfo
 	// #1101: per-remote cost summary collected on the same SSH fanout.
 	costs map[string]*costs.RemoteCostSummary
+	// groups holds each remote's FULL group path list (incl. empty groups)
+	// from `group list --json`, so the move/create dialogs can offer folders
+	// that currently hold no sessions. Only remotes that reported a fresh
+	// list appear here.
+	groups map[string][]string
+	// groupsFailed marks remotes whose group-list fetch errored this round;
+	// the handler keeps their last-good cached group paths.
+	groupsFailed map[string]bool
 	// failed marks remotes whose fetch errored this round (issue #1170).
 	// The handler keeps their last-good sessions instead of wiping them,
 	// so one slow/offline remote can't flicker the whole list.
@@ -2120,21 +2134,31 @@ func (h *Home) scopedGroupPaths() []string {
 	return scoped
 }
 
-// remoteGroupPaths returns the distinct, normalized group paths currently
-// observed on a remote, sorted for the move dialog (M key on a remote
-// session). These are the only groups the remote knows about; a remote move
-// is executed with `agent-deck group move <id> <group>` on that host.
+// remoteGroupPaths returns the distinct, normalized group paths available as
+// move targets on a remote, sorted for the move dialog (M key on a remote
+// session). The remote's own group list (fetched on the fleet poll via
+// `group list --json`) is the primary source: unlike session-derived buckets
+// it includes EMPTY groups, so a folder that currently holds no sessions is
+// still offered after every session has been moved out of it. Groups observed
+// on the fetched sessions are unioned in as a fallback for remotes whose
+// group-list fetch failed or predates the JSON shape.
 func (h *Home) remoteGroupPaths(remoteName string) []string {
 	h.remoteSessionsMu.RLock()
 	defer h.remoteSessionsMu.RUnlock()
 	seen := make(map[string]bool)
 	var paths []string
-	for _, s := range h.remoteSessions[remoteName] {
-		p := normalizeRemoteGroupPath(s.Group)
+	add := func(p string) {
+		p = normalizeRemoteGroupPath(p)
 		if !seen[p] {
 			seen[p] = true
 			paths = append(paths, p)
 		}
+	}
+	for _, p := range h.remoteGroups[remoteName] {
+		add(p)
+	}
+	for _, s := range h.remoteSessions[remoteName] {
+		add(s.Group)
 	}
 	sort.Strings(paths)
 	return paths
@@ -3538,6 +3562,14 @@ func (h *Home) fetchRemoteSessions() tea.Msg {
 	// as "remote contributes zero" so a single broken remote can't poison
 	// the displayed total.
 	costResults := make(map[string]*costs.RemoteCostSummary, len(config.Remotes))
+	// Remote group lists (group list --json) ride the same fanout so the
+	// move/create dialogs can offer EMPTY remote folders — a folder that
+	// currently holds no sessions is invisible to session-derived buckets
+	// but is still a valid target. Successful fetches land in groupResults;
+	// failures in groupsFailed keep last-good cache entries (same contract
+	// as the sessions map, issue #1170).
+	groupResults := make(map[string][]string, len(config.Remotes))
+	groupsFailed := make(map[string]bool, len(config.Remotes))
 	// #1170: track remotes that errored so the handler keeps their last-good
 	// sessions instead of dropping them.
 	failed := make(map[string]bool, len(config.Remotes))
@@ -3563,6 +3595,8 @@ func (h *Home) fetchRemoteSessions() tea.Msg {
 			if err != nil {
 				mu.Lock()
 				failed[name] = true
+				// The group list can't be trusted either — keep last-good.
+				groupsFailed[name] = true
 				mu.Unlock()
 				return
 			}
@@ -3576,17 +3610,33 @@ func (h *Home) fetchRemoteSessions() tea.Msg {
 			summary, costErr := runner.FetchCostSummary(costCtx)
 			costCancel()
 
+			// Group list fetch has the same isolation: a slow `group list`
+			// on one remote must not starve the session/cost data of any
+			// other remote, and a failure degrades to the session-derived
+			// group fallback in remoteGroupPaths.
+			groupCtx, groupCancel := context.WithTimeout(h.ctx, rc.GetCommandTimeout())
+			groupPaths, groupErr := runner.FetchGroupPaths(groupCtx)
+			groupCancel()
+
 			mu.Lock()
 			results[name] = sessions
 			if costErr == nil && summary != nil {
 				costResults[name] = summary
+			}
+			if groupErr == nil {
+				if groupPaths == nil {
+					groupPaths = []string{}
+				}
+				groupResults[name] = groupPaths
+			} else {
+				groupsFailed[name] = true
 			}
 			mu.Unlock()
 		}(name, rc)
 	}
 	wg.Wait()
 
-	return remoteSessionsFetchedMsg{sessions: results, costs: costResults, failed: failed}
+	return remoteSessionsFetchedMsg{sessions: results, costs: costResults, groups: groupResults, groupsFailed: groupsFailed, failed: failed}
 }
 
 // mergeRemoteSessions reconciles a freshly fetched remote-session map against
@@ -6571,6 +6621,26 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// #1170: merge rather than wholesale-replace so a remote that errored
 		// this round keeps its last-good sessions instead of flickering out.
 		h.remoteSessions = mergeRemoteSessions(h.remoteSessions, msg.sessions, msg.failed)
+		// Remote group lists: replace wholesale for remotes that reported a
+		// fresh list; failed remotes keep their last-good cached paths so the
+		// move dialog doesn't lose empty-group targets on a transient SSH
+		// hiccup. Remotes absent from BOTH lists are dropped (deconfigured).
+		if h.remoteGroups == nil {
+			h.remoteGroups = make(map[string][]string)
+		}
+		keepGroups := make(map[string]bool, len(msg.groups)+len(msg.groupsFailed))
+		for name, paths := range msg.groups {
+			h.remoteGroups[name] = paths
+			keepGroups[name] = true
+		}
+		for name := range msg.groupsFailed {
+			keepGroups[name] = true
+		}
+		for name := range h.remoteGroups {
+			if !keepGroups[name] {
+				delete(h.remoteGroups, name)
+			}
+		}
 		for name := range msg.sessions {
 			if !msg.failed[name] {
 				delete(h.remoteFromCache, name)

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1362,6 +1362,17 @@ type maintenanceCompleteMsg struct {
 	result session.MaintenanceResult
 }
 
+// remoteMoveResultMsg reports the outcome of an SSH-routed "move to group"
+// for a remote session (M key → GroupDialogMove). The session's row lives in
+// the remote's own state DB, so the move is executed there and the local
+// fleet cache is patched only after the remote confirms.
+type remoteMoveResultMsg struct {
+	remoteName string
+	sessionID  string
+	groupPath  string
+	err        error
+}
+
 // clearMaintenanceMsg signals auto-clear of maintenance banner
 type clearMaintenanceMsg struct{}
 
@@ -2107,6 +2118,55 @@ func (h *Home) scopedGroupPaths() []string {
 		}
 	}
 	return scoped
+}
+
+// remoteGroupPaths returns the distinct, normalized group paths currently
+// observed on a remote, sorted for the move dialog (M key on a remote
+// session). These are the only groups the remote knows about; a remote move
+// is executed with `agent-deck group move <id> <group>` on that host.
+func (h *Home) remoteGroupPaths(remoteName string) []string {
+	h.remoteSessionsMu.RLock()
+	defer h.remoteSessionsMu.RUnlock()
+	seen := make(map[string]bool)
+	var paths []string
+	for _, s := range h.remoteSessions[remoteName] {
+		p := normalizeRemoteGroupPath(s.Group)
+		if !seen[p] {
+			seen[p] = true
+			paths = append(paths, p)
+		}
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+// moveRemoteSessionToGroup routes a TUI "move to group" for a remote session
+// over SSH: the session's row lives in the remote's own state DB, so the
+// local tree cannot move it. Runs `agent-deck group move <id> <group>` on the
+// remote (the same command the remote's own TUI would run) and returns a
+// remoteMoveResultMsg so the fleet cache is updated only on remote
+// confirmation. Mirrors the remote-rename path in GroupDialogRenameSession.
+func (h *Home) moveRemoteSessionToGroup(title, remoteName, sessionID, targetGroupPath string) tea.Cmd {
+	return func() tea.Msg {
+		config, err := session.LoadUserConfig()
+		if err != nil || config == nil || config.Remotes == nil {
+			return remoteMoveResultMsg{remoteName: remoteName, sessionID: sessionID, groupPath: targetGroupPath,
+				err: fmt.Errorf("cannot move '%s': failed to load remotes config: %v", title, err)}
+		}
+		rc, ok := config.Remotes[remoteName]
+		if !ok {
+			return remoteMoveResultMsg{remoteName: remoteName, sessionID: sessionID, groupPath: targetGroupPath,
+				err: fmt.Errorf("cannot move '%s': remote '%s' is not configured", title, remoteName)}
+		}
+		runner := session.NewSSHRunner(remoteName, rc)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if _, err := runner.RunCommand(ctx, "group", "move", sessionID, targetGroupPath); err != nil {
+			return remoteMoveResultMsg{remoteName: remoteName, sessionID: sessionID, groupPath: targetGroupPath,
+				err: fmt.Errorf("failed to move '%s' on %s: %v", title, remoteName, err)}
+		}
+		return remoteMoveResultMsg{remoteName: remoteName, sessionID: sessionID, groupPath: targetGroupPath}
+	}
 }
 
 // groupScopeDisplayName returns the human-readable name for the active group scope.
@@ -6627,6 +6687,29 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return h, nil
 
+	case remoteMoveResultMsg:
+		if msg.err != nil {
+			h.setError(msg.err)
+			return h, nil
+		}
+		// Remote confirmed; patch the local fleet cache so the row moves
+		// groups immediately, before the next poll re-fetches the truth.
+		// The persisted local order overlay for the old bucket is harmless:
+		// applyRemoteSessionOrder skips overlay IDs the remote no longer
+		// reports in that bucket.
+		h.remoteSessionsMu.Lock()
+		if sessions, ok := h.remoteSessions[msg.remoteName]; ok {
+			for i := range sessions {
+				if sessions[i].ID == msg.sessionID {
+					sessions[i].Group = msg.groupPath
+					break
+				}
+			}
+		}
+		h.remoteSessionsMu.Unlock()
+		h.rebuildFlatItems()
+		return h, nil
+
 	case reviverTickMsg:
 		// Fire-and-forget reviver sweep for instances whose tmux server
 		// survived an SSH scope cleanup but whose pipe was reaped. Runs in
@@ -9450,6 +9533,13 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				h.setError(errSessionStillCreating)
 			} else if item.Type == session.ItemTypeSession {
 				h.groupDialog.ShowMove(h.scopedGroupPaths())
+			} else if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil {
+				// Remote sessions live in the remote's own state DB, so the
+				// local tree cannot move them. Offer the group paths currently
+				// observed on that remote (the only groups the remote knows
+				// about); the confirmed move is routed over SSH in
+				// GroupDialogMove (see moveRemoteSessionToGroup).
+				h.groupDialog.ShowMove(h.remoteGroupPaths(item.RemoteName))
 			}
 		}
 		return h, nil
@@ -11630,6 +11720,10 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		h.clearError() // Clear any previous validation error
 
+		// moveCmd is set when the confirmed action is a remote-session move,
+		// which runs over SSH and reports back via remoteMoveResultMsg.
+		var moveCmd tea.Cmd
+
 		switch h.groupDialog.Mode() {
 		case GroupDialogCreate:
 			name := h.groupDialog.GetValue()
@@ -11700,6 +11794,12 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					h.instancesMu.Unlock()
 					h.rebuildFlatItems()
 					h.saveInstances()
+				} else if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil && item.RemoteName != "" {
+					// The row lives in the remote's own DB; run
+					// `agent-deck group move` there over SSH (mirrors the
+					// remote-rename path) and refresh the fleet cache when the
+					// remote confirms via remoteMoveResultMsg.
+					moveCmd = h.moveRemoteSessionToGroup(item.RemoteSession.Title, item.RemoteName, item.RemoteSession.ID, targetGroupPath)
 				}
 			}
 		case GroupDialogRenameSession:
@@ -11788,7 +11888,7 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		h.groupDialog.Hide()
 		h.lastGTime = time.Time{} // Reset gg-detection so next 'g' opens dialog, not jump-to-top
-		return h, nil
+		return h, moveCmd
 	case "esc":
 		h.groupDialog.Hide()
 		h.clearError()            // Clear any validation error

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -719,6 +719,9 @@ type Home struct {
 	// dropped otherwise, so a slow answer for an earlier opening can never
 	// replace the slot list the user is choosing from now.
 	remoteAccountsGen uint64
+	// pendingRemoteCreate holds the remote create whose path the server
+	// reported missing, while the create-directory confirmation is open.
+	pendingRemoteCreate *remoteCreateDirNeededMsg
 	// insertKeySender is the persistent dispatch path opened on
 	// enterInsertMode and closed on exitInsertMode (#1102 perf fix +
 	// remote support). Local sessions get a tmux.KeySender (control-mode
@@ -6767,6 +6770,15 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.applyRemoteAccounts(msg)
 		return h, nil
 
+	case remoteCreateDirNeededMsg:
+		// The server refused the path; ask before retrying with --create-dir
+		// so a typo never silently creates a directory on the remote.
+		pending := msg
+		h.pendingRemoteCreate = &pending
+		h.confirmDialog.ShowCreateRemoteDirectory(msg.remoteName, msg.opts.Path)
+		h.beginAttachReturnGrace(time.Now())
+		return h, tea.Batch(tea.EnableMouseCellMotion, RestoreLegacyKeyboardCmd(os.Stdout), tea.WindowSize())
+
 	case remoteSessionCreatedMsg:
 		if msg.err != nil {
 			h.setError(msg.err)
@@ -10672,9 +10684,11 @@ func (h *Home) handleConfirmDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if h.confirmDialog.GetFocusedButton() == 0 {
 				return h, h.confirmCreateDirectory()
 			}
+			h.pendingRemoteCreate = nil
 			h.confirmDialog.Hide()
 			return h, nil
 		case "n", "N", "esc":
+			h.pendingRemoteCreate = nil
 			h.confirmDialog.Hide()
 			return h, nil
 		}
@@ -10799,6 +10813,17 @@ func (h *Home) confirmAction() tea.Cmd {
 
 // confirmCreateDirectory handles the "yes" action for ConfirmCreateDirectory.
 func (h *Home) confirmCreateDirectory() tea.Cmd {
+	if pending := h.pendingRemoteCreate; pending != nil {
+		h.pendingRemoteCreate = nil
+		h.confirmDialog.Hide()
+		opts := pending.opts
+		opts.CreateDir = true
+		create := h.createRemoteSessionWithOptions
+		if h.remoteCreateSink != nil {
+			create = h.remoteCreateSink
+		}
+		return create(pending.remoteName, opts)
+	}
 	name, path, command, groupPath, pendingToolOpts, pendingExtraArgs, pendingStartQuery, pendingAccount, pendingLaunchModelID, parentSessionID, parentProjectPath := h.confirmDialog.GetPendingSession()
 	h.confirmDialog.Hide()
 	if err := os.MkdirAll(path, 0o755); err != nil {
@@ -14341,6 +14366,14 @@ type remoteSessionCreatedMsg struct {
 	err error
 }
 
+// remoteCreateDirNeededMsg reports a remote create refused because the
+// dialog's path does not exist on the server; Home offers to create it.
+type remoteCreateDirNeededMsg struct {
+	remoteName string
+	opts       session.RemoteAddOptions
+	err        error
+}
+
 // deleteRemoteSession deletes a remote session and refreshes the remote list.
 func (h *Home) deleteRemoteSession(remoteName, sessionID, title string) tea.Cmd {
 	return func() tea.Msg {
@@ -14761,6 +14794,9 @@ func (h *Home) createRemoteSessionWithOptions(remoteName string, opts session.Re
 			var attachErr remoteAttachFailedError
 			if errors.As(err, &attachErr) {
 				return remoteSessionCreatedMsg{err: fmt.Errorf("failed to attach to remote session after creating it: %w", attachErr)}
+			}
+			if !opts.CreateDir && strings.TrimSpace(opts.Path) != "" && session.IsRemotePathMissing(err) {
+				return remoteCreateDirNeededMsg{remoteName: remoteName, opts: opts, err: err}
 			}
 			return sessionCreatedMsg{err: fmt.Errorf("failed to create remote session: %w", err)}
 		}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -630,7 +630,7 @@ type Home struct {
 	// fleet poll). Unlike session-derived buckets it includes EMPTY groups,
 	// so the M move dialog can still offer a remote folder after every
 	// session has been moved out of it. Guarded by remoteSessionsMu.
-	remoteGroups       map[string][]string  // remoteName -> sorted group paths (incl. empty groups)
+	remoteGroups       map[string][]string  // remoteName -> group paths in the remote's own order (incl. empty groups)
 	remoteFromCache    map[string]bool      // remoteName -> data is a startup cache snapshot, not live yet
 	remoteFetchedAt    map[string]time.Time // remoteName -> when its sessions last came from a live fetch
 	remoteSessionsMu   sync.RWMutex
@@ -1389,6 +1389,18 @@ type remoteMoveResultMsg struct {
 type remoteGroupResultMsg struct {
 	remoteName string
 	groupPath  string
+	err        error
+}
+
+// remoteGroupReorderResultMsg reports the outcome of an SSH-routed group
+// reorder (shift+up/down on a remote group header → `group reorder` on the
+// remote). delta is -1 for up and +1 for down; moved is the remote's own
+// verdict, false when the group was already at the edge of its siblings.
+type remoteGroupReorderResultMsg struct {
+	remoteName string
+	groupPath  string
+	delta      int
+	moved      bool
 	err        error
 }
 
@@ -2758,9 +2770,11 @@ func (h *Home) rebuildFlatItemsAt(now time.Time) {
 	h.remoteSessionsMu.RLock()
 	remoteNames := make([]string, 0, len(h.remoteSessions))
 	remotes := make(map[string][]session.RemoteSessionInfo, len(h.remoteSessions))
+	remoteGroupLists := make(map[string][]string, len(h.remoteGroups))
 	for name, sessions := range h.remoteSessions {
 		remoteNames = append(remoteNames, name)
 		remotes[name] = append([]session.RemoteSessionInfo(nil), sessions...)
+		remoteGroupLists[name] = append([]string(nil), h.remoteGroups[name]...)
 	}
 	h.remoteSessionsMu.RUnlock()
 	sort.Strings(remoteNames)
@@ -2933,8 +2947,9 @@ func (h *Home) rebuildFlatItemsAt(now time.Time) {
 			// describe the surviving sessions.
 			// #1553: nest each remote's sessions under their Group paths
 			// instead of dumping them flat at Level 1.
-			// #1875: apply the user's manual row order for this remote.
-			h.flatItems = append(h.flatItems, buildRemoteFlatItemsOrdered(remoteName, sessions, h.remoteGroupsCollapsed, h.remoteSessionOrder.forRemote(remoteName))...)
+			// #1875: apply the user's manual row order for this remote, and
+			// the remote's own group order to the group headers.
+			h.flatItems = append(h.flatItems, buildRemoteFlatItemsWithGroups(remoteName, sessions, h.remoteGroupsCollapsed, h.remoteSessionOrder.forRemote(remoteName), remoteGroupLists[remoteName])...)
 		}
 	}
 
@@ -6874,11 +6889,38 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		if !seen {
+			// Appended, not sorted: the list is in the remote's own group
+			// order, and a new group joins the end of it there too.
 			h.remoteGroups[msg.remoteName] = append(h.remoteGroups[msg.remoteName], msg.groupPath)
-			sort.Strings(h.remoteGroups[msg.remoteName])
 		}
 		h.remoteSessionsMu.Unlock()
 		h.setError(fmt.Errorf("created group '%s' on %s", msg.groupPath, msg.remoteName))
+		return h, nil
+
+	case remoteGroupReorderResultMsg:
+		if msg.err != nil {
+			h.setError(msg.err)
+			return h, nil
+		}
+		direction := "up"
+		if msg.delta > 0 {
+			direction = "down"
+		}
+		if !msg.moved {
+			h.setError(fmt.Errorf("'%s' did not move %s on %s: it is already at the edge of its siblings there", msg.groupPath, direction, msg.remoteName))
+			return h, nil
+		}
+		// Remote confirmed and persisted the new order; patch the cached
+		// group list the same way so the header moves now, before the next
+		// fleet poll re-reads the truth from `group list`.
+		h.remoteSessionsMu.Lock()
+		if h.remoteGroups == nil {
+			h.remoteGroups = make(map[string][]string)
+		}
+		h.remoteGroups[msg.remoteName] = swapRemoteGroupSibling(h.remoteGroups[msg.remoteName], msg.groupPath, msg.delta)
+		h.remoteSessionsMu.Unlock()
+		h.clearError()
+		h.rebuildFlatItemsPreservingSelection(h.captureSelectedItemIdentity())
 		return h, nil
 
 	case reviverTickMsg:
@@ -9461,8 +9503,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				// carry a local order overlay instead. Returning here also
 				// skips the forceSaveInstances below, which has nothing to do
 				// with a remote reorder.
-				h.moveRemoteItem(item, -1)
-				return h, nil
+				return h, h.moveRemoteItem(item, -1)
 			case session.ItemTypeGroup:
 				h.groupTree.MoveGroupUp(item.Path)
 				h.rebuildFlatItems()
@@ -9498,8 +9539,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			switch item.Type {
 			case session.ItemTypeRemoteSession, session.ItemTypeRemoteGroup:
 				// #1875 — see the shift+up twin above.
-				h.moveRemoteItem(item, 1)
-				return h, nil
+				return h, h.moveRemoteItem(item, 1)
 			case session.ItemTypeGroup:
 				h.groupTree.MoveGroupDown(item.Path)
 				h.rebuildFlatItems()
@@ -14834,15 +14874,11 @@ func (a attachWindowCmd) SetStderr(w io.Writer) {}
 // being fixed — a remote row that swallows the keystroke is indistinguishable
 // from a stuck key.
 //
-// Remote GROUP headers deliberately do not reorder. buildRemoteFlatItems emits
-// them by walking the bucket paths in lexicographic order, which is what makes
-// a parent header land immediately before its descendants and lets the
-// intermediate headers of "a/b/c" be synthesized on the fly; a manual group
-// order would have to replace that walk with a real tree. Remote groups also
-// have no identity of their own — they exist only as the Group strings of the
-// sessions inside them, so a group with no sessions cannot even be addressed.
-// The header therefore says so instead of going quiet.
-func (h *Home) moveRemoteItem(item session.Item, delta int) {
+// Remote GROUP headers are different: their order lives in the remote's own
+// state DB, so the move is forwarded as `group reorder` and the header only
+// moves once the remote confirms (see reorderRemoteGroup); the returned
+// command carries that round trip. Session moves return nil.
+func (h *Home) moveRemoteItem(item session.Item, delta int) tea.Cmd {
 	direction := "up"
 	edge := "first"
 	if delta > 0 {
@@ -14851,17 +14887,16 @@ func (h *Home) moveRemoteItem(item session.Item, delta int) {
 	}
 
 	if item.Type == session.ItemTypeRemoteGroup {
-		h.setError(fmt.Errorf("cannot move %s: remote group rows are ordered by name — reorder the sessions inside instead", direction))
-		return
+		return h.reorderRemoteGroup(item, delta)
 	}
 	if item.RemoteSession == nil || item.RemoteName == "" {
 		h.setError(fmt.Errorf("cannot move %s: this remote session row is malformed", direction))
-		return
+		return nil
 	}
 	moved := item.RemoteSession
 	if moved.ID == "" {
 		h.setError(fmt.Errorf("cannot move '%s' %s: %s did not report an id for it", moved.Title, direction, item.RemoteName))
-		return
+		return nil
 	}
 
 	// The bucket is the one buildRemoteFlatItems put this row in: same remote,
@@ -14884,7 +14919,7 @@ func (h *Home) moveRemoteItem(item session.Item, delta int) {
 	for _, id := range natural {
 		if id == "" {
 			h.setError(fmt.Errorf("cannot move '%s' %s: %s lists a session without an id in this group, so its order cannot be tracked", moved.Title, direction, item.RemoteName))
-			return
+			return nil
 		}
 	}
 
@@ -14896,7 +14931,7 @@ func (h *Home) moveRemoteItem(item session.Item, delta int) {
 	// answering to the same ID cannot be told apart. Report it instead.
 	if dup, ok := firstDuplicateID(natural); ok {
 		h.setError(fmt.Errorf("cannot move '%s' %s: %s lists more than one session with id %q in this group, so their order cannot be tracked", moved.Title, direction, item.RemoteName, dup))
-		return
+		return nil
 	}
 
 	// Start from what is actually on screen — the fetched list with the
@@ -14912,13 +14947,13 @@ func (h *Home) moveRemoteItem(item session.Item, delta int) {
 	}
 	if pos < 0 {
 		h.setError(fmt.Errorf("cannot move '%s' %s: it is no longer listed on %s", moved.Title, direction, item.RemoteName))
-		return
+		return nil
 	}
 
 	target := pos + delta
 	if target < 0 || target >= len(current) {
 		h.setError(fmt.Errorf("'%s' is already %s in its group on %s", moved.Title, edge, item.RemoteName))
-		return
+		return nil
 	}
 	current[pos], current[target] = current[target], current[pos]
 
@@ -14938,6 +14973,131 @@ func (h *Home) moveRemoteItem(item session.Item, delta int) {
 	if err := h.saveUIStateErr(); err != nil {
 		h.setError(fmt.Errorf("moved '%s' %s, but the order could not be saved and will not survive a restart: %w", moved.Title, direction, err))
 	}
+	return nil
+}
+
+// reorderRemoteGroup forwards shift+up/down on a remote group header to the
+// remote as `group reorder <path> --up|--down`, the same command the remote's
+// own TUI runs for the same keystroke, so the order is persisted in the
+// remote's state DB and every viewer of that remote sees it. The level-0 host
+// header is not a remote group: remotes are listed in config order.
+//
+// The edge check runs locally first, against the sibling headers actually on
+// screen, so a group that is already first or last gets an immediate answer
+// without an SSH round trip. The remote's own verdict still decides the rest
+// (see remoteGroupReorderResultMsg).
+func (h *Home) reorderRemoteGroup(item session.Item, delta int) tea.Cmd {
+	direction := "up"
+	edge := "first"
+	if delta > 0 {
+		direction = "down"
+		edge = "last"
+	}
+	groupPath := remoteGroupPathFromItem(item)
+	if groupPath == "" || item.RemoteName == "" {
+		h.setError(fmt.Errorf("cannot move %s: remote hosts are listed in the order of [remotes] in config.toml", direction))
+		return nil
+	}
+
+	siblings := h.visibleRemoteGroupSiblings(item.RemoteName, groupPath)
+	pos := -1
+	for i, p := range siblings {
+		if p == groupPath {
+			pos = i
+			break
+		}
+	}
+	target := pos + delta
+	if pos >= 0 && (target < 0 || target >= len(siblings)) {
+		h.setError(fmt.Errorf("'%s' is already %s among its siblings on %s", groupPath, edge, item.RemoteName))
+		return nil
+	}
+
+	remoteName := item.RemoteName
+	return func() tea.Msg {
+		config, err := session.LoadUserConfig()
+		if err != nil || config == nil || config.Remotes == nil {
+			return remoteGroupReorderResultMsg{remoteName: remoteName, groupPath: groupPath, delta: delta,
+				err: fmt.Errorf("cannot move '%s' %s: failed to load remotes config: %v", groupPath, direction, err)}
+		}
+		rc, ok := config.Remotes[remoteName]
+		if !ok {
+			return remoteGroupReorderResultMsg{remoteName: remoteName, groupPath: groupPath, delta: delta,
+				err: fmt.Errorf("cannot move '%s' %s: remote '%s' is not configured", groupPath, direction, remoteName)}
+		}
+		runner := session.NewSSHRunner(remoteName, rc)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		moved, err := runner.ReorderGroup(ctx, groupPath, delta)
+		if err != nil {
+			return remoteGroupReorderResultMsg{remoteName: remoteName, groupPath: groupPath, delta: delta,
+				err: fmt.Errorf("failed to move '%s' %s on %s: %v", groupPath, direction, remoteName, err)}
+		}
+		return remoteGroupReorderResultMsg{remoteName: remoteName, groupPath: groupPath, delta: delta, moved: moved}
+	}
+}
+
+// visibleRemoteGroupSiblings lists the group headers currently on screen for
+// one remote that share groupPath's parent, in screen order.
+func (h *Home) visibleRemoteGroupSiblings(remoteName, groupPath string) []string {
+	parent := ""
+	if i := strings.LastIndex(groupPath, "/"); i >= 0 {
+		parent = groupPath[:i]
+	}
+	var siblings []string
+	for _, it := range h.flatItems {
+		if it.Type != session.ItemTypeRemoteGroup || it.RemoteName != remoteName {
+			continue
+		}
+		p := remoteGroupPathFromItem(it)
+		if p == "" {
+			continue
+		}
+		pp := ""
+		if i := strings.LastIndex(p, "/"); i >= 0 {
+			pp = p[:i]
+		}
+		if pp == parent {
+			siblings = append(siblings, p)
+		}
+	}
+	return siblings
+}
+
+// swapRemoteGroupSibling returns paths with groupPath exchanged against its
+// nearest sibling (same parent) in the given direction, mirroring what
+// GroupTree.MoveGroupUp/Down did on the remote. A path that is missing or has
+// no sibling in that direction leaves the list unchanged.
+func swapRemoteGroupSibling(paths []string, groupPath string, delta int) []string {
+	out := append([]string(nil), paths...)
+	parentOf := func(p string) string {
+		if i := strings.LastIndex(p, "/"); i >= 0 {
+			return p[:i]
+		}
+		return ""
+	}
+	pos := -1
+	for i, p := range out {
+		if p == groupPath {
+			pos = i
+			break
+		}
+	}
+	if pos < 0 {
+		return out
+	}
+	parent := parentOf(groupPath)
+	step := 1
+	if delta < 0 {
+		step = -1
+	}
+	for j := pos + step; j >= 0 && j < len(out); j += step {
+		if parentOf(out[j]) == parent {
+			out[pos], out[j] = out[j], out[pos]
+			return out
+		}
+	}
+	return out
 }
 
 // attachRemoteSession attaches to a remote session via SSH, suspending the TUI.

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1379,6 +1379,16 @@ type remoteMoveResultMsg struct {
 	err        error
 }
 
+// remoteGroupResultMsg reports the outcome of an SSH-routed "create group"
+// for a remote context (g key on a remote row → GroupDialogCreate). The
+// group must be created in the remote's own state DB; groupPath is the full
+// path the remote assigned (parent/name, or name for a root-level group).
+type remoteGroupResultMsg struct {
+	remoteName string
+	groupPath  string
+	err        error
+}
+
 // clearMaintenanceMsg signals auto-clear of maintenance banner
 type clearMaintenanceMsg struct{}
 
@@ -2191,6 +2201,56 @@ func (h *Home) moveRemoteSessionToGroup(title, remoteName, sessionID, targetGrou
 		}
 		return remoteMoveResultMsg{remoteName: remoteName, sessionID: sessionID, groupPath: targetGroupPath}
 	}
+}
+
+// createRemoteGroup routes a TUI "create group" (g key on a remote row) over
+// SSH: the group must be created in the remote's own state DB, not the local
+// tree. Runs `agent-deck group create <name> [--parent <parent>]` on the
+// remote and returns a remoteGroupResultMsg so the local group-path cache is
+// updated only on remote confirmation. Mirrors moveRemoteSessionToGroup and
+// the remote-rename path in GroupDialogRenameSession.
+func (h *Home) createRemoteGroup(name, remoteName, parentPath string) tea.Cmd {
+	return func() tea.Msg {
+		config, err := session.LoadUserConfig()
+		if err != nil || config == nil || config.Remotes == nil {
+			return remoteGroupResultMsg{remoteName: remoteName,
+				err: fmt.Errorf("cannot create group '%s': failed to load remotes config: %v", name, err)}
+		}
+		rc, ok := config.Remotes[remoteName]
+		if !ok {
+			return remoteGroupResultMsg{remoteName: remoteName,
+				err: fmt.Errorf("cannot create group '%s': remote '%s' is not configured", name, remoteName)}
+		}
+		runner := session.NewSSHRunner(remoteName, rc)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		args := []string{"group", "create", name}
+		if parentPath != "" {
+			args = append(args, "--parent", parentPath)
+		}
+		if _, err := runner.RunCommand(ctx, args...); err != nil {
+			return remoteGroupResultMsg{remoteName: remoteName,
+				err: fmt.Errorf("failed to create group '%s' on %s: %v", name, remoteName, err)}
+		}
+		full := name
+		if parentPath != "" {
+			full = parentPath + "/" + name
+		}
+		return remoteGroupResultMsg{remoteName: remoteName, groupPath: full}
+	}
+}
+
+// remoteGroupPathFromItem extracts the remote-relative group path from a
+// remote group header's Item.Path ("remotes/<name>/<group-path>"); returns
+// "" for the level-0 host header (Path == "remotes/<name>"). Used by the g
+// key handler to decide the parent for a remote subgroup create.
+func remoteGroupPathFromItem(item session.Item) string {
+	prefix := "remotes/" + item.RemoteName + "/"
+	p := strings.TrimPrefix(item.Path, prefix)
+	if p == item.Path {
+		return "" // level-0 host header
+	}
+	return p
 }
 
 // groupScopeDisplayName returns the human-readable name for the active group scope.
@@ -6780,6 +6840,35 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.rebuildFlatItems()
 		return h, nil
 
+	case remoteGroupResultMsg:
+		if msg.err != nil {
+			h.setError(msg.err)
+			return h, nil
+		}
+		// Remote confirmed the group exists; add it to the cached group list
+		// so the M move dialog (and subsequent subgroup creates) offer it
+		// immediately, before the next fleet poll re-confirms from the
+		// remote's own DB. The sessions map is untouched — creating a group
+		// moves no sessions.
+		h.remoteSessionsMu.Lock()
+		if h.remoteGroups == nil {
+			h.remoteGroups = make(map[string][]string)
+		}
+		seen := false
+		for _, p := range h.remoteGroups[msg.remoteName] {
+			if p == msg.groupPath {
+				seen = true
+				break
+			}
+		}
+		if !seen {
+			h.remoteGroups[msg.remoteName] = append(h.remoteGroups[msg.remoteName], msg.groupPath)
+			sort.Strings(h.remoteGroups[msg.remoteName])
+		}
+		h.remoteSessionsMu.Unlock()
+		h.setError(fmt.Errorf("created group '%s' on %s", msg.groupPath, msg.remoteName))
+		return h, nil
+
 	case reviverTickMsg:
 		// Fire-and-forget reviver sweep for instances whose tmux server
 		// survived an SSH scope cleanup but whose pipe was reaped. Runs in
@@ -9696,7 +9785,32 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		} else if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
-			if item.Type == session.ItemTypeGroup {
+			if item.Type == session.ItemTypeRemoteGroup {
+				// Remote group header (incl. the level-0 host header): create
+				// the group on the remote itself. The parent defaults to the
+				// header's own group path so Enter creates a remote subgroup;
+				// Tab toggles to root-level remote create (issue #111 parity).
+				parentPath := remoteGroupPathFromItem(item)
+				parentName := parentPath
+				if idx := strings.LastIndex(parentPath, "/"); idx >= 0 {
+					parentName = parentPath[idx+1:]
+				}
+				h.groupDialog.ShowCreateRemoteWithContext(parentPath, parentName, item.RemoteName)
+			} else if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil {
+				// Remote session: default to a root-level group on the remote;
+				// Tab toggles to a subgroup under the session's current group.
+				if gPath := item.RemoteSession.Group; gPath != "" {
+					gName := gPath
+					if idx := strings.LastIndex(gPath, "/"); idx >= 0 {
+						gName = gPath[idx+1:]
+					}
+					h.groupDialog.ShowCreateRemoteWithContextDefaultRoot(gPath, gName, item.RemoteName)
+				} else {
+					// Ungrouped remote session: root only, no toggle (mirrors
+					// the local ungrouped case below).
+					h.groupDialog.ShowCreateRemoteWithContext("", "", item.RemoteName)
+				}
+			} else if item.Type == session.ItemTypeGroup {
 				// On group header: default to subgroup mode
 				h.groupDialog.ShowCreateWithContext(item.Group.Path, item.Group.Name)
 			} else if item.Type == session.ItemTypeSession && item.Session != nil && item.Session.GroupPath != "" {
@@ -11790,14 +11904,29 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		h.clearError() // Clear any previous validation error
 
-		// moveCmd is set when the confirmed action is a remote-session move,
-		// which runs over SSH and reports back via remoteMoveResultMsg.
-		var moveCmd tea.Cmd
+		// remoteCmd is set when the confirmed action runs over SSH against a
+		// remote's own state DB (remote-session move, remote group create) and
+		// reports back via remoteMoveResultMsg / remoteGroupResultMsg.
+		var remoteCmd tea.Cmd
 
 		switch h.groupDialog.Mode() {
 		case GroupDialogCreate:
 			name := h.groupDialog.GetValue()
 			if name != "" {
+				if remoteName := h.groupDialog.RemoteName(); remoteName != "" {
+					// g was pressed on a REMOTE row: the group must be created
+					// in the remote's own state DB, not the local tree. Run
+					// `agent-deck group create` there over SSH (mirrors the
+					// remote-move and remote-rename paths); the local group
+					// path cache updates when the remote confirms via
+					// remoteGroupResultMsg.
+					parentPath := ""
+					if h.groupDialog.HasParent() {
+						parentPath = h.groupDialog.GetParentPath()
+					}
+					remoteCmd = h.createRemoteGroup(name, remoteName, parentPath)
+					break
+				}
 				// Seed the new-group default from [group_defaults].max_concurrent.
 				if cfg, _ := session.LoadUserConfig(); cfg != nil {
 					h.groupTree.DefaultMaxConcurrent = cfg.GroupDefaults.MaxConcurrent
@@ -11869,7 +11998,7 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					// `agent-deck group move` there over SSH (mirrors the
 					// remote-rename path) and refresh the fleet cache when the
 					// remote confirms via remoteMoveResultMsg.
-					moveCmd = h.moveRemoteSessionToGroup(item.RemoteSession.Title, item.RemoteName, item.RemoteSession.ID, targetGroupPath)
+					remoteCmd = h.moveRemoteSessionToGroup(item.RemoteSession.Title, item.RemoteName, item.RemoteSession.ID, targetGroupPath)
 				}
 			}
 		case GroupDialogRenameSession:
@@ -11958,7 +12087,7 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		h.groupDialog.Hide()
 		h.lastGTime = time.Time{} // Reset gg-detection so next 'g' opens dialog, not jump-to-top
-		return h, moveCmd
+		return h, remoteCmd
 	case "esc":
 		h.groupDialog.Hide()
 		h.clearError()            // Clear any validation error

--- a/internal/ui/remote_create_dir_test.go
+++ b/internal/ui/remote_create_dir_test.go
@@ -1,0 +1,76 @@
+package ui
+
+import (
+	"errors"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// A remote create whose path the server reports missing must not end as a
+// bare error in the footer: the TUI asks whether to create the directory on
+// that remote and, only on confirmation, retries with CreateDir set so the
+// server's `add --create-dir` makes it.
+
+func newRemoteDirNeededHome(t *testing.T) (*Home, *remoteCreateCapture) {
+	t.Helper()
+	setXDGTestHome(t)
+	h := newTestHomeWithItems(100, 30, nil)
+	capture := &remoteCreateCapture{}
+	h.remoteCreateSink = capture.sink
+	return h, capture
+}
+
+func missingDirMsg() remoteCreateDirNeededMsg {
+	return remoteCreateDirNeededMsg{
+		remoteName: "lab",
+		opts:       session.RemoteAddOptions{Tool: "claude", Title: "new work", Path: "/srv/new-project"},
+		err:        errors.New("ssh command failed: exit status 1: Error: path does not exist: /srv/new-project"),
+	}
+}
+
+func TestRemoteCreateMissingDir_ConfirmRetriesWithCreateDir(t *testing.T) {
+	h, capture := newRemoteDirNeededHome(t)
+
+	model, _ := h.Update(missingDirMsg())
+	h = model.(*Home)
+	if !h.confirmDialog.IsVisible() || h.confirmDialog.GetConfirmType() != ConfirmCreateDirectory {
+		t.Fatalf("missing remote path must open the create-directory confirmation, got visible=%v type=%v",
+			h.confirmDialog.IsVisible(), h.confirmDialog.GetConfirmType())
+	}
+	if got := h.confirmDialog.GetRemoteName(); got != "lab" {
+		t.Fatalf("confirmation remote = %q, want lab", got)
+	}
+	if capture.calls != 0 {
+		t.Fatalf("remote contacted %d times before the user confirmed, want 0", capture.calls)
+	}
+
+	model, _ = h.handleConfirmDialogKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	h = model.(*Home)
+	if capture.calls != 1 {
+		t.Fatalf("remote create calls after confirm = %d, want 1", capture.calls)
+	}
+	if capture.remoteName != "lab" || !capture.opts.CreateDir || capture.opts.Path != "/srv/new-project" || capture.opts.Title != "new work" {
+		t.Fatalf("retry forwarded remote=%q opts=%+v; want the same dialog values on lab with CreateDir", capture.remoteName, capture.opts)
+	}
+	if h.confirmDialog.IsVisible() || h.pendingRemoteCreate != nil {
+		t.Fatal("confirmation must close and clear the pending create after retrying")
+	}
+}
+
+func TestRemoteCreateMissingDir_CancelCreatesNothing(t *testing.T) {
+	h, capture := newRemoteDirNeededHome(t)
+
+	model, _ := h.Update(missingDirMsg())
+	h = model.(*Home)
+	model, _ = h.handleConfirmDialogKey(tea.KeyMsg{Type: tea.KeyEsc})
+	h = model.(*Home)
+	if capture.calls != 0 {
+		t.Fatalf("remote contacted %d times after cancel, want 0", capture.calls)
+	}
+	if h.confirmDialog.IsVisible() || h.pendingRemoteCreate != nil {
+		t.Fatal("cancel must close the confirmation and drop the pending create")
+	}
+}

--- a/internal/ui/remote_create_group_test.go
+++ b/internal/ui/remote_create_group_test.go
@@ -1,0 +1,221 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Regression tests for "g (create group) only creates LOCAL groups, even when
+// the cursor is on a remote row".
+//
+// The g-key dispatch in handleMainKey offered the create dialog without any
+// remote awareness, so confirming it created the group in the local tree via
+// GroupDialogCreate → groupTree.CreateGroup even though the cursor sat on a
+// remote session/header whose groups live in the remote's own state DB. These
+// tests pin the remote create path at the same dispatch boundary used by the
+// remote-move (#2081) and remote-shift-enter (#1100) tests: the dialog must
+// carry the remote name, and Enter must return an SSH-routed tea.Cmd instead
+// of mutating the local tree.
+
+// TestRemoteCreateGroup_GKeyOnRemoteSessionRoutesOverSSH pins the dispatch:
+// g on a remote-session row must open the create dialog scoped to that remote
+// (RemoteName == "lab"), and confirming it must return the SSH-routed create
+// cmd without touching the local group tree.
+func TestRemoteCreateGroup_GKeyOnRemoteSessionRoutesOverSSH(t *testing.T) {
+	home := armHomeWithOneRemoteSessionInGroups(t)
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("g on a remote session did not open the create dialog")
+	}
+	if home.groupDialog.Mode() != GroupDialogCreate {
+		t.Fatalf("expected GroupDialogCreate mode, got %v", home.groupDialog.Mode())
+	}
+	if got := home.groupDialog.RemoteName(); got != "lab" {
+		t.Fatalf("create dialog remoteName = %q, want \"lab\"", got)
+	}
+	// The helper's cursor session lives in group "work", so the dialog
+	// defaults to root mode with Tab toggling to a subgroup under "work".
+	if home.groupDialog.CanToggle() {
+		if got := home.groupDialog.GetParentPath(); got != "" {
+			t.Fatalf("root-mode create should have no parent, got %q", got)
+		}
+	} else {
+		t.Fatal("grouped remote session create dialog should offer the Root/Subgroup toggle")
+	}
+
+	home.groupDialog.nameInput.SetValue("newgroup")
+	model, cmd := home.handleGroupDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("Enter on the remote create dialog returned a nil cmd; expected the SSH-routed create")
+	}
+	if _, ok := model.(*Home); !ok {
+		t.Fatalf("unexpected model type %T", model)
+	}
+
+	// The local tree must be untouched: the group lives on the remote.
+	if len(home.instances) != 0 {
+		t.Fatalf("local instances mutated by remote group create: %d rows", len(home.instances))
+	}
+}
+
+// TestRemoteCreateGroup_GKeyOnRemoteGroupHeaderDefaultsToSubgroup pins the
+// header path: g on a remote group header opens the create dialog scoped to
+// that remote WITH the header's group as the parent (subgroup mode), so Enter
+// runs `group create <name> --parent <header>` on the remote.
+func TestRemoteCreateGroup_GKeyOnRemoteGroupHeaderDefaultsToSubgroup(t *testing.T) {
+	withTempAgentDeckHome(t, `
+[remotes.lab]
+host = "alice@lab.example"
+agent_deck_path = "/usr/local/bin/agent-deck"
+profile = "work"
+`)
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	// Cursor sits on the "work" group header of remote "lab" (the session
+	// row keeps the header present in the flat list, as in the real TUI).
+	home.flatItems = []session.Item{
+		{
+			Type:       session.ItemTypeRemoteSession,
+			RemoteName: "lab",
+			Path:       "remotes/lab/work",
+			RemoteSession: &session.RemoteSessionInfo{
+				ID:    "remote-id-xyz",
+				Title: "remote session",
+				Group: "work",
+			},
+		},
+		{Type: session.ItemTypeRemoteGroup, RemoteName: "lab", Path: "remotes/lab/work", Level: 1},
+	}
+	home.cursor = 1
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("g on a remote group header did not open the create dialog")
+	}
+	if got := home.groupDialog.RemoteName(); got != "lab" {
+		t.Fatalf("create dialog remoteName = %q, want \"lab\"", got)
+	}
+	if !home.groupDialog.HasParent() {
+		t.Fatal("remote group header create should default to subgroup mode")
+	}
+	if got := home.groupDialog.GetParentPath(); got != "work" {
+		t.Fatalf("create dialog parent path = %q, want \"work\"", got)
+	}
+
+	home.groupDialog.nameInput.SetValue("sub")
+	_, cmd := home.handleGroupDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("Enter on the remote subgroup create dialog returned a nil cmd; expected the SSH-routed create")
+	}
+}
+
+// TestRemoteCreateGroup_GKeyOnRemoteHostHeaderCreatesRootGroup pins the
+// level-0 host-header path: g on "remotes/<name>" (the host header itself)
+// opens a root-level remote create with no parent.
+func TestRemoteCreateGroup_GKeyOnRemoteHostHeaderCreatesRootGroup(t *testing.T) {
+	withTempAgentDeckHome(t, `
+[remotes.lab]
+host = "alice@lab.example"
+agent_deck_path = "/usr/local/bin/agent-deck"
+profile = "work"
+`)
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeRemoteGroup, RemoteName: "lab", Path: "remotes/lab", Level: 0},
+	}
+	home.cursor = 0
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("g on the remote host header did not open the create dialog")
+	}
+	if got := home.groupDialog.RemoteName(); got != "lab" {
+		t.Fatalf("create dialog remoteName = %q, want \"lab\"", got)
+	}
+	if home.groupDialog.HasParent() {
+		t.Fatalf("host-header create should be root-level, got parent %q", home.groupDialog.GetParentPath())
+	}
+}
+
+// TestRemoteCreateGroup_LocalSessionStillCreatesLocally guards the other side
+// of the branch: g on a LOCAL session keeps creating the group in the local
+// tree, with no remote name and no SSH cmd.
+func TestRemoteCreateGroup_LocalSessionStillCreatesLocally(t *testing.T) {
+	withTempAgentDeckHome(t, "")
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	home.groupTree = session.NewGroupTree([]*session.Instance{})
+	inst := &session.Instance{
+		ID:          "local-id-1",
+		Title:       "local session",
+		ProjectPath: "/tmp/local-proj",
+		GroupPath:   "work",
+	}
+	home.instances = []*session.Instance{inst}
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeSession, Session: inst},
+	}
+	home.cursor = 0
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("g on a local session did not open the create dialog")
+	}
+	if got := home.groupDialog.RemoteName(); got != "" {
+		t.Fatalf("local create dialog remoteName = %q, want \"\"", got)
+	}
+
+	home.groupDialog.nameInput.SetValue("newgroup")
+	_, cmd := home.handleGroupDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatalf("local group create returned a non-nil cmd %v; local creates are synchronous", cmd)
+	}
+}
+
+// TestRemoteGroupResultMsgPatchesCache pins the create confirmation: when the
+// remote reports a successful `group create`, the new path is added to the
+// cached group list so the M move dialog offers it immediately (before the
+// next fleet poll re-confirms from the remote's own DB).
+func TestRemoteGroupResultMsgPatchesCache(t *testing.T) {
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	home.remoteSessionsMu.Lock()
+	home.remoteGroups = map[string][]string{"lab": {"work"}}
+	home.remoteSessionsMu.Unlock()
+
+	model, _ := home.Update(remoteGroupResultMsg{remoteName: "lab", groupPath: "work/newgroup"})
+	h, ok := model.(*Home)
+	if !ok {
+		t.Fatalf("unexpected model type %T", model)
+	}
+
+	h.remoteSessionsMu.RLock()
+	got := append([]string(nil), h.remoteGroups["lab"]...)
+	h.remoteSessionsMu.RUnlock()
+
+	want := []string{"work", "work/newgroup"}
+	if len(got) != len(want) {
+		t.Fatalf("remoteGroups[lab] = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("remoteGroups[lab][%d] = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+}

--- a/internal/ui/remote_group_order_test.go
+++ b/internal/ui/remote_group_order_test.go
@@ -1,0 +1,262 @@
+// Issue #2156: shift+up/down on a remote group header used to be refused with
+// "remote group rows are ordered by name". The remote keeps a persisted group
+// order of its own (`group reorder`, reflected by `group list --json`), so the
+// TUI now renders remote group headers in that order and forwards the
+// keystroke as `group reorder <path> --up|--down`, exactly what the remote's
+// own TUI runs for the same key.
+package ui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// visibleRemoteGroupPaths reads the on-screen order of one remote's group
+// headers (host header excluded) straight out of the flat item list.
+func visibleRemoteGroupPaths(items []session.Item, remoteName string) []string {
+	var paths []string
+	for _, it := range items {
+		if it.Type != session.ItemTypeRemoteGroup || it.RemoteName != remoteName {
+			continue
+		}
+		if p := remoteGroupPathFromItem(it); p != "" {
+			paths = append(paths, p)
+		}
+	}
+	return paths
+}
+
+func putCursorOnRemoteGroup(t *testing.T, h *Home, remoteName, groupPath string) {
+	t.Helper()
+	for i, it := range h.flatItems {
+		if it.Type == session.ItemTypeRemoteGroup && it.RemoteName == remoteName && remoteGroupPathFromItem(it) == groupPath {
+			h.cursor = i
+			return
+		}
+	}
+	t.Fatalf("no remote group header %q on %s; headers=%v", groupPath, remoteName, visibleRemoteGroupPaths(h.flatItems, remoteName))
+}
+
+var groupOrderSessions = []session.RemoteSessionInfo{
+	{ID: "s1", Title: "one", Group: "archive"},
+	{ID: "s2", Title: "two", Group: "work/alpha"},
+	{ID: "s3", Title: "three", Group: "work/zeta"},
+	{ID: "s4", Title: "four", Group: "work"},
+	{ID: "s5", Title: "five", Group: ""},
+}
+
+// Headers follow the remote's own order where it is known; a parent still
+// precedes its descendants, and groups the remote did not list (here the
+// default bucket of an ungrouped session) fall back to name order after the
+// ranked ones.
+func TestRemoteGroupHeadersFollowRemoteOrder(t *testing.T) {
+	remoteList := []string{"work", "work/zeta", "work/alpha", "archive"}
+	items := buildRemoteFlatItemsWithGroups("dev", groupOrderSessions, nil, nil, remoteList)
+	want := "work,work/zeta,work/alpha,archive," + session.DefaultGroupPath
+	if got := strings.Join(visibleRemoteGroupPaths(items, "dev"), ","); got != want {
+		t.Fatalf("headers = %s, want %s", got, want)
+	}
+
+	// Sessions still sit directly under their own header.
+	var seq []string
+	for _, it := range items {
+		switch it.Type {
+		case session.ItemTypeRemoteGroup:
+			seq = append(seq, "G:"+remoteGroupPathFromItem(it))
+		case session.ItemTypeRemoteSession:
+			seq = append(seq, it.RemoteSession.ID)
+		}
+	}
+	wantSeq := "G:,G:work,s4,G:work/zeta,s3,G:work/alpha,s2,G:archive,s1,G:" + session.DefaultGroupPath + ",s5"
+	if got := strings.Join(seq, ","); got != wantSeq {
+		t.Fatalf("rows = %s, want %s", got, wantSeq)
+	}
+}
+
+// Nothing changes for a remote that reports no group list (older builds):
+// name order, exactly as before.
+func TestRemoteGroupHeadersDefaultToNameOrder(t *testing.T) {
+	want := "archive," + session.DefaultGroupPath + ",work,work/alpha,work/zeta"
+	for _, list := range [][]string{nil, {}} {
+		items := buildRemoteFlatItemsWithGroups("dev", groupOrderSessions, nil, nil, list)
+		if got := strings.Join(visibleRemoteGroupPaths(items, "dev"), ","); got != want {
+			t.Fatalf("headers with list %v = %s, want %s", list, got, want)
+		}
+	}
+	// The pre-existing entry point is the nil-list case.
+	items := buildRemoteFlatItemsOrdered("dev", groupOrderSessions, nil, nil)
+	if got := strings.Join(visibleRemoteGroupPaths(items, "dev"), ","); got != want {
+		t.Fatalf("buildRemoteFlatItemsOrdered headers = %s, want %s", got, want)
+	}
+}
+
+// A collapsed header still hides its subtree under the remote's order.
+func TestRemoteGroupOrderRespectsCollapse(t *testing.T) {
+	collapsed := map[string]bool{"remotes/dev/work": true}
+	items := buildRemoteFlatItemsWithGroups("dev", groupOrderSessions, collapsed, nil, []string{"work", "work/zeta", "work/alpha", "archive"})
+	if got := strings.Join(visibleRemoteGroupPaths(items, "dev"), ","); got != "work,archive,"+session.DefaultGroupPath {
+		t.Fatalf("headers = %s", got)
+	}
+}
+
+func TestSwapRemoteGroupSibling(t *testing.T) {
+	list := []string{"work", "work/zeta", "work/alpha", "archive", "misc"}
+	if got := strings.Join(swapRemoteGroupSibling(list, "archive", -1), ","); got != "archive,work/zeta,work/alpha,work,misc" {
+		t.Fatalf("archive up = %s", got)
+	}
+	if got := strings.Join(swapRemoteGroupSibling(list, "work/alpha", -1), ","); got != "work,work/alpha,work/zeta,archive,misc" {
+		t.Fatalf("work/alpha up = %s", got)
+	}
+	if got := strings.Join(swapRemoteGroupSibling(list, "misc", 1), ","); got != strings.Join(list, ",") {
+		t.Fatalf("misc down (last) = %s, want unchanged", got)
+	}
+	if got := strings.Join(swapRemoteGroupSibling(list, "nope", 1), ","); got != strings.Join(list, ",") {
+		t.Fatalf("unknown path = %s, want unchanged", got)
+	}
+	if len(list) != 5 || list[0] != "work" || list[3] != "archive" {
+		t.Fatalf("input mutated: %v", list)
+	}
+}
+
+func armHomeForRemoteGroupOrder(t *testing.T) *Home {
+	t.Helper()
+	withTempAgentDeckHome(t, `
+[remotes.dev]
+host = "user@dev.example"
+agent_deck_path = "/usr/local/bin/agent-deck"
+`)
+	h := NewHome()
+	h.width, h.height = 160, 40
+	h.initialLoading = false
+	h.remoteSessions = map[string][]session.RemoteSessionInfo{"dev": groupOrderSessions}
+	h.remoteGroups = map[string][]string{"dev": {"work", "work/zeta", "work/alpha", "archive"}}
+	h.rebuildFlatItems()
+	return h
+}
+
+// The key handler forwards a movable group over SSH (a command comes back and
+// nothing is announced yet), refuses an edge move locally with a plain
+// message, and never says "ordered by name" any more.
+func TestShiftUpOnRemoteGroupForwardsOrRefusesHonestly(t *testing.T) {
+	h := armHomeForRemoteGroupOrder(t)
+
+	putCursorOnRemoteGroup(t, h, "dev", "archive")
+	h.clearError()
+	if cmd := h.moveRemoteItem(h.flatItems[h.cursor], -1); cmd == nil {
+		t.Fatal("moving a group with a sibling above it returned no command")
+	}
+	if h.err != nil {
+		t.Fatalf("forwarded move set an error before the remote answered: %v", h.err)
+	}
+
+	putCursorOnRemoteGroup(t, h, "dev", "work")
+	h.clearError()
+	if cmd := h.moveRemoteItem(h.flatItems[h.cursor], -1); cmd != nil {
+		t.Fatal("the first group returned a command instead of refusing locally")
+	}
+	if h.err == nil || !strings.Contains(h.err.Error(), "already first") {
+		t.Fatalf("first group up: err = %v, want 'already first'", h.err)
+	}
+	if strings.Contains(strings.ToLower(h.err.Error()), "ordered by name") {
+		t.Fatalf("old refusal still present: %v", h.err)
+	}
+
+	putCursorOnRemoteGroup(t, h, "dev", "work/alpha")
+	h.clearError()
+	if cmd := h.moveRemoteItem(h.flatItems[h.cursor], 1); cmd != nil {
+		t.Fatal("the last subgroup returned a command instead of refusing locally")
+	}
+	if h.err == nil || !strings.Contains(h.err.Error(), "already last") {
+		t.Fatalf("last subgroup down: err = %v, want 'already last'", h.err)
+	}
+
+	// The host header is not a remote group.
+	for i, it := range h.flatItems {
+		if it.Type == session.ItemTypeRemoteGroup && it.RemoteName == "dev" && remoteGroupPathFromItem(it) == "" {
+			h.cursor = i
+		}
+	}
+	h.clearError()
+	if cmd := h.moveRemoteItem(h.flatItems[h.cursor], 1); cmd != nil {
+		t.Fatal("host header returned a command")
+	}
+	if h.err == nil || !strings.Contains(h.err.Error(), "config.toml") {
+		t.Fatalf("host header: err = %v", h.err)
+	}
+
+	// Through the real key dispatch, the command is returned to Bubble Tea.
+	putCursorOnRemoteGroup(t, h, "dev", "archive")
+	h.clearError()
+	_, cmd := h.handleMainKey(tea.KeyMsg{Type: tea.KeyShiftUp})
+	if cmd == nil {
+		t.Fatal("shift+up on a movable remote group header returned no command")
+	}
+}
+
+// Once the remote confirms, the cached group list is patched the way the
+// remote patched its own, the header moves and the cursor stays on it. A
+// refused edge move and an SSH failure both surface in the footer instead.
+func TestRemoteGroupReorderResultUpdatesHeaders(t *testing.T) {
+	h := armHomeForRemoteGroupOrder(t)
+	putCursorOnRemoteGroup(t, h, "dev", "archive")
+
+	model, _ := h.Update(remoteGroupReorderResultMsg{remoteName: "dev", groupPath: "archive", delta: -1, moved: true})
+	h = model.(*Home)
+	if h.err != nil {
+		t.Fatalf("confirmed move set an error: %v", h.err)
+	}
+	if got := strings.Join(visibleRemoteGroupPaths(h.flatItems, "dev"), ","); got != "archive,work,work/zeta,work/alpha,"+session.DefaultGroupPath {
+		t.Fatalf("headers after confirmed move = %s", got)
+	}
+	if it := h.flatItems[h.cursor]; it.Type != session.ItemTypeRemoteGroup || remoteGroupPathFromItem(it) != "archive" {
+		t.Fatalf("cursor left the moved header: %+v", it)
+	}
+	h.remoteSessionsMu.RLock()
+	cached := strings.Join(h.remoteGroups["dev"], ",")
+	h.remoteSessionsMu.RUnlock()
+	if cached != "archive,work/zeta,work/alpha,work" {
+		t.Fatalf("cached remote group list = %s", cached)
+	}
+
+	model, _ = h.Update(remoteGroupReorderResultMsg{remoteName: "dev", groupPath: "archive", delta: -1, moved: false})
+	h = model.(*Home)
+	if h.err == nil || !strings.Contains(h.err.Error(), "did not move") {
+		t.Fatalf("refused edge move: err = %v", h.err)
+	}
+
+	model, _ = h.Update(remoteGroupReorderResultMsg{remoteName: "dev", groupPath: "archive", delta: 1, err: errors.New("ssh: boom")})
+	h = model.(*Home)
+	if h.err == nil || !strings.Contains(h.err.Error(), "boom") {
+		t.Fatalf("ssh failure: err = %v", h.err)
+	}
+	if got := strings.Join(visibleRemoteGroupPaths(h.flatItems, "dev"), ","); !strings.HasPrefix(got, "archive,work") {
+		t.Fatalf("a failed move changed the headers: %s", got)
+	}
+}
+
+// A fresh fleet poll replaces the cached list with the remote's order, and
+// the headers follow it; a remote that created a group appends it last.
+func TestRemoteGroupOrderFromFleetPoll(t *testing.T) {
+	h := armHomeForRemoteGroupOrder(t)
+	model, _ := h.Update(remoteSessionsFetchedMsg{
+		sessions: map[string][]session.RemoteSessionInfo{"dev": groupOrderSessions},
+		groups:   map[string][]string{"dev": {"archive", "work", "work/alpha", "work/zeta"}},
+	})
+	h = model.(*Home)
+	if got := strings.Join(visibleRemoteGroupPaths(h.flatItems, "dev"), ","); got != "archive,work,work/alpha,work/zeta,"+session.DefaultGroupPath {
+		t.Fatalf("headers after poll = %s", got)
+	}
+	model, _ = h.Update(remoteGroupResultMsg{remoteName: "dev", groupPath: "aaa"})
+	h = model.(*Home)
+	h.remoteSessionsMu.RLock()
+	cached := strings.Join(h.remoteGroups["dev"], ",")
+	h.remoteSessionsMu.RUnlock()
+	if cached != "archive,work,work/alpha,work/zeta,aaa" {
+		t.Fatalf("cached list after create = %s, want the new group last", cached)
+	}
+}

--- a/internal/ui/remote_move_to_group_test.go
+++ b/internal/ui/remote_move_to_group_test.go
@@ -1,0 +1,148 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Regression tests for "M (move to group) does nothing on remote sessions".
+//
+// The M-key dispatch in handleMainKey only offered the move dialog for
+// ItemTypeSession, so pressing M on a remote-session row was a silent no-op
+// even though the remote-rename path (GroupDialogRenameSession) already knows
+// how to mutate a remote session over SSH. These tests pin the remote move
+// path at the same dispatch boundary used by the #1100 remote-shift-enter
+// tests.
+
+// armHomeWithOneRemoteSessionInGroups sets up a Home whose cursor sits on a
+// remote session row, with a populated remote fleet cache so remoteGroupPaths
+// has something to offer. The remote is declared in $HOME's config.toml so
+// any executed SSH command can resolve it (tests that would execute SSH only
+// assert the returned tea.Cmd is non-nil and never run it).
+func armHomeWithOneRemoteSessionInGroups(t *testing.T) *Home {
+	t.Helper()
+
+	withTempAgentDeckHome(t, `
+[remotes.lab]
+host = "alice@lab.example"
+agent_deck_path = "/usr/local/bin/agent-deck"
+profile = "work"
+`)
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	// Remote fleet cache: two sessions across two groups, plus the row the
+	// cursor will sit on.
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"lab": {
+			{ID: "remote-id-xyz", Title: "remote session", Group: "work"},
+			{ID: "remote-id-abc", Title: "other session", Group: "personal"},
+			{ID: "remote-id-ungrouped", Title: "loose session", Group: ""},
+		},
+	}
+	home.flatItems = []session.Item{
+		{
+			Type:       session.ItemTypeRemoteSession,
+			RemoteName: "lab",
+			RemoteSession: &session.RemoteSessionInfo{
+				ID:    "remote-id-xyz",
+				Title: "remote session",
+				Group: "work",
+			},
+		},
+	}
+	home.cursor = 0
+	return home
+}
+
+// TestRemoteMoveToGroup_MKeyOpensDialogWithRemoteGroups pins the dispatch:
+// pressing M on a remote-session row must open the move dialog (the same one
+// local sessions get) with the groups observed on that remote.
+func TestRemoteMoveToGroup_MKeyOpensDialogWithRemoteGroups(t *testing.T) {
+	home := armHomeWithOneRemoteSessionInGroups(t)
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("M on a remote session did not open the move dialog")
+	}
+	if home.groupDialog.Mode() != GroupDialogMove {
+		t.Fatalf("expected GroupDialogMove mode, got %v", home.groupDialog.Mode())
+	}
+
+	// The dialog must offer the remote's own groups (normalized, sorted,
+	// deduped) — not the local group tree, which knows nothing about the
+	// remote. Empty remote group normalizes to the default group path.
+	want := []string{"my-sessions", "personal", "work"}
+	got := home.groupDialog.groupPaths
+	if len(got) != len(want) {
+		t.Fatalf("dialog offered %d group paths %v, want %d %v", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("dialog groupPaths[%d] = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// TestRemoteMoveToGroup_EnterReturnsMoveCmd pins the submit path: confirming
+// the dialog on a remote row must return a tea.Cmd (the SSH-routed move) and
+// must NOT mutate the local group tree.
+func TestRemoteMoveToGroup_EnterReturnsMoveCmd(t *testing.T) {
+	home := armHomeWithOneRemoteSessionInGroups(t)
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("M on a remote session did not open the move dialog")
+	}
+
+	model, cmd := home.handleGroupDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("Enter on the remote move dialog returned a nil cmd; expected the SSH-routed move")
+	}
+	if _, ok := model.(*Home); !ok {
+		t.Fatalf("unexpected model type %T", model)
+	}
+
+	// The local tree must be untouched: the remote row is not a local
+	// instance, so MoveSessionToGroup must never have been called.
+	if len(home.instances) != 0 {
+		t.Fatalf("local instances mutated by remote move: %d rows", len(home.instances))
+	}
+}
+
+// TestRemoteMoveToGroup_LocalSessionStillUsesLocalTree guards the other side
+// of the branch: moving a LOCAL session must keep using the local tree and
+// return no SSH cmd.
+func TestRemoteMoveToGroup_LocalSessionStillUsesLocalTree(t *testing.T) {
+	withTempAgentDeckHome(t, "")
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	inst := &session.Instance{
+		ID:          "local-id-1",
+		Title:       "local session",
+		ProjectPath: "/tmp/local-proj",
+		GroupPath:   "work",
+	}
+	home.instances = []*session.Instance{inst}
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeSession, Session: inst},
+	}
+	home.cursor = 0
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("M on a local session did not open the move dialog")
+	}
+
+	_, cmd := home.handleGroupDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatalf("local move returned a non-nil cmd %v; local moves are synchronous", cmd)
+	}
+}

--- a/internal/ui/remote_move_to_group_test.go
+++ b/internal/ui/remote_move_to_group_test.go
@@ -89,6 +89,79 @@ func TestRemoteMoveToGroup_MKeyOpensDialogWithRemoteGroups(t *testing.T) {
 	}
 }
 
+// TestRemoteMoveToGroup_MKeyIncludesEmptyGroups pins the empty-folder fix:
+// the move dialog must offer groups that currently hold NO sessions on the
+// remote (a folder left empty after every session was moved out of it).
+// Session-derived buckets can never contain an empty group, so this relies on
+// the fleet poll's cached `group list --json` (Home.remoteGroups) being
+// unioned into remoteGroupPaths.
+func TestRemoteMoveToGroup_MKeyIncludesEmptyGroups(t *testing.T) {
+	home := armHomeWithOneRemoteSessionInGroups(t)
+
+	// The remote's own group DB reports an extra EMPTY folder (no sessions):
+	// it must still be offered as a move target.
+	home.remoteSessionsMu.Lock()
+	home.remoteGroups = map[string][]string{
+		"lab": {"empty-folder", "personal", "work"},
+	}
+	home.remoteSessionsMu.Unlock()
+
+	if _, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}}); !home.groupDialog.IsVisible() {
+		t.Fatal("M on a remote session did not open the move dialog")
+	}
+
+	// Union of the remote's own group list (incl. the empty folder) and the
+	// session-derived groups (empty remote group normalizes to my-sessions).
+	want := []string{"empty-folder", "my-sessions", "personal", "work"}
+	got := home.groupDialog.groupPaths
+	if len(got) != len(want) {
+		t.Fatalf("dialog offered %d group paths %v, want %d %v", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("dialog groupPaths[%d] = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// TestRemoteSessionsFetchedMsgPopulatesGroupCache pins the fleet-poll wiring:
+// the remote group lists carried on remoteSessionsFetchedMsg land in
+// Home.remoteGroups (guarded by remoteSessionsMu), which is what the M move
+// dialog reads to offer empty remote folders.
+func TestRemoteSessionsFetchedMsgPopulatesGroupCache(t *testing.T) {
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	model, _ := home.Update(remoteSessionsFetchedMsg{
+		sessions: map[string][]session.RemoteSessionInfo{
+			"lab": {{ID: "x", Title: "s", Group: "work"}},
+		},
+		groups: map[string][]string{
+			"lab": {"empty-folder", "work"},
+		},
+	})
+	h, ok := model.(*Home)
+	if !ok {
+		t.Fatalf("unexpected model type %T", model)
+	}
+
+	h.remoteSessionsMu.RLock()
+	got := append([]string(nil), h.remoteGroups["lab"]...)
+	h.remoteSessionsMu.RUnlock()
+
+	want := []string{"empty-folder", "work"}
+	if len(got) != len(want) {
+		t.Fatalf("remoteGroups[lab] = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("remoteGroups[lab][%d] = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
 // TestRemoteMoveToGroup_EnterReturnsMoveCmd pins the submit path: confirming
 // the dialog on a remote row must return a tea.Cmd (the SSH-routed move) and
 // must NOT mutate the local group tree.

--- a/internal/ui/remote_tree.go
+++ b/internal/ui/remote_tree.go
@@ -36,6 +36,18 @@ func buildRemoteFlatItems(remoteName string, sessions []session.RemoteSessionInf
 // session IDs (i.e. remoteOrder.forRemote(remoteName)) and may be nil, in
 // which case each bucket keeps the order the remote listed.
 func buildRemoteFlatItemsOrdered(remoteName string, sessions []session.RemoteSessionInfo, collapsed map[string]bool, order map[string][]string) []session.Item {
+	return buildRemoteFlatItemsWithGroups(remoteName, sessions, collapsed, order, nil)
+}
+
+// buildRemoteFlatItemsWithGroups is buildRemoteFlatItemsOrdered with the
+// remote's OWN group order applied to the group headers. groupPaths is the
+// remote's group list as `group list --json` returned it (see
+// SSHRunner.FetchGroupPaths): siblings in the remote's persisted order, a
+// parent before its children. It may be nil or incomplete, in which case the
+// groups it does not mention keep their lexicographic order, so a remote too
+// old to report the list, or a group seen only on a session, renders exactly
+// as before.
+func buildRemoteFlatItemsWithGroups(remoteName string, sessions []session.RemoteSessionInfo, collapsed map[string]bool, order map[string][]string, groupPaths []string) []session.Item {
 	items := make([]session.Item, 0, len(sessions)+2)
 
 	remoteRoot := "remotes/" + remoteName
@@ -61,18 +73,19 @@ func buildRemoteFlatItemsOrdered(remoteName string, sessions []session.RemoteSes
 		buckets[g] = append(buckets[g], i)
 	}
 
-	// Sort group paths lexicographically. Lexicographic order places a parent
-	// path directly before all of its descendants ("a" < "a/b" < "a/c" < "b"),
-	// which lets us emit intermediate headers with a simple prefix walk.
-	groupPaths := make([]string, 0, len(buckets))
+	// Sort group paths so that a parent path lands directly before all of its
+	// descendants ("a" < "a/b" < "a/c" < "b"), which lets us emit intermediate
+	// headers with a simple prefix walk. Siblings follow the remote's own
+	// group order where it is known and their names otherwise.
+	bucketPaths := make([]string, 0, len(buckets))
 	for g := range buckets {
-		groupPaths = append(groupPaths, g)
+		bucketPaths = append(bucketPaths, g)
 	}
-	sort.Strings(groupPaths)
+	sortRemoteGroupPaths(bucketPaths, remoteGroupRank(groupPaths))
 
 	emitted := make(map[string]bool) // group paths whose header we already wrote
 
-	for _, gp := range groupPaths {
+	for _, gp := range bucketPaths {
 		// Emit a header for every not-yet-emitted prefix of this group path so
 		// nested "a/b/c" gets headers for "a", "a/b", "a/b/c" in order.
 		segments := strings.Split(gp, "/")
@@ -111,8 +124,7 @@ func buildRemoteFlatItemsOrdered(remoteName string, sessions []session.RemoteSes
 
 		// Sessions sit one level below their owning group header.
 		sessionLevel := len(segments) + 1
-		// #1875: the user's manual order for this bucket, if any. Group
-		// headers keep their lexicographic order; only sessions move.
+		// #1875: the user's manual order for this bucket, if any.
 		idxs := orderRemoteBucket(sessions, buckets[gp], order[gp])
 		for j, idx := range idxs {
 			items = append(items, session.Item{
@@ -127,6 +139,64 @@ func buildRemoteFlatItemsOrdered(remoteName string, sessions []session.RemoteSes
 	}
 
 	return items
+}
+
+// remoteGroupRank maps each remote group path to its index in the remote's
+// own listing. A nil or empty listing yields an empty map, and every path
+// then falls back to name order in sortRemoteGroupPaths.
+func remoteGroupRank(groupPaths []string) map[string]int {
+	rank := make(map[string]int, len(groupPaths))
+	for i, p := range groupPaths {
+		p = normalizeRemoteGroupPath(p)
+		if _, seen := rank[p]; !seen {
+			rank[p] = i
+		}
+	}
+	return rank
+}
+
+// sortRemoteGroupPaths orders group paths for the header walk in
+// buildRemoteFlatItemsWithGroups: a parent always precedes its descendants,
+// and two paths that part ways at some segment are ordered by the remote's
+// rank of the prefixes ending in that segment. Prefixes the remote did not
+// rank compare by name, and a ranked prefix precedes an unranked one, which
+// mirrors how the remote's own list puts persisted groups before anything
+// that exists only as a session's Group string.
+func sortRemoteGroupPaths(paths []string, rank map[string]int) {
+	sort.SliceStable(paths, func(i, j int) bool {
+		return remoteGroupPathLess(paths[i], paths[j], rank)
+	})
+}
+
+func remoteGroupPathLess(a, b string, rank map[string]int) bool {
+	sa := strings.Split(a, "/")
+	sb := strings.Split(b, "/")
+	prefixA, prefixB := "", ""
+	for k := 0; k < len(sa) && k < len(sb); k++ {
+		prefixA = joinGroupSegment(prefixA, sa[k])
+		prefixB = joinGroupSegment(prefixB, sb[k])
+		if sa[k] == sb[k] {
+			continue
+		}
+		ra, okA := rank[prefixA]
+		rb, okB := rank[prefixB]
+		switch {
+		case okA && okB:
+			return ra < rb
+		case okA != okB:
+			return okA
+		default:
+			return sa[k] < sb[k]
+		}
+	}
+	return len(sa) < len(sb) // the shorter path is the ancestor
+}
+
+func joinGroupSegment(prefix, seg string) string {
+	if prefix == "" {
+		return seg
+	}
+	return prefix + "/" + seg
 }
 
 // normalizeRemoteGroupPath maps an empty remote group to the default group


### PR DESCRIPTION
## What problem does this solve?

Part of #2156. Creating a session on a remote deck from the TUI (`n` on a remote group or session) could not attach MCPs: `RemoteAddOptions.MCPs` already travelled as repeated `--mcp`, but no dialog field ever set it, so the only way to get an MCP onto a remote session was `agent-deck remote <name> mcp attach` after the fact. The dialog now offers the remote's own MCPs and forwards the picks at creation time.

## Why this change

It follows the forwarding chain of #2155 and #2157: a dialog field, then an `SSHRunner` method, then the remote's own CLI verb.

- `SSHRunner.FetchMCPs` runs the remote's read-only `mcp list --json` and keeps only the names, sorted (the remote lists them in map order). Commands, args, env and URLs describe processes on the server and are dropped. An unknown command on an old remote, human text or empty stdout is an error, never a silent empty list, the same contract as `FetchAccounts`.
- The new-session dialog gains an "MCPs (remote)" row of checkboxes, populated only through `SetRemoteMCPs`. Left/Right moves along the row, Space toggles, and `GetRemoteCreateOptions` forwards the picks as `RemoteAddOptions.MCPs`. A local opening never sets the row, so the local dialog is byte for byte unchanged and attaching MCPs to a local session stays where it was.
- The fetch is batched with the account-slot fetch when the dialog opens and stamped with the same opening generation (`stampRemoteFetch`), so a late answer for an earlier opening, another remote, a failed fetch or a closed dialog is dropped rather than replacing the list the user is choosing from. `SetRemoteMCPs` also clears earlier picks, since they were made against another list.
- `remote <name> mcp list` and `skill list` join the read-only CLI passthrough allow-list, so the same call the TUI makes is available on the command line and covered by `TestRemoteCommandParity`.

Skills stay out of the dialog on purpose: the remote `add` takes no skill flag, so attaching one at creation would need a second, session-restarting `skill attach` round trip or a server-side flag. The docs say so and point at `remote <name> skill attach`.

## User impact

- `n` on a remote group or session now shows an "MCPs (remote)" row listing the MCPs defined in the server's `config.toml`; the picked ones are attached when the session is created (`add --mcp <name> ...`).
- An MCP defined only on this machine is never offered for a remote target; one defined only on the server can be picked. Only names travel; no MCP definition, command or credential is copied over SSH.
- The row is absent when the server defines no MCPs, is offline, or runs an agent-deck too old for `mcp list --json`, so the dialog never shows a control whose value the server would reject.
- Users without remotes see no change: the local dialog has no such row and its focus order is untouched.
- `agent-deck remote <name> mcp list --json` and `skill list --json` now work on the command line.

## Evidence

- `gofmt -l ./cmd ./internal` is empty; `go build ./...` and `go vet ./internal/ui ./internal/session ./cmd/agent-deck` pass on the branch.
- Local go test is disallowed on this host; full suite runs in CI on this PR.
- New tests: `TestSSHRunnerFetchMCPs` (exact remote command, names only and sorted, blank entries dropped), `TestSSHRunnerFetchMCPs_ErrorsAreNotEmptyLists`, `TestSSHRunnerFetchMCPs_EmptyListIsNotAnError`, and the TUI-level `internal/ui/remote_create_mcps_test.go` which drives the real dialog through `n`, arrow keys, Space and Ctrl+S: a local-only MCP is never offered or forwarded and the remote is asked once; remote-only MCPs are offered and the picks travel in the remote's order; Space toggles a pick off; answers for another remote, a failed fetch or a closed dialog are dropped; a late answer for an earlier opening of the same remote never replaces the current list or the pick; a reopened dialog carries neither the old list nor the old pick; a local opening has no row. `TestRemoteCommandParity` gains `mcp list --json` and `skill list --json`.
- No remote host was contacted while developing this; the SSH paths are replaced by captures in every test.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5-1

## What actually bothered you

My human asked: "can I use the remote side from the TUI seamlessly like I would do locally? That is the idea, from the TUI please."

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5-1 intent=yes -->
