### PR TITLE
feat(remote): the screen never waits for the remote, and every action reports its time

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -648,6 +648,10 @@ type Home struct {
 	// time from keypress to the remote's confirmation, the number that
 	// tells whether a remote deck feels local.
 	remoteActionStarted map[string]time.Time
+	// remotePending marks remote session rows with an action underway
+	// (sessionID -> "deleting…"), drawn on the row so the screen says what
+	// is happening while the remote answers instead of freezing.
+	remotePending map[string]string
 	// remoteSessionRefreshSec is the poll cadence (seconds) for re-fetching
 	// the remote session list, resolved once at construction from
 	// [ui] remote_session_refresh_secs. Issue #1170.
@@ -2329,6 +2333,55 @@ func remoteGroupBaseName(path string) string {
 		return path[idx+1:]
 	}
 	return path
+}
+
+// setRemotePending marks (verb != "") or clears a remote session row's
+// in-flight action and redraws.
+func (h *Home) setRemotePending(sessionID, verb string) {
+	if h.remotePending == nil {
+		h.remotePending = make(map[string]string)
+	}
+	if verb == "" {
+		delete(h.remotePending, sessionID)
+	} else {
+		h.remotePending[sessionID] = verb
+	}
+	// Read at draw time by renderRemoteSessionItem; no row rebuild needed.
+}
+
+// patchRemoteSession applies fn to the cached copy of one remote session and
+// redraws, so the screen reflects a confirmed action now rather than at the
+// next poll; the next fetch reconciles from the remote's truth.
+func (h *Home) patchRemoteSession(remoteName, sessionID string, fn func(*session.RemoteSessionInfo)) {
+	h.remoteSessionsMu.Lock()
+	if sessions, ok := h.remoteSessions[remoteName]; ok {
+		for i := range sessions {
+			if sessions[i].ID == sessionID {
+				fn(&sessions[i])
+				break
+			}
+		}
+	}
+	h.remoteSessionsMu.Unlock()
+	h.cachedStatusCounts.valid.Store(false)
+	h.rebuildFlatItems()
+}
+
+// dropRemoteSession removes one session from the cache and redraws.
+func (h *Home) dropRemoteSession(remoteName, sessionID string) {
+	h.remoteSessionsMu.Lock()
+	if sessions, ok := h.remoteSessions[remoteName]; ok {
+		kept := sessions[:0]
+		for _, s := range sessions {
+			if s.ID != sessionID {
+				kept = append(kept, s)
+			}
+		}
+		h.remoteSessions[remoteName] = kept
+	}
+	h.remoteSessionsMu.Unlock()
+	h.cachedStatusCounts.valid.Store(false)
+	h.rebuildFlatItems()
 }
 
 // remoteActionKey identifies one in-flight remote action for timing.
@@ -6915,16 +6968,19 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 	case remoteSessionDeletedMsg:
+		h.setRemotePending(msg.sessionID, "")
 		if msg.err != nil {
-			h.setError(fmt.Errorf("failed to delete remote session: %w", msg.err))
+			h.setError(fmt.Errorf("failed to delete '%s' on %s: %w", msg.title, msg.remoteName, msg.err))
 			return h, nil
 		}
+		h.dropRemoteSession(msg.remoteName, msg.sessionID)
 		h.setError(fmt.Errorf("deleted '%s' on %s%s", msg.title, msg.remoteName, h.remoteActionTook(msg.remoteName, "delete", msg.sessionID)))
 		return h, h.fetchRemoteSessions
 
 	case remoteSessionClosedMsg:
+		h.setRemotePending(msg.sessionID, "")
 		if msg.err != nil {
-			h.setError(fmt.Errorf("failed to close remote session: %w", msg.err))
+			h.setError(fmt.Errorf("failed to close '%s' on %s: %w", msg.title, msg.remoteName, msg.err))
 			return h, nil
 		}
 		h.setError(fmt.Errorf("closed '%s' on %s%s", msg.title, msg.remoteName, h.remoteActionTook(msg.remoteName, "close", msg.sessionID)))
@@ -6935,28 +6991,39 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if !msg.archived {
 			verb = "unarchive"
 		}
+		h.setRemotePending(msg.sessionID, "")
 		if msg.err != nil {
-			h.setError(fmt.Errorf("failed to %s remote session: %w", verb, msg.err))
+			h.setError(fmt.Errorf("failed to %s '%s' on %s: %w", verb, msg.title, msg.remoteName, msg.err))
 			return h, nil
 		}
+		archived := msg.archived
+		h.patchRemoteSession(msg.remoteName, msg.sessionID, func(s *session.RemoteSessionInfo) {
+			s.Archived = archived
+			if archived {
+				s.Status = string(session.StatusStopped)
+			}
+		})
 		h.setError(fmt.Errorf("%sd '%s' on %s%s", verb, msg.title, msg.remoteName, h.remoteActionTook(msg.remoteName, "archive", msg.sessionID)))
 		return h, h.fetchRemoteSessions
 
 	case remoteSessionRestartedMsg:
 		delete(h.remoteRestarting, remoteRestartAnimationID(msg.remoteName, msg.sessionID))
 		delete(h.resumingSessions, remoteRestartAnimationID(msg.remoteName, msg.sessionID))
+		h.setRemotePending(msg.sessionID, "")
 		if msg.err != nil {
-			h.setError(fmt.Errorf("failed to restart remote session: %w", msg.err))
+			h.setError(fmt.Errorf("failed to restart '%s' on %s: %w", msg.title, msg.remoteName, msg.err))
 			return h, nil
 		}
+		h.patchRemoteSession(msg.remoteName, msg.sessionID, func(s *session.RemoteSessionInfo) { s.Status = string(session.StatusRunning) })
 		h.setError(fmt.Errorf("restarted '%s' on %s%s", msg.title, msg.remoteName, h.remoteActionTook(msg.remoteName, "restart", msg.sessionID)))
 		return h, h.fetchRemoteSessions
 
 	case remoteSessionForkedMsg:
 		delete(h.remoteForking, remoteRestartAnimationID(msg.remoteName, msg.sessionID))
 		delete(h.forkingSessions, remoteRestartAnimationID(msg.remoteName, msg.sessionID))
+		h.setRemotePending(msg.sessionID, "")
 		if msg.err != nil {
-			h.setError(fmt.Errorf("failed to fork remote session: %w", msg.err))
+			h.setError(fmt.Errorf("failed to fork '%s' on %s: %w", msg.title, msg.remoteName, msg.err))
 			return h, nil
 		}
 		h.setError(fmt.Errorf("forked '%s' on %s%s", msg.title, msg.remoteName, h.remoteActionTook(msg.remoteName, "fork", msg.sessionID)))
@@ -10880,6 +10947,9 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Remote decks refresh in the same keystroke, so a change made on a
 		// remote (or from another machine) shows up now, not at the next poll.
 		state := h.preserveState()
+		h.remoteSessionsMu.Lock()
+		h.remotesFetchActive = true // so the remote headers show "refreshing…"
+		h.remoteSessionsMu.Unlock()
 		return h, tea.Batch(h.sessionLoadCmd(&state, false), h.fetchRemoteSessions)
 
 	case "ctrl+s":
@@ -14807,6 +14877,7 @@ type remoteCreateDirNeededMsg struct {
 // deleteRemoteSession deletes a remote session and refreshes the remote list.
 func (h *Home) deleteRemoteSession(remoteName, sessionID, title string) tea.Cmd {
 	h.markRemoteAction(remoteName, "delete", sessionID)
+	h.setRemotePending(sessionID, "deleting…")
 	return func() tea.Msg {
 		config, err := session.LoadUserConfig()
 		if err != nil || config == nil || config.Remotes == nil {
@@ -14837,6 +14908,7 @@ func (h *Home) deleteRemoteSession(remoteName, sessionID, title string) tea.Cmd 
 // closeRemoteSession stops a remote session process without deleting metadata.
 func (h *Home) closeRemoteSession(remoteName, sessionID, title string) tea.Cmd {
 	h.markRemoteAction(remoteName, "close", sessionID)
+	h.setRemotePending(sessionID, "closing…")
 	return func() tea.Msg {
 		config, err := session.LoadUserConfig()
 		if err != nil || config == nil || config.Remotes == nil {
@@ -14870,6 +14942,11 @@ func (h *Home) closeRemoteSession(remoteName, sessionID, title string) tea.Cmd {
 // archived (^) views the way a local session does.
 func (h *Home) setRemoteSessionArchived(remoteName, sessionID, title string, archive bool) tea.Cmd {
 	h.markRemoteAction(remoteName, "archive", sessionID)
+	if archive {
+		h.setRemotePending(sessionID, "archiving…")
+	} else {
+		h.setRemotePending(sessionID, "restoring…")
+	}
 	return func() tea.Msg {
 		result := remoteSessionArchivedMsg{remoteName: remoteName, sessionID: sessionID, title: title, archived: archive}
 		config, err := session.LoadUserConfig()
@@ -14900,6 +14977,7 @@ func (h *Home) setRemoteSessionArchived(remoteName, sessionID, title string, arc
 // the remote confirms via remoteSessionForkedMsg so the new row appears.
 func (h *Home) forkRemoteSession(remoteName, sessionID, title string) tea.Cmd {
 	h.markRemoteAction(remoteName, "fork", sessionID)
+	h.setRemotePending(sessionID, "forking…")
 	return func() tea.Msg {
 		result := remoteSessionForkedMsg{remoteName: remoteName, sessionID: sessionID, title: title}
 		config, err := session.LoadUserConfig()
@@ -14923,6 +15001,7 @@ func (h *Home) forkRemoteSession(remoteName, sessionID, title string) tea.Cmd {
 // restartRemoteSession restarts a remote session.
 func (h *Home) restartRemoteSession(remoteName, sessionID, title string) tea.Cmd {
 	h.markRemoteAction(remoteName, "restart", sessionID)
+	h.setRemotePending(sessionID, "restarting…")
 	return func() tea.Msg {
 		config, err := session.LoadUserConfig()
 		if err != nil || config == nil || config.Remotes == nil {
@@ -18964,12 +19043,17 @@ func (h *Home) renderRemoteGroupItem(b *strings.Builder, item session.Item, sele
 	count := len(sessions)
 	running, waiting := remoteStatusCounts(sessions, "")
 	fromCache := h.remoteFromCache[item.RemoteName]
+	fetching := h.remotesFetchActive
 	h.remoteSessionsMu.RUnlock()
 
 	trailer := h.renderRemoteLatencyMarker(item.RemoteName, selected)
 	if fromCache {
 		// Honest staleness: this is the startup snapshot, not live state yet.
 		trailer = " " + DimStyle.Render("— cached, refreshing…")
+	} else if fetching {
+		// A fetch is in flight: what is shown is the last answer, and the
+		// header says so instead of leaving the user to guess.
+		trailer += " " + DimStyle.Render("· refreshing…")
 	}
 
 	b.WriteString(fmt.Sprintf("%s%s %s%s%s%s\n",
@@ -19081,13 +19165,21 @@ func (h *Home) renderRemoteSessionItem(b *strings.Builder, item session.Item, se
 		indent = "  " // defensive: never dedent past the old flat baseline
 	}
 
-	b.WriteString(fmt.Sprintf("%s%s%s %s %s%s\n",
+	pendingStr := ""
+	if item.RemoteSession != nil {
+		if verb, ok := h.remotePending[item.RemoteSession.ID]; ok {
+			pendingStr = " " + DimStyle.Render("· "+verb)
+		}
+	}
+
+	b.WriteString(fmt.Sprintf("%s%s%s %s %s%s%s\n",
 		remoteRowGutter(selected), // align with group/session hotkey gutter
 		indent,
 		DimStyle.Render(treeConnector),
 		sStyle.Render(statusIcon),
 		titleStyle.Render(titleStr),
 		toolStr,
+		pendingStr,
 	))
 }
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -643,6 +643,11 @@ type Home struct {
 	// archive just triggered (a stale snapshot would resurrect the row).
 	remoteFetchSeq     uint64
 	remoteFetchApplied uint64
+	// remoteActionStarted records when each remote action was requested
+	// (keyed by remote, verb and target) so its footer line can report the
+	// time from keypress to the remote's confirmation, the number that
+	// tells whether a remote deck feels local.
+	remoteActionStarted map[string]time.Time
 	// remoteSessionRefreshSec is the poll cadence (seconds) for re-fetching
 	// the remote session list, resolved once at construction from
 	// [ui] remote_session_refresh_secs. Issue #1170.
@@ -2220,6 +2225,7 @@ func (h *Home) remoteGroupPaths(remoteName string) []string {
 // remoteMoveResultMsg so the fleet cache is updated only on remote
 // confirmation. Mirrors the remote-rename path in GroupDialogRenameSession.
 func (h *Home) moveRemoteSessionToGroup(title, remoteName, sessionID, targetGroupPath string) tea.Cmd {
+	h.markRemoteAction(remoteName, "move", sessionID)
 	return func() tea.Msg {
 		config, err := session.LoadUserConfig()
 		if err != nil || config == nil || config.Remotes == nil {
@@ -2265,6 +2271,7 @@ func remoteGroupCreateArgs(name, parentPath, defaultPath string) []string {
 }
 
 func (h *Home) createRemoteGroup(name, remoteName, parentPath, defaultPath string) tea.Cmd {
+	h.markRemoteAction(remoteName, "create-group", name)
 	return func() tea.Msg {
 		config, err := session.LoadUserConfig()
 		if err != nil || config == nil || config.Remotes == nil {
@@ -2297,6 +2304,7 @@ func (h *Home) createRemoteGroup(name, remoteName, parentPath, defaultPath strin
 // --force, so a group that still holds sessions is refused by the remote with
 // its own message instead of silently moving sessions around.
 func (h *Home) deleteRemoteGroup(groupPath, remoteName string) tea.Cmd {
+	h.markRemoteAction(remoteName, "delete-group", groupPath)
 	return func() tea.Msg {
 		result := func(err error) tea.Msg {
 			return remoteGroupDeleteResultMsg{remoteName: remoteName, groupPath: groupPath, err: err}
@@ -2312,6 +2320,45 @@ func (h *Home) deleteRemoteGroup(groupPath, remoteName string) tea.Cmd {
 		}
 		return result(nil)
 	}
+}
+
+// remoteGroupBaseName is the last segment of a remote group path, the name
+// createRemoteGroup was asked for.
+func remoteGroupBaseName(path string) string {
+	if idx := strings.LastIndex(path, "/"); idx >= 0 {
+		return path[idx+1:]
+	}
+	return path
+}
+
+// remoteActionKey identifies one in-flight remote action for timing.
+func remoteActionKey(remoteName, verb, target string) string {
+	return remoteName + "|" + verb + "|" + target
+}
+
+// markRemoteAction records the moment a remote action was requested.
+func (h *Home) markRemoteAction(remoteName, verb, target string) {
+	if h.remoteActionStarted == nil {
+		h.remoteActionStarted = make(map[string]time.Time)
+	}
+	h.remoteActionStarted[remoteActionKey(remoteName, verb, target)] = time.Now()
+}
+
+// remoteActionTook returns " in 0.4s" for an action recorded by
+// markRemoteAction, and "" when the start is unknown. The entry is dropped so
+// a later action with the same key measures itself afresh. The raw number
+// also goes to the debug log as remote_action, so latency can be compared
+// across builds without reading the screen.
+func (h *Home) remoteActionTook(remoteName, verb, target string) string {
+	key := remoteActionKey(remoteName, verb, target)
+	start, ok := h.remoteActionStarted[key]
+	if !ok {
+		return ""
+	}
+	delete(h.remoteActionStarted, key)
+	elapsed := time.Since(start)
+	uiLog.Debug("remote_action", slog.String("remote", remoteName), slog.String("verb", verb), slog.String("target", target), slog.Int64("took_ms", elapsed.Milliseconds()))
+	return fmt.Sprintf(" in %.1fs", elapsed.Seconds())
 }
 
 // remoteGroupPathFromItem extracts the remote-relative group path from a
@@ -6872,7 +6919,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			h.setError(fmt.Errorf("failed to delete remote session: %w", msg.err))
 			return h, nil
 		}
-		h.setError(fmt.Errorf("deleted '%s' on %s", msg.title, msg.remoteName))
+		h.setError(fmt.Errorf("deleted '%s' on %s%s", msg.title, msg.remoteName, h.remoteActionTook(msg.remoteName, "delete", msg.sessionID)))
 		return h, h.fetchRemoteSessions
 
 	case remoteSessionClosedMsg:
@@ -6880,7 +6927,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			h.setError(fmt.Errorf("failed to close remote session: %w", msg.err))
 			return h, nil
 		}
-		h.setError(fmt.Errorf("closed '%s' on %s", msg.title, msg.remoteName))
+		h.setError(fmt.Errorf("closed '%s' on %s%s", msg.title, msg.remoteName, h.remoteActionTook(msg.remoteName, "close", msg.sessionID)))
 		return h, h.fetchRemoteSessions
 
 	case remoteSessionArchivedMsg:
@@ -6892,7 +6939,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			h.setError(fmt.Errorf("failed to %s remote session: %w", verb, msg.err))
 			return h, nil
 		}
-		h.setError(fmt.Errorf("%sd '%s' on %s", verb, msg.title, msg.remoteName))
+		h.setError(fmt.Errorf("%sd '%s' on %s%s", verb, msg.title, msg.remoteName, h.remoteActionTook(msg.remoteName, "archive", msg.sessionID)))
 		return h, h.fetchRemoteSessions
 
 	case remoteSessionRestartedMsg:
@@ -6902,7 +6949,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			h.setError(fmt.Errorf("failed to restart remote session: %w", msg.err))
 			return h, nil
 		}
-		h.setError(fmt.Errorf("restarted '%s' on %s", msg.title, msg.remoteName))
+		h.setError(fmt.Errorf("restarted '%s' on %s%s", msg.title, msg.remoteName, h.remoteActionTook(msg.remoteName, "restart", msg.sessionID)))
 		return h, h.fetchRemoteSessions
 
 	case remoteSessionForkedMsg:
@@ -6912,7 +6959,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			h.setError(fmt.Errorf("failed to fork remote session: %w", msg.err))
 			return h, nil
 		}
-		h.setError(fmt.Errorf("forked '%s' on %s", msg.title, msg.remoteName))
+		h.setError(fmt.Errorf("forked '%s' on %s%s", msg.title, msg.remoteName, h.remoteActionTook(msg.remoteName, "fork", msg.sessionID)))
 		return h, h.fetchRemoteSessions
 
 	case remoteAccountsFetchedMsg:
@@ -6986,7 +7033,9 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err != nil {
 			h.setRemoteSessionTitle(msg.remoteName, msg.sessionID, msg.oldTitle)
 			h.setError(fmt.Errorf("failed to rename '%s' on %s: %v", msg.oldTitle, msg.remoteName, msg.err))
+			return h, nil
 		}
+		h.setError(fmt.Errorf("renamed to '%s' on %s%s", msg.newTitle, msg.remoteName, h.remoteActionTook(msg.remoteName, "rename", msg.sessionID)))
 		return h, nil
 
 	case remoteMoveResultMsg:
@@ -7010,6 +7059,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		h.remoteSessionsMu.Unlock()
 		h.rebuildFlatItems()
+		h.setError(fmt.Errorf("moved to '%s' on %s%s", msg.groupPath, msg.remoteName, h.remoteActionTook(msg.remoteName, "move", msg.sessionID)))
 		return h, nil
 
 	case remoteGroupResultMsg:
@@ -7041,7 +7091,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.remoteSessionsMu.Unlock()
 		// Show the new (empty) group's row now instead of after the next poll.
 		h.rebuildFlatItems()
-		h.setError(fmt.Errorf("created group '%s' on %s", msg.groupPath, msg.remoteName))
+		h.setError(fmt.Errorf("created group '%s' on %s%s", msg.groupPath, msg.remoteName, h.remoteActionTook(msg.remoteName, "create-group", remoteGroupBaseName(msg.groupPath))))
 		return h, nil
 
 	case remoteGroupDeleteResultMsg:
@@ -7063,7 +7113,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.remoteGroups[msg.remoteName] = kept
 		h.remoteSessionsMu.Unlock()
 		h.rebuildFlatItems()
-		h.setError(fmt.Errorf("deleted group '%s' on %s", msg.groupPath, msg.remoteName))
+		h.setError(fmt.Errorf("deleted group '%s' on %s%s", msg.groupPath, msg.remoteName, h.remoteActionTook(msg.remoteName, "delete-group", msg.groupPath)))
 		return h, h.fetchRemoteSessions
 
 	case remoteGroupReorderResultMsg:
@@ -14719,6 +14769,7 @@ func (h *Home) setRemoteSessionTitle(remoteName, sessionID, title string) string
 // outcome, instead of firing it and forgetting (a refused or unreachable
 // rename used to show the new title and silently snap back on the next poll).
 func (h *Home) renameRemoteSession(remoteName, sessionID, oldTitle, newTitle string) tea.Cmd {
+	h.markRemoteAction(remoteName, "rename", sessionID)
 	return func() tea.Msg {
 		result := remoteRenameResultMsg{remoteName: remoteName, sessionID: sessionID, oldTitle: oldTitle, newTitle: newTitle}
 		runner, err := remoteRunnerFor(remoteName)
@@ -14755,6 +14806,7 @@ type remoteCreateDirNeededMsg struct {
 
 // deleteRemoteSession deletes a remote session and refreshes the remote list.
 func (h *Home) deleteRemoteSession(remoteName, sessionID, title string) tea.Cmd {
+	h.markRemoteAction(remoteName, "delete", sessionID)
 	return func() tea.Msg {
 		config, err := session.LoadUserConfig()
 		if err != nil || config == nil || config.Remotes == nil {
@@ -14784,6 +14836,7 @@ func (h *Home) deleteRemoteSession(remoteName, sessionID, title string) tea.Cmd 
 
 // closeRemoteSession stops a remote session process without deleting metadata.
 func (h *Home) closeRemoteSession(remoteName, sessionID, title string) tea.Cmd {
+	h.markRemoteAction(remoteName, "close", sessionID)
 	return func() tea.Msg {
 		config, err := session.LoadUserConfig()
 		if err != nil || config == nil || config.Remotes == nil {
@@ -14816,6 +14869,7 @@ func (h *Home) closeRemoteSession(remoteName, sessionID, title string) tea.Cmd {
 // then refreshes the remote list so the row moves between the active and
 // archived (^) views the way a local session does.
 func (h *Home) setRemoteSessionArchived(remoteName, sessionID, title string, archive bool) tea.Cmd {
+	h.markRemoteAction(remoteName, "archive", sessionID)
 	return func() tea.Msg {
 		result := remoteSessionArchivedMsg{remoteName: remoteName, sessionID: sessionID, title: title, archived: archive}
 		config, err := session.LoadUserConfig()
@@ -14845,6 +14899,7 @@ func (h *Home) setRemoteSessionArchived(remoteName, sessionID, title string, arc
 // eligibility are decided on the server; the fleet list is refreshed when
 // the remote confirms via remoteSessionForkedMsg so the new row appears.
 func (h *Home) forkRemoteSession(remoteName, sessionID, title string) tea.Cmd {
+	h.markRemoteAction(remoteName, "fork", sessionID)
 	return func() tea.Msg {
 		result := remoteSessionForkedMsg{remoteName: remoteName, sessionID: sessionID, title: title}
 		config, err := session.LoadUserConfig()
@@ -14867,6 +14922,7 @@ func (h *Home) forkRemoteSession(remoteName, sessionID, title string) tea.Cmd {
 
 // restartRemoteSession restarts a remote session.
 func (h *Home) restartRemoteSession(remoteName, sessionID, title string) tea.Cmd {
+	h.markRemoteAction(remoteName, "restart", sessionID)
 	return func() tea.Msg {
 		config, err := session.LoadUserConfig()
 		if err != nil || config == nil || config.Remotes == nil {


### PR DESCRIPTION
## What problem does this solve?
A remote deck still felt laggy even after #2171: the row you acted on froze until the next poll, nothing said an action was underway, and there was no number for how long a remote action took. Stacked on #2172 (its three commits are included; merge that first, this PR then shows only the last two). Part of #2156 / #2167 / #2138.

## Why this change
- **Pending markers.** Delete, close, archive, unarchive, restart and fork mark the row with a dim "· deleting…" style marker at keypress; the marker is read at draw time (no row rebuild), and cleared on the remote's answer.
- **Confirmed state applied at once.** On confirmation the cached row is patched (dropped, flipped to archived, set running) and redrawn, instead of waiting for the next fleet poll. The sequence guard from #2172 keeps an older poll from undoing it.
- **Refreshing marker.** While a fleet fetch is in flight (periodic or ctrl+r) the remote host header shows "· refreshing…" next to its latency, so the view is understood as the last answer rather than frozen.
- **Timing on every action.** Each remote action's footer line ends with the keypress-to-confirmation time ("created group 'x' on agentbox in 0.2s"); move and rename, previously silent, get a line too. The same number is logged as `remote_action` (remote, verb, target, took_ms) so latency is comparable across builds.

## User impact
Over a 100 ms Tailscale link the marker appears within 150 ms of the keypress and the row settles 0.2 s later; the screen never blocks on the remote, and the user can see both what is in flight and what each action cost.

## Evidence
Driven in a sandbox TUI against the maintainer's Agent Box (direct Tailscale path, RTT 97 ms): archive shows "· archiving…" at t+150 ms and the row leaves the active view at 0.2 s with the footer "archived 'e2e-smooth' on agentbox in 0.2s"; group create and delete confirm in 0.2 s. `internal/ui` and the remote `internal/session` tests pass in the Docker test image. Local go test is disallowed on this host.

## AI disclosure
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5-1

## What actually bothered you
My human asked: "still quite slow sometimes, can we do something like a state saving thing so it maintains the state properly and updates there, making it smoother" and "until the state matches show something in flight" and "show the actual time on screen, we should get some internal metric".

## Checklist
- [x] Targeted diff: one problem, no unrelated changes
- [ ] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5-1 intent=yes -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Remote session actions now show in-progress status and provide faster visual updates.
  - Pressing Enter on a stopped remote session restarts it.
  - Queued session requests now provide clear, distinguishable feedback.

- **Bug Fixes**
  - Prevented outdated refreshes from overwriting newer remote-session data.
  - Cached remotes are preserved when configuration cannot be read.
  - Rename and other remote actions now revert correctly and report failures.
  - Attach failures are now surfaced instead of being ignored.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->