### PR TITLE
fix(remote): stale polls, refused renames, queued creates and failed attaches tell the truth

### DIFF
--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -1355,7 +1355,7 @@ func (r *SSHRunner) CreateSessionWithOptions(ctx context.Context, opts RemoteAdd
 		Status string `json:"status"`
 	}
 	if err := json.Unmarshal(bytes.TrimSpace(startOutput), &startResult); err == nil && startResult.Status == string(StatusQueued) {
-		return "", fmt.Errorf("remote session %q was queued and is not ready to attach", result.Title)
+		return "", &RemoteSessionQueuedError{ID: result.ID, Title: result.Title}
 	}
 
 	return result.ID, nil
@@ -1377,6 +1377,18 @@ func remoteStartArgs(sessionID string, noWait bool) []string {
 // "flag provided but not defined: -name").
 func isUnknownFlagError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "flag provided but not defined")
+}
+
+// RemoteSessionQueuedError reports that `add` succeeded but `session start`
+// queued the session because its group is at max_concurrent. The session
+// exists on the remote; it is not attachable yet.
+type RemoteSessionQueuedError struct {
+	ID    string
+	Title string
+}
+
+func (e *RemoteSessionQueuedError) Error() string {
+	return fmt.Sprintf("remote session %q was queued and is not ready to attach", e.Title)
 }
 
 // DeleteSession removes a session on the remote host.

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -637,6 +637,12 @@ type Home struct {
 	remoteSessionsMu   sync.RWMutex
 	lastRemoteFetch    time.Time // When remote sessions were last fetched
 	remotesFetchActive bool      // Prevents overlapping fetches
+	// remoteFetchSeq numbers every fleet fetch as it starts; the handler
+	// applies a result only if no newer fetch has been applied already, so a
+	// slow periodic poll cannot overwrite the refresh a delete, move or
+	// archive just triggered (a stale snapshot would resurrect the row).
+	remoteFetchSeq     uint64
+	remoteFetchApplied uint64
 	// remoteSessionRefreshSec is the poll cadence (seconds) for re-fetching
 	// the remote session list, resolved once at construction from
 	// [ui] remote_session_refresh_secs. Issue #1170.
@@ -1436,7 +1442,12 @@ type sendOutputResultMsg struct {
 
 // remoteSessionsFetchedMsg is sent when async remote sessions fetch completes.
 type remoteSessionsFetchedMsg struct {
-	sessions map[string][]session.RemoteSessionInfo
+	// gen is the fetch's sequence number (see Home.remoteFetchSeq).
+	gen uint64
+	// configErr is set when the user config could not be read; the handler
+	// then keeps every cached remote instead of treating them as removed.
+	configErr error
+	sessions  map[string][]session.RemoteSessionInfo
 	// #1101: per-remote cost summary collected on the same SSH fanout.
 	costs map[string]*costs.RemoteCostSummary
 	// groups holds each remote's FULL group path list (incl. empty groups)
@@ -3686,9 +3697,16 @@ func (h *Home) propagateThemeToSessions() {
 
 // fetchRemoteSessions fetches sessions from all configured remotes.
 func (h *Home) fetchRemoteSessions() tea.Msg {
+	gen := atomic.AddUint64(&h.remoteFetchSeq, 1)
 	config, err := session.LoadUserConfig()
-	if err != nil || config == nil || len(config.Remotes) == 0 {
-		return remoteSessionsFetchedMsg{sessions: nil}
+	if err != nil {
+		// A hand-edited config.toml that fails to parse must not wipe the
+		// remotes from the tree (and the on-disk cache) as if they had been
+		// deconfigured; keep everything and say why.
+		return remoteSessionsFetchedMsg{gen: gen, configErr: err}
+	}
+	if config == nil || len(config.Remotes) == 0 {
+		return remoteSessionsFetchedMsg{gen: gen, sessions: nil}
 	}
 
 	// #1421: sweep orphaned SSH ControlMaster sockets before fetching. A stale
@@ -3795,7 +3813,7 @@ func (h *Home) fetchRemoteSessions() tea.Msg {
 	}
 	wg.Wait()
 
-	return remoteSessionsFetchedMsg{sessions: results, costs: costResults, groups: groupResults, groupsFailed: groupsFailed, failed: failed}
+	return remoteSessionsFetchedMsg{gen: gen, sessions: results, costs: costResults, groups: groupResults, groupsFailed: groupsFailed, failed: failed}
 }
 
 // mergeRemoteSessions reconciles a freshly fetched remote-session map against
@@ -6776,6 +6794,19 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 	case remoteSessionsFetchedMsg:
+		if msg.configErr != nil || (msg.gen != 0 && msg.gen < h.remoteFetchApplied) {
+			// Config unreadable, or a fetch that started before one already
+			// applied: keep the current tree. Only release the in-flight
+			// guard so the next poll runs.
+			h.remoteSessionsMu.Lock()
+			h.remotesFetchActive = false
+			h.remoteSessionsMu.Unlock()
+			if msg.configErr != nil {
+				h.setError(fmt.Errorf("remote refresh skipped, config could not be read: %v", msg.configErr))
+			}
+			return h, nil
+		}
+		h.remoteFetchApplied = msg.gen
 		h.remoteSessionsMu.Lock()
 		// #1170: merge rather than wholesale-replace so a remote that errored
 		// this round keeps its last-good sessions instead of flickering out.
@@ -6902,6 +6933,8 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case remoteSessionCreatedMsg:
 		if msg.err != nil {
 			h.setError(msg.err)
+		} else if msg.notice != "" {
+			h.setError(errors.New(msg.notice))
 		}
 		// This message is returned after tea.Exec finishes the remote
 		// create+attach. Mirror the statusUpdateMsg attach-return cleanup so
@@ -6946,6 +6979,13 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return h, tea.Tick(30*time.Second, func(_ time.Time) tea.Msg {
 				return clearMaintenanceMsg{}
 			})
+		}
+		return h, nil
+
+	case remoteRenameResultMsg:
+		if msg.err != nil {
+			h.setRemoteSessionTitle(msg.remoteName, msg.sessionID, msg.oldTitle)
+			h.setError(fmt.Errorf("failed to rename '%s' on %s: %v", msg.oldTitle, msg.remoteName, msg.err))
 		}
 		return h, nil
 
@@ -9654,7 +9694,12 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					}
 				}
 			} else if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil {
-				// Attach to remote session via SSH
+				// A stopped remote session is restarted first, as Enter on a
+				// dead local session restarts it; the row refreshes when the
+				// remote confirms. Otherwise attach over SSH.
+				if strings.EqualFold(item.RemoteSession.Status, string(session.StatusStopped)) {
+					return h, h.restartRemoteSession(item.RemoteName, item.RemoteSession.ID, item.RemoteSession.Title)
+				}
 				return h, h.attachRemoteSession(item.RemoteName, item.RemoteSession.ID)
 			}
 		}
@@ -12319,32 +12364,11 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					parts := strings.SplitN(sessionID, ":", 3) // "remote", remoteName, actualID
 					if len(parts) == 3 {
 						remoteName, remoteID := parts[1], parts[2]
-						go func() {
-							config, err := session.LoadUserConfig()
-							if err != nil || config == nil || config.Remotes == nil {
-								return
-							}
-							rc, ok := config.Remotes[remoteName]
-							if !ok {
-								return
-							}
-							runner := session.NewSSHRunner(remoteName, rc)
-							ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-							defer cancel()
-							_, _ = runner.RunCommand(ctx, "rename", remoteID, newName)
-						}()
-						// Update local cache immediately for responsiveness
-						h.remoteSessionsMu.Lock()
-						if sessions, ok := h.remoteSessions[remoteName]; ok {
-							for i := range sessions {
-								if sessions[i].ID == parts[2] {
-									sessions[i].Title = newName
-									break
-								}
-							}
-						}
-						h.remoteSessionsMu.Unlock()
-						h.rebuildFlatItems()
+						// Show the new title now; the remote's answer arrives as
+						// remoteRenameResultMsg, which reverts it with a message
+						// if the remote refused or could not be reached.
+						oldTitle := h.setRemoteSessionTitle(remoteName, remoteID, newName)
+						remoteCmd = h.renameRemoteSession(remoteName, remoteID, oldTitle, newName)
 					}
 				} else {
 					// Local session rename
@@ -14657,6 +14681,58 @@ func remoteRestartAnimationID(remoteName, sessionID string) string {
 
 type remoteSessionCreatedMsg struct {
 	err error
+	// notice is a non-error outcome worth a footer line (e.g. queued).
+	notice string
+}
+
+// remoteRenameResultMsg reports the remote's answer to a rename started from
+// the rename dialog on a remote session row.
+type remoteRenameResultMsg struct {
+	remoteName string
+	sessionID  string
+	oldTitle   string
+	newTitle   string
+	err        error
+}
+
+// setRemoteSessionTitle patches the cached title of a remote session and
+// rebuilds the rows; it returns the previous title so a refused rename can
+// be reverted.
+func (h *Home) setRemoteSessionTitle(remoteName, sessionID, title string) string {
+	old := ""
+	h.remoteSessionsMu.Lock()
+	if sessions, ok := h.remoteSessions[remoteName]; ok {
+		for i := range sessions {
+			if sessions[i].ID == sessionID {
+				old = sessions[i].Title
+				sessions[i].Title = title
+				break
+			}
+		}
+	}
+	h.remoteSessionsMu.Unlock()
+	h.rebuildFlatItems()
+	return old
+}
+
+// renameRemoteSession runs `agent-deck rename` on the remote and reports the
+// outcome, instead of firing it and forgetting (a refused or unreachable
+// rename used to show the new title and silently snap back on the next poll).
+func (h *Home) renameRemoteSession(remoteName, sessionID, oldTitle, newTitle string) tea.Cmd {
+	return func() tea.Msg {
+		result := remoteRenameResultMsg{remoteName: remoteName, sessionID: sessionID, oldTitle: oldTitle, newTitle: newTitle}
+		runner, err := remoteRunnerFor(remoteName)
+		if err != nil {
+			result.err = err
+			return result
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if _, err := runner.RunCommand(ctx, "rename", sessionID, newTitle); err != nil {
+			result.err = err
+		}
+		return result
+	}
 }
 
 // remoteSessionForkedMsg reports the outcome of an SSH-routed quick fork (f
@@ -15155,7 +15231,15 @@ func (h *Home) createRemoteSessionWithOptions(remoteName string, opts session.Re
 			if !opts.CreateDir && strings.TrimSpace(opts.Path) != "" && session.IsRemotePathMissing(err) {
 				return remoteCreateDirNeededMsg{remoteName: remoteName, opts: opts, err: err}
 			}
-			return sessionCreatedMsg{err: fmt.Errorf("failed to create remote session: %w", err)}
+			var queued *session.RemoteSessionQueuedError
+			if errors.As(err, &queued) {
+				// The session exists on the remote; it starts when the group
+				// has a free slot. Not a failure, and the row must show now.
+				return remoteSessionCreatedMsg{notice: fmt.Sprintf("created '%s' on %s, queued until group '%s' has a free slot", queued.Title, remoteName, opts.Group)}
+			}
+			// Routed as the remote message so the terminal cleanup after
+			// tea.Exec (mouse, keyboard mode, resize) runs on failure too.
+			return remoteSessionCreatedMsg{err: fmt.Errorf("on %s: %w", remoteName, err)}
 		}
 		return remoteSessionCreatedMsg{}
 	})
@@ -15419,15 +15503,13 @@ func swapRemoteGroupSibling(paths []string, groupPath string, delta int) []strin
 
 // attachRemoteSession attaches to a remote session via SSH, suspending the TUI.
 func (h *Home) attachRemoteSession(remoteName, sessionID string) tea.Cmd {
-	config, err := session.LoadUserConfig()
-	if err != nil || config == nil || config.Remotes == nil {
-		return nil
+	runner, err := remoteRunnerFor(remoteName)
+	if err != nil {
+		// Say so instead of a silent no-op on Enter.
+		return func() tea.Msg {
+			return remoteSessionCreatedMsg{err: fmt.Errorf("cannot attach on %s: %w", remoteName, err)}
+		}
 	}
-	rc, ok := config.Remotes[remoteName]
-	if !ok {
-		return nil
-	}
-	runner := session.NewSSHRunner(remoteName, rc)
 	h.isAttaching.Store(true)
 	return tea.Exec(remoteAttachCmd{
 		runner:    runner,
@@ -15437,6 +15519,11 @@ func (h *Home) attachRemoteSession(remoteName, sessionID string) tea.Cmd {
 		onExit: func() { h.isAttaching.Store(false) },
 	}, func(err error) tea.Msg {
 		h.isAttaching.Store(false)
+		if err != nil {
+			// An unreachable host or a session the remote refuses to attach
+			// used to flash the screen and say nothing.
+			return remoteSessionCreatedMsg{err: fmt.Errorf("failed to attach to '%s' on %s: %w", sessionID, remoteName, err)}
+		}
 		return statusUpdateMsg{}
 	})
 }

--- a/internal/ui/remote_correctness_test.go
+++ b/internal/ui/remote_correctness_test.go
@@ -1,0 +1,81 @@
+// Remote-deck correctness (#2170): a stale fleet poll must not undo an
+// action, a broken config must not wipe the remotes, and a refused rename
+// must revert with a message instead of snapping back silently.
+
+package ui
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func remoteTitles(h *Home, remote string) []string {
+	h.remoteSessionsMu.RLock()
+	defer h.remoteSessionsMu.RUnlock()
+	var out []string
+	for _, s := range h.remoteSessions[remote] {
+		out = append(out, s.Title)
+	}
+	return out
+}
+
+func TestRemoteFetch_StaleResultIsIgnored(t *testing.T) {
+	home := newTestHomeWithItems(100, 30, nil)
+	fresh := map[string][]session.RemoteSessionInfo{"box": {{ID: "a", Title: "kept"}}}
+	stale := map[string][]session.RemoteSessionInfo{"box": {{ID: "a", Title: "kept"}, {ID: "b", Title: "deleted-meanwhile"}}}
+
+	model, _ := home.Update(remoteSessionsFetchedMsg{gen: 5, sessions: fresh})
+	h := model.(*Home)
+	model, _ = h.Update(remoteSessionsFetchedMsg{gen: 4, sessions: stale})
+	h = model.(*Home)
+
+	if got := remoteTitles(h, "box"); len(got) != 1 || got[0] != "kept" {
+		t.Fatalf("a fetch older than the last applied one must be ignored; sessions = %v", got)
+	}
+	if h.remotesFetchActive {
+		t.Fatal("a stale result must still release the in-flight guard")
+	}
+}
+
+func TestRemoteFetch_ConfigErrorKeepsRemotes(t *testing.T) {
+	home := newTestHomeWithItems(100, 30, nil)
+	model, _ := home.Update(remoteSessionsFetchedMsg{gen: 1, sessions: map[string][]session.RemoteSessionInfo{"box": {{ID: "a", Title: "kept"}}}})
+	h := model.(*Home)
+	model, _ = h.Update(remoteSessionsFetchedMsg{gen: 2, configErr: errors.New("toml: line 3: bad key")})
+	h = model.(*Home)
+
+	if got := remoteTitles(h, "box"); len(got) != 1 {
+		t.Fatalf("an unreadable config must not drop cached remotes; sessions = %v", got)
+	}
+	if h.err == nil {
+		t.Fatal("an unreadable config must be reported in the footer")
+	}
+}
+
+func TestRemoteRename_RefusedRevertsTitle(t *testing.T) {
+	home := newTestHomeWithItems(100, 30, nil)
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{"box": {{ID: "a", Title: "old"}}}
+
+	if old := home.setRemoteSessionTitle("box", "a", "new"); old != "old" {
+		t.Fatalf("setRemoteSessionTitle returned %q, want the previous title", old)
+	}
+	model, _ := home.Update(remoteRenameResultMsg{remoteName: "box", sessionID: "a", oldTitle: "old", newTitle: "new", err: errors.New("title already taken")})
+	h := model.(*Home)
+
+	if got := remoteTitles(h, "box"); got[0] != "old" {
+		t.Fatalf("a refused rename must revert the cached title; got %v", got)
+	}
+	if h.err == nil {
+		t.Fatal("a refused rename must be reported")
+	}
+}
+
+func TestRemoteCreate_QueuedIsNoticeNotError(t *testing.T) {
+	var queued *session.RemoteSessionQueuedError
+	err := error(&session.RemoteSessionQueuedError{ID: "x", Title: "job"})
+	if !errors.As(err, &queued) || queued.Title != "job" {
+		t.Fatal("the queued outcome must be a typed error the TUI can tell apart from a failure")
+	}
+}


### PR DESCRIPTION
## What problem does this solve?
Five confirmed findings from the remote-deck review (#2170, items 2, 3, 4, 6, 7 and 9 there): a stale fleet poll could undo a delete/archive/move for a cycle; an unreadable config wiped every remote; a refused rename snapped back silently; a queued create was shown as a failure; create and attach failures were silent or unnamed, and Enter on a stopped remote session did nothing. Part of #2156 / #2138.

## Why this change
- `remoteSessionsFetchedMsg` carries a sequence number (`Home.remoteFetchSeq`); the handler ignores a result older than the last applied one and only releases the in-flight guard. Mutation refreshes therefore always win over an overlapping periodic poll.
- `fetchRemoteSessions` returns `configErr` instead of an empty map when `LoadUserConfig` fails; the handler keeps the cache and reports the parse error.
- Remote rename runs as a `tea.Cmd` yielding `remoteRenameResultMsg`; the optimistic title is reverted on error with "failed to rename '<title>' on <remote>: ...".
- `CreateSessionWithOptions` returns a typed `RemoteSessionQueuedError`; the TUI shows "created ... queued until group has a free slot" and refreshes, instead of a red failure.
- Create failures return `remoteSessionCreatedMsg{err}` (named remote, terminal cleanup after `tea.Exec`); `attachRemoteSession` surfaces config and attach errors; Enter on a `stopped` remote row routes to the existing restart path.

## User impact
Rows no longer reappear after a delete; a bad config no longer empties the remote tree; refused renames and failed attaches say what happened and where; queued creates are not mistaken for failures.

## Evidence
`internal/ui` passes in the Docker test image, including four new tests (`remote_correctness_test.go`: stale fetch ignored, config error keeps remotes, refused rename reverts, queued error typed). Local go test is disallowed on this host.

## AI disclosure
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5-1

## What actually bothered you
My human asked: "for latency and all fixes, do we have them merged?" after the review listed these.

## Checklist
- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5-1 intent=yes -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer notices when remote sessions are queued during creation.
  * Pressing Enter on a stopped remote session now restarts it before attaching.
  * Remote session renames update immediately and revert if the server rejects them.
  * Attach failures now display an error instead of failing silently.
  * Remote actions report their elapsed time.

* **Bug Fixes**
  * Prevented outdated remote-session results from replacing newer data.
  * Preserved cached remotes when configuration parsing fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->