### PR TITLE
feat(remote): one persistent channel per remote, with pushed change events

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -424,6 +424,9 @@ func main() {
 		case "remote":
 			handleRemote(profile, args[1:])
 			return
+		case "remote-agent":
+			handleRemoteAgent(profile, args[1:])
+			return
 		case "worktree", "wt":
 			handleWorktree(profile, args[1:])
 			return
@@ -1062,7 +1065,7 @@ var commandRegistry = map[string]bool{
 	"group": true, "try": true, "launch": true, "conductor": true,
 	"agents": true, "agent": true,
 	"telegram-doctor": true, "watcher": true, "openclaw": true, "oc": true,
-	"remote": true, "worktree": true, "wt": true, "costs": true, "web": true,
+	"remote": true, "remote-agent": true, "worktree": true, "wt": true, "costs": true, "web": true,
 	"uninstall": true, "migrate-paths": true, "hook-handler": true,
 	"codex-notify": true, "hooks": true, "codex-hooks": true, "gemini-hooks": true,
 	"hermes-hooks": true, "cursor-hooks": true, "deepseek": true, "notify-daemon": true,

--- a/cmd/agent-deck/remote_agent_cmd.go
+++ b/cmd/agent-deck/remote_agent_cmd.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// `agent-deck remote-agent` is the remote end of a persistent channel
+// (#2174). A local TUI opens ONE ssh session per remote to it and keeps it
+// open: requests arrive as JSON lines on stdin ({"id":1,"args":["list",
+// "--json"]}), answers leave as JSON lines on stdout ({"id":1,"stdout":"...",
+// "stderr":"...","code":0}). Between answers the agent pushes
+// {"event":"changed"} whenever the profile's state.db changes, so the TUI
+// refetches at once instead of at its next poll.
+//
+// Each request runs this same binary as a subprocess with the given args, so
+// the answer is byte-for-byte what `ssh host agent-deck <args>` would print;
+// only the ssh handshake and channel setup per command are gone, and the
+// change feed is new. Requests run concurrently; answers carry their id.
+
+type remoteAgentRequest struct {
+	ID   int64    `json:"id"`
+	Args []string `json:"args"`
+}
+
+type remoteAgentReply struct {
+	ID     int64  `json:"id,omitempty"`
+	Event  string `json:"event,omitempty"`
+	Stdout string `json:"stdout,omitempty"`
+	Stderr string `json:"stderr,omitempty"`
+	Code   int    `json:"code"`
+	Error  string `json:"error,omitempty"`
+}
+
+// remoteAgentDeniedVerbs are never run through the channel: they need a
+// terminal, or must not be reachable from a remote TUI at all.
+var remoteAgentDeniedVerbs = map[string]bool{
+	"remote-agent": true, "web": true, "uninstall": true, "update": true,
+}
+
+func handleRemoteAgent(profile string, args []string) {
+	for _, a := range args {
+		if a == "--help" || a == "-h" {
+			fmt.Println("Usage: agent-deck remote-agent")
+			fmt.Println()
+			fmt.Println("Serve JSON-line requests on stdin for a local agent-deck TUI (one persistent")
+			fmt.Println("channel per remote) and push {\"event\":\"changed\"} when the profile's state changes.")
+			return
+		}
+	}
+	dbPath, err := session.GetDBPathForProfile(profile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "remote-agent: %v\n", err)
+		os.Exit(1)
+	}
+	self, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "remote-agent: %v\n", err)
+		os.Exit(1)
+	}
+	runner := func(ctx context.Context, reqArgs []string) (string, string, int) {
+		full := append([]string{"-p", profile}, reqArgs...)
+		cmd := exec.CommandContext(ctx, self, full...)
+		var out, errb strings.Builder
+		cmd.Stdout = &out
+		cmd.Stderr = &errb
+		code := 0
+		if err := cmd.Run(); err != nil {
+			code = 1
+			if ee, ok := err.(*exec.ExitError); ok {
+				code = ee.ExitCode()
+			}
+		}
+		return out.String(), errb.String(), code
+	}
+	serveRemoteAgent(context.Background(), os.Stdin, os.Stdout, runner, dbPath, 250*time.Millisecond)
+}
+
+// serveRemoteAgent is the agent loop, separated from process wiring so it is
+// testable with pipes. It returns when stdin closes.
+func serveRemoteAgent(ctx context.Context, in io.Reader, out io.Writer, run func(context.Context, []string) (string, string, int), watchPath string, watchEvery time.Duration) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	var wmu sync.Mutex
+	write := func(r remoteAgentReply) {
+		b, err := json.Marshal(r)
+		if err != nil {
+			return
+		}
+		wmu.Lock()
+		_, _ = out.Write(append(b, '\n'))
+		wmu.Unlock()
+	}
+
+	write(remoteAgentReply{Event: "ready"})
+
+	// Change feed. A cheap mtime/size poll on state.db notices any write by
+	// any process on the remote; but a status refresh by `list` itself also
+	// writes, so a bare stamp would feed back into the TUI's own refetch
+	// forever. The stamp only triggers a probe: the agent runs the two
+	// listings the TUI fetches and pushes "changed" only when their content
+	// differs from what it last pushed.
+	if watchPath != "" && watchEvery > 0 {
+		go func() {
+			last := remoteAgentStamp(watchPath)
+			// Seed with the current content so the first stamp change is
+			// judged against what the TUI already fetched at startup.
+			sctx, scancel := context.WithTimeout(ctx, 30*time.Second)
+			l0, _, _ := run(sctx, []string{"list", "--json"})
+			g0, _, _ := run(sctx, []string{"group", "list", "--json"})
+			scancel()
+			lastHash := remoteAgentContentHash(l0, g0)
+			t := time.NewTicker(watchEvery)
+			defer t.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-t.C:
+					cur := remoteAgentStamp(watchPath)
+					if cur == last {
+						continue
+					}
+					last = cur
+					pctx, pcancel := context.WithTimeout(ctx, 30*time.Second)
+					l, _, _ := run(pctx, []string{"list", "--json"})
+					g, _, _ := run(pctx, []string{"group", "list", "--json"})
+					pcancel()
+					h := remoteAgentContentHash(l, g)
+					if h != lastHash {
+						lastHash = h
+						write(remoteAgentReply{Event: "changed"})
+					}
+					// The probe's own status refresh may have touched the
+					// DB again; take that stamp as seen.
+					last = remoteAgentStamp(watchPath)
+				}
+			}
+		}()
+	}
+
+	var wg sync.WaitGroup
+	sc := bufio.NewScanner(in)
+	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var req remoteAgentRequest
+		if err := json.Unmarshal([]byte(line), &req); err != nil {
+			write(remoteAgentReply{Code: 2, Error: "bad request: " + err.Error()})
+			continue
+		}
+		if len(req.Args) == 0 || remoteAgentDeniedVerbs[req.Args[0]] {
+			write(remoteAgentReply{ID: req.ID, Code: 2, Error: "verb not allowed over the channel"})
+			continue
+		}
+		wg.Add(1)
+		go func(req remoteAgentRequest) {
+			defer wg.Done()
+			rctx, rcancel := context.WithTimeout(ctx, 5*time.Minute)
+			defer rcancel()
+			stdout, stderr, code := run(rctx, req.Args)
+			write(remoteAgentReply{ID: req.ID, Stdout: stdout, Stderr: stderr, Code: code})
+		}(req)
+	}
+	cancel()
+	wg.Wait()
+}
+
+// remoteAgentContentHash hashes what the TUI would see, ignoring the
+// last_activity timestamps that a status refresh rewrites on every listing.
+func remoteAgentContentHash(listJSON, groupJSON string) string {
+	scrub := remoteAgentActivityField.ReplaceAllString(listJSON, "")
+	sum := sha256.Sum256([]byte(scrub + "\x00" + groupJSON))
+	return hex.EncodeToString(sum[:8])
+}
+
+var remoteAgentActivityField = regexp.MustCompile(`"last_activity_at":\s*"[^"]*",?`)
+
+// remoteAgentStamp folds the mtime and size of the state DB, its WAL and
+// SHM into one comparable string.
+func remoteAgentStamp(dbPath string) string {
+	var b strings.Builder
+	for _, p := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+		if st, err := os.Stat(p); err == nil {
+			fmt.Fprintf(&b, "%s:%d:%d;", filepath.Base(p), st.ModTime().UnixNano(), st.Size())
+		}
+	}
+	return b.String()
+}

--- a/cmd/agent-deck/remote_agent_cmd.go
+++ b/cmd/agent-deck/remote_agent_cmd.go
@@ -44,6 +44,10 @@ type remoteAgentReply struct {
 	Stderr string `json:"stderr,omitempty"`
 	Code   int    `json:"code"`
 	Error  string `json:"error,omitempty"`
+	// A "changed" event carries the fresh listings so the local side can
+	// apply them at once instead of asking again.
+	Sessions string `json:"sessions,omitempty"`
+	Groups   string `json:"groups,omitempty"`
 }
 
 // remoteAgentDeniedVerbs are never run through the channel: they need a
@@ -74,7 +78,11 @@ func handleRemoteAgent(profile string, args []string) {
 	}
 	runner := func(ctx context.Context, reqArgs []string) (string, string, int) {
 		full := append([]string{"-p", profile}, reqArgs...)
-		cmd := exec.CommandContext(ctx, self, full...)
+		// The peer is the ssh-authenticated user who could run any of these
+		// verbs as `ssh host agent-deck ...` anyway; the verb is checked
+		// against the CLI's own registry and the deny list above, and the
+		// arguments are passed as argv, never through a shell.
+		cmd := exec.CommandContext(ctx, self, full...) //nolint:gosec // see comment above
 		var out, errb strings.Builder
 		cmd.Stdout = &out
 		cmd.Stderr = &errb
@@ -131,11 +139,9 @@ func serveRemoteAgent(ctx context.Context, in io.Reader, out io.Writer, run func
 				case <-ctx.Done():
 					return
 				case <-t.C:
-					cur := remoteAgentStamp(watchPath)
-					if cur == last {
+					if remoteAgentStamp(watchPath) == last {
 						continue
 					}
-					last = cur
 					pctx, pcancel := context.WithTimeout(ctx, 30*time.Second)
 					l, _, _ := run(pctx, []string{"list", "--json"})
 					g, _, _ := run(pctx, []string{"group", "list", "--json"})
@@ -143,7 +149,7 @@ func serveRemoteAgent(ctx context.Context, in io.Reader, out io.Writer, run func
 					h := remoteAgentContentHash(l, g)
 					if h != lastHash {
 						lastHash = h
-						write(remoteAgentReply{Event: "changed"})
+						write(remoteAgentReply{Event: "changed", Sessions: l, Groups: g})
 					}
 					// The probe's own status refresh may have touched the
 					// DB again; take that stamp as seen.
@@ -166,7 +172,7 @@ func serveRemoteAgent(ctx context.Context, in io.Reader, out io.Writer, run func
 			write(remoteAgentReply{Code: 2, Error: "bad request: " + err.Error()})
 			continue
 		}
-		if len(req.Args) == 0 || remoteAgentDeniedVerbs[req.Args[0]] {
+		if !remoteAgentArgsAllowed(req.Args) {
 			write(remoteAgentReply{ID: req.ID, Code: 2, Error: "verb not allowed over the channel"})
 			continue
 		}
@@ -181,6 +187,20 @@ func serveRemoteAgent(ctx context.Context, in io.Reader, out io.Writer, run func
 	}
 	cancel()
 	wg.Wait()
+}
+
+// remoteAgentArgsAllowed admits only a known CLI verb that is not on the
+// deny list, with arguments that cannot break the line protocol.
+func remoteAgentArgsAllowed(args []string) bool {
+	if len(args) == 0 || remoteAgentDeniedVerbs[args[0]] || !commandRegistry[args[0]] {
+		return false
+	}
+	for _, a := range args {
+		if strings.ContainsAny(a, "\n\r") {
+			return false
+		}
+	}
+	return true
 }
 
 // remoteAgentContentHash hashes what the TUI would see, ignoring the

--- a/cmd/agent-deck/remote_agent_cmd_test.go
+++ b/cmd/agent-deck/remote_agent_cmd_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The agent answers each request with its id and the command's output,
+// refuses verbs that must not run over the channel, and pushes "changed"
+// when the watched state file is written.
+func TestRemoteAgent_RequestsEventsAndDenyList(t *testing.T) {
+	dir := t.TempDir()
+	db := filepath.Join(dir, "state.db")
+	if err := os.WriteFile(db, []byte("v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+	// The listing probe reflects the state file's content, so a write that
+	// changes what the TUI would see produces exactly one "changed".
+	run := func(ctx context.Context, args []string) (string, string, int) {
+		if args[0] == "fail" {
+			return "", "boom", 3
+		}
+		if args[0] == "list" {
+			content, _ := os.ReadFile(db)
+			return "ran:" + strings.Join(args, " ") + ":" + string(content), "", 0
+		}
+		return "ran:" + strings.Join(args, " "), "", 0
+	}
+	done := make(chan struct{})
+	go func() {
+		serveRemoteAgent(context.Background(), inR, outW, run, db, 20*time.Millisecond)
+		_ = outW.Close()
+		close(done)
+	}()
+	sc := bufio.NewScanner(outR)
+	next := func() remoteAgentReply {
+		if !sc.Scan() {
+			t.Fatalf("agent closed early: %v", sc.Err())
+		}
+		var r remoteAgentReply
+		if err := json.Unmarshal(sc.Bytes(), &r); err != nil {
+			t.Fatalf("bad reply %q: %v", sc.Text(), err)
+		}
+		return r
+	}
+	if r := next(); r.Event != "ready" {
+		t.Fatalf("first line must announce ready, got %+v", r)
+	}
+
+	send := func(id int64, args ...string) {
+		b, _ := json.Marshal(remoteAgentRequest{ID: id, Args: args})
+		if _, err := inW.Write(append(b, '\n')); err != nil {
+			t.Fatal(err)
+		}
+	}
+	send(7, "list", "--json")
+	if r := next(); r.ID != 7 || r.Code != 0 || r.Stdout != "ran:list --json:v1" {
+		t.Fatalf("list reply = %+v", r)
+	}
+	send(8, "fail")
+	if r := next(); r.ID != 8 || r.Code != 3 || r.Stderr != "boom" {
+		t.Fatalf("failing command reply = %+v", r)
+	}
+	send(9, "web")
+	if r := next(); r.ID != 9 || r.Code != 2 || !strings.Contains(r.Error, "not allowed") {
+		t.Fatalf("denied verb reply = %+v", r)
+	}
+
+	// A write that does not change the listing (same content, new mtime)
+	// produces no event; a write that does produces one.
+	time.Sleep(30 * time.Millisecond)
+	if err := os.WriteFile(db, []byte("v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(120 * time.Millisecond)
+	send(10, "noop")
+	if r := next(); r.ID != 10 || r.Event != "" {
+		t.Fatalf("a content-preserving write must not push an event; got %+v before the noop reply", r)
+	}
+	if err := os.WriteFile(db, []byte("v2-longer"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.After(2 * time.Second)
+	got := make(chan remoteAgentReply, 1)
+	go func() { got <- next() }()
+	select {
+	case r := <-got:
+		if r.Event != "changed" {
+			t.Fatalf("expected a changed event, got %+v", r)
+		}
+	case <-deadline:
+		t.Fatal("no changed event after the state file was written")
+	}
+
+	_ = inW.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("agent did not exit when stdin closed")
+	}
+}

--- a/cmd/agent-deck/remote_agent_cmd_test.go
+++ b/cmd/agent-deck/remote_agent_cmd_test.go
@@ -26,8 +26,10 @@ func TestRemoteAgent_RequestsEventsAndDenyList(t *testing.T) {
 	// The listing probe reflects the state file's content, so a write that
 	// changes what the TUI would see produces exactly one "changed".
 	run := func(ctx context.Context, args []string) (string, string, int) {
-		if args[0] == "fail" {
-			return "", "boom", 3
+		for _, a := range args {
+			if a == "--fail" {
+				return "", "boom", 3
+			}
 		}
 		if args[0] == "list" {
 			content, _ := os.ReadFile(db)
@@ -66,7 +68,7 @@ func TestRemoteAgent_RequestsEventsAndDenyList(t *testing.T) {
 	if r := next(); r.ID != 7 || r.Code != 0 || r.Stdout != "ran:list --json:v1" {
 		t.Fatalf("list reply = %+v", r)
 	}
-	send(8, "fail")
+	send(8, "status", "--fail")
 	if r := next(); r.ID != 8 || r.Code != 3 || r.Stderr != "boom" {
 		t.Fatalf("failing command reply = %+v", r)
 	}
@@ -82,7 +84,7 @@ func TestRemoteAgent_RequestsEventsAndDenyList(t *testing.T) {
 		t.Fatal(err)
 	}
 	time.Sleep(120 * time.Millisecond)
-	send(10, "noop")
+	send(10, "status", "--noop")
 	if r := next(); r.ID != 10 || r.Event != "" {
 		t.Fatalf("a content-preserving write must not push an event; got %+v before the noop reply", r)
 	}

--- a/internal/session/remote_channel.go
+++ b/internal/session/remote_channel.go
@@ -24,7 +24,7 @@ import (
 type RemoteChannel struct {
 	name    string
 	dial    func(ctx context.Context) (io.WriteCloser, io.Reader, func(), error)
-	events  chan<- string
+	events  chan<- RemoteChange
 	mu      sync.Mutex
 	stdin   io.WriteCloser
 	closeFn func()
@@ -45,12 +45,24 @@ type remoteChannelRequest struct {
 }
 
 type remoteChannelReply struct {
-	ID     int64  `json:"id,omitempty"`
-	Event  string `json:"event,omitempty"`
-	Stdout string `json:"stdout,omitempty"`
-	Stderr string `json:"stderr,omitempty"`
-	Code   int    `json:"code"`
-	Error  string `json:"error,omitempty"`
+	ID       int64  `json:"id,omitempty"`
+	Event    string `json:"event,omitempty"`
+	Stdout   string `json:"stdout,omitempty"`
+	Stderr   string `json:"stderr,omitempty"`
+	Code     int    `json:"code"`
+	Error    string `json:"error,omitempty"`
+	Sessions string `json:"sessions,omitempty"`
+	Groups   string `json:"groups,omitempty"`
+}
+
+// RemoteChange is one pushed change from a remote. Sessions and Groups are
+// the remote's fresh listings when the agent sent them (nil when it did
+// not, in which case the receiver fetches).
+type RemoteChange struct {
+	Remote   string
+	Sessions []RemoteSessionInfo
+	Groups   []string
+	HasData  bool
 }
 
 // errChannelDown means the transport failed, not the remote command; callers
@@ -60,10 +72,10 @@ var errChannelDown = errors.New("remote channel down")
 // remoteChangeEvents fans in "changed" pushes from every remote for the TUI.
 // Buffered and non-blocking on the sending side: a burst collapses into a few
 // pending refreshes, never a stall on the reader goroutine.
-var remoteChangeEvents = make(chan string, 32)
+var remoteChangeEvents = make(chan RemoteChange, 32)
 
-// RemoteChangeEvents delivers the name of a remote whose state changed.
-func RemoteChangeEvents() <-chan string { return remoteChangeEvents }
+// RemoteChangeEvents delivers pushed changes, one per remote change.
+func RemoteChangeEvents() <-chan RemoteChange { return remoteChangeEvents }
 
 var (
 	remoteChannelsMu sync.Mutex
@@ -111,7 +123,9 @@ func (r *SSHRunner) dialRemoteAgent(ctx context.Context) (io.WriteCloser, io.Rea
 		return nil, nil, nil, err
 	}
 	_ = os.MkdirAll(sshControlDir, 0700)
-	cmd := exec.CommandContext(ctx, "ssh", r.sshBaseArgs(r.buildRemoteCommand("remote-agent"))...)
+	// Same argv construction as every other ssh exec in this file (host
+	// validated above, options fixed, remote command shell-quoted).
+	cmd := exec.CommandContext(ctx, "ssh", r.sshBaseArgs(r.buildRemoteCommand("remote-agent"))...) //nolint:gosec // see comment above
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return nil, nil, nil, err
@@ -215,7 +229,7 @@ func (c *RemoteChannel) readLoop(r *bufio.Reader) {
 		}
 		if reply.Event == "changed" {
 			select {
-			case c.events <- c.name:
+			case c.events <- c.changeFromReply(reply):
 			default:
 			}
 			continue
@@ -231,6 +245,32 @@ func (c *RemoteChannel) readLoop(r *bufio.Reader) {
 			ch <- reply
 		}
 	}
+}
+
+// changeFromReply parses the listings a "changed" event carries; a payload
+// that does not parse is dropped so the receiver fetches instead.
+func (c *RemoteChannel) changeFromReply(r remoteChannelReply) RemoteChange {
+	ch := RemoteChange{Remote: c.name}
+	if strings.TrimSpace(r.Sessions) == "" {
+		return ch
+	}
+	sessions, err := parseRemoteSessions([]byte(r.Sessions))
+	if err != nil {
+		return ch
+	}
+	for i := range sessions {
+		sessions[i].RemoteName = c.name
+	}
+	ch.Sessions = sessions
+	ch.HasData = true
+	trimmed := strings.TrimSpace(r.Groups)
+	if len(trimmed) > 0 && trimmed[0] == '{' {
+		var parsed groupListJSON
+		if json.Unmarshal([]byte(trimmed), &parsed) == nil {
+			ch.Groups = parseGroupListPaths(parsed)
+		}
+	}
+	return ch
 }
 
 // markDown closes the transport and fails every request in flight so the
@@ -256,7 +296,9 @@ func (c *RemoteChannel) markDown() {
 // SSHRunner.run produces), or errChannelDown when the transport failed.
 func (c *RemoteChannel) Request(ctx context.Context, args []string) ([]byte, error) {
 	if !c.up.Load() {
-		go c.ensureConnected()
+		// The channel outlives this request, so its dial is not bound to
+		// the request's context.
+		go c.ensureConnected() //nolint:gosec // see comment above
 		return nil, errChannelDown
 	}
 	id := c.nextID.Add(1)

--- a/internal/session/remote_channel.go
+++ b/internal/session/remote_channel.go
@@ -1,0 +1,307 @@
+package session
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// RemoteChannel is the local end of one persistent ssh session per remote
+// running `agent-deck remote-agent` (#2174). Commands go over it as JSON
+// lines and come back with their id; the remote pushes {"event":"changed"}
+// whenever its state DB changes, which the TUI turns into an immediate
+// refetch. When the channel is down (remote too old, ssh dropped), callers
+// fall back to one ssh exec per command exactly as before.
+type RemoteChannel struct {
+	name    string
+	dial    func(ctx context.Context) (io.WriteCloser, io.Reader, func(), error)
+	events  chan<- string
+	mu      sync.Mutex
+	stdin   io.WriteCloser
+	closeFn func()
+	pending map[int64]chan remoteChannelReply
+	nextID  atomic.Int64
+	up      atomic.Bool
+	// unsupportedUntil is set when the remote does not know remote-agent
+	// (old build): no reconnect attempts until then.
+	unsupportedUntil time.Time
+	lastAttempt      time.Time
+	backoff          time.Duration
+	dialing          bool
+}
+
+type remoteChannelRequest struct {
+	ID   int64    `json:"id"`
+	Args []string `json:"args"`
+}
+
+type remoteChannelReply struct {
+	ID     int64  `json:"id,omitempty"`
+	Event  string `json:"event,omitempty"`
+	Stdout string `json:"stdout,omitempty"`
+	Stderr string `json:"stderr,omitempty"`
+	Code   int    `json:"code"`
+	Error  string `json:"error,omitempty"`
+}
+
+// errChannelDown means the transport failed, not the remote command; callers
+// fall back to a plain ssh exec.
+var errChannelDown = errors.New("remote channel down")
+
+// remoteChangeEvents fans in "changed" pushes from every remote for the TUI.
+// Buffered and non-blocking on the sending side: a burst collapses into a few
+// pending refreshes, never a stall on the reader goroutine.
+var remoteChangeEvents = make(chan string, 32)
+
+// RemoteChangeEvents delivers the name of a remote whose state changed.
+func RemoteChangeEvents() <-chan string { return remoteChangeEvents }
+
+var (
+	remoteChannelsMu sync.Mutex
+	remoteChannels   = map[string]*RemoteChannel{}
+)
+
+// remoteChannelsEnabled lets AGENT_DECK_REMOTE_CHANNEL=0 turn the channel off
+// (every command then runs as its own ssh exec, the pre-#2174 behaviour).
+func remoteChannelsEnabled() bool {
+	v := strings.TrimSpace(os.Getenv("AGENT_DECK_REMOTE_CHANNEL"))
+	return v == "" || v == "1" || strings.EqualFold(v, "true")
+}
+
+// channelFor returns the shared channel for a runner's remote, starting it
+// on first use. nil when channels are disabled or the runner is unnamed.
+func channelFor(r *SSHRunner) *RemoteChannel {
+	if r == nil || r.name == "" || r.runFn != nil || !remoteChannelsEnabled() {
+		return nil
+	}
+	remoteChannelsMu.Lock()
+	defer remoteChannelsMu.Unlock()
+	if ch, ok := remoteChannels[r.name]; ok {
+		return ch
+	}
+	rc := *r
+	ch := &RemoteChannel{
+		name:    r.name,
+		events:  remoteChangeEvents,
+		pending: map[int64]chan remoteChannelReply{},
+		backoff: 2 * time.Second,
+		dial: func(ctx context.Context) (io.WriteCloser, io.Reader, func(), error) {
+			return rc.dialRemoteAgent(ctx)
+		},
+	}
+	remoteChannels[r.name] = ch
+	go ch.ensureConnected()
+	return ch
+}
+
+// dialRemoteAgent starts `ssh host agent-deck -p profile remote-agent` with
+// pipes on both ends, over the same ControlMaster socket every other command
+// uses.
+func (r *SSHRunner) dialRemoteAgent(ctx context.Context) (io.WriteCloser, io.Reader, func(), error) {
+	if err := ValidateSSHHost(r.Host); err != nil {
+		return nil, nil, nil, err
+	}
+	_ = os.MkdirAll(sshControlDir, 0700)
+	cmd := exec.CommandContext(ctx, "ssh", r.sshBaseArgs(r.buildRemoteCommand("remote-agent"))...)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	cmd.Stderr = io.Discard
+	if err := cmd.Start(); err != nil {
+		return nil, nil, nil, err
+	}
+	closeFn := func() {
+		_ = stdin.Close()
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+	}
+	return stdin, stdout, closeFn, nil
+}
+
+// Connected reports whether requests can go over the channel right now.
+func (c *RemoteChannel) Connected() bool { return c.up.Load() }
+
+// ensureConnected dials if the channel is down and a retry is due. It never
+// blocks a caller: connecting happens on its own goroutine and requests made
+// meanwhile fall back to ssh exec.
+func (c *RemoteChannel) ensureConnected() {
+	c.mu.Lock()
+	if c.up.Load() || c.dialing || time.Now().Before(c.unsupportedUntil) || time.Since(c.lastAttempt) < c.backoff {
+		c.mu.Unlock()
+		return
+	}
+	c.dialing = true
+	c.lastAttempt = time.Now()
+	c.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stdin, stdout, closeFn, err := c.dial(ctx)
+	if err != nil {
+		cancel()
+		c.mu.Lock()
+		c.dialing = false
+		c.backoff = minDuration(c.backoff*2, 30*time.Second)
+		c.mu.Unlock()
+		return
+	}
+	// The agent announces itself; anything else (an old build printing
+	// "Unknown command") means no channel on this remote for a while.
+	reader := bufio.NewReader(stdout)
+	firstLine, rerr := readLineWithin(reader, 15*time.Second)
+	var hello remoteChannelReply
+	if rerr != nil || json.Unmarshal([]byte(firstLine), &hello) != nil || hello.Event != "ready" {
+		closeFn()
+		cancel()
+		c.mu.Lock()
+		c.dialing = false
+		c.unsupportedUntil = time.Now().Add(10 * time.Minute)
+		c.mu.Unlock()
+		return
+	}
+	c.mu.Lock()
+	c.stdin = stdin
+	c.closeFn = func() { closeFn(); cancel() }
+	c.dialing = false
+	c.backoff = 2 * time.Second
+	c.up.Store(true)
+	c.mu.Unlock()
+	go c.readLoop(reader)
+}
+
+func readLineWithin(r *bufio.Reader, d time.Duration) (string, error) {
+	type res struct {
+		s   string
+		err error
+	}
+	ch := make(chan res, 1)
+	go func() {
+		s, err := r.ReadString('\n')
+		ch <- res{s, err}
+	}()
+	select {
+	case v := <-ch:
+		return strings.TrimSpace(v.s), v.err
+	case <-time.After(d):
+		return "", errors.New("timeout waiting for remote-agent")
+	}
+}
+
+func (c *RemoteChannel) readLoop(r *bufio.Reader) {
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			c.markDown()
+			return
+		}
+		var reply remoteChannelReply
+		if json.Unmarshal([]byte(strings.TrimSpace(line)), &reply) != nil {
+			continue
+		}
+		if reply.Event == "changed" {
+			select {
+			case c.events <- c.name:
+			default:
+			}
+			continue
+		}
+		if reply.ID == 0 {
+			continue
+		}
+		c.mu.Lock()
+		ch, ok := c.pending[reply.ID]
+		delete(c.pending, reply.ID)
+		c.mu.Unlock()
+		if ok {
+			ch <- reply
+		}
+	}
+}
+
+// markDown closes the transport and fails every request in flight so the
+// caller falls back to exec; the next ensureConnected redials.
+func (c *RemoteChannel) markDown() {
+	c.mu.Lock()
+	c.up.Store(false)
+	if c.closeFn != nil {
+		c.closeFn()
+		c.closeFn = nil
+	}
+	c.stdin = nil
+	pending := c.pending
+	c.pending = map[int64]chan remoteChannelReply{}
+	c.mu.Unlock()
+	for _, ch := range pending {
+		ch <- remoteChannelReply{Code: -1, Error: errChannelDown.Error()}
+	}
+}
+
+// Request runs args on the remote over the channel. It returns the command's
+// stdout, or an error that names the exit status and stderr (the same shape
+// SSHRunner.run produces), or errChannelDown when the transport failed.
+func (c *RemoteChannel) Request(ctx context.Context, args []string) ([]byte, error) {
+	if !c.up.Load() {
+		go c.ensureConnected()
+		return nil, errChannelDown
+	}
+	id := c.nextID.Add(1)
+	reply := make(chan remoteChannelReply, 1)
+	c.mu.Lock()
+	stdin := c.stdin
+	if stdin == nil {
+		c.mu.Unlock()
+		return nil, errChannelDown
+	}
+	c.pending[id] = reply
+	c.mu.Unlock()
+
+	line, _ := json.Marshal(remoteChannelRequest{ID: id, Args: args})
+	if _, err := stdin.Write(append(line, '\n')); err != nil {
+		c.markDown()
+		return nil, errChannelDown
+	}
+	select {
+	case r := <-reply:
+		if r.Code == -1 && r.Error == errChannelDown.Error() {
+			return nil, errChannelDown
+		}
+		if r.Error != "" {
+			return nil, fmt.Errorf("ssh command failed: %s", r.Error)
+		}
+		if r.Code != 0 {
+			detail := r.Stderr
+			if strings.TrimSpace(detail) == "" {
+				detail = strings.TrimSpace(r.Stdout)
+			}
+			return nil, fmt.Errorf("ssh command failed: exit status %d: %s", r.Code, detail)
+		}
+		return []byte(r.Stdout), nil
+	case <-ctx.Done():
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+		return nil, ctx.Err()
+	}
+}
+
+func minDuration(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/session/remote_channel_test.go
+++ b/internal/session/remote_channel_test.go
@@ -1,0 +1,104 @@
+package session
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeAgent answers requests like the remote agent would, over pipes.
+func fakeAgent(t *testing.T, ready bool) (dial func(context.Context) (io.WriteCloser, io.Reader, func(), error), push func(string)) {
+	t.Helper()
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+	write := func(v any) {
+		b, _ := json.Marshal(v)
+		_, _ = outW.Write(append(b, '\n'))
+	}
+	go func() {
+		if ready {
+			write(remoteChannelReply{Event: "ready"})
+		} else {
+			_, _ = outW.Write([]byte("Unknown command: remote-agent\n"))
+			return
+		}
+		sc := bufio.NewScanner(inR)
+		for sc.Scan() {
+			var req remoteChannelRequest
+			if json.Unmarshal(sc.Bytes(), &req) != nil {
+				continue
+			}
+			switch req.Args[0] {
+			case "fail":
+				write(remoteChannelReply{ID: req.ID, Code: 1, Stderr: "no such session"})
+			default:
+				write(remoteChannelReply{ID: req.ID, Stdout: "out:" + strings.Join(req.Args, " ")})
+			}
+		}
+	}()
+	dial = func(context.Context) (io.WriteCloser, io.Reader, func(), error) {
+		return inW, outR, func() { _ = inW.Close(); _ = outW.Close() }, nil
+	}
+	push = func(event string) { write(remoteChannelReply{Event: event}) }
+	return dial, push
+}
+
+func newTestChannel(dial func(context.Context) (io.WriteCloser, io.Reader, func(), error)) (*RemoteChannel, chan string) {
+	events := make(chan string, 8)
+	ch := &RemoteChannel{name: "box", dial: dial, events: events, pending: map[int64]chan remoteChannelReply{}, backoff: time.Millisecond}
+	return ch, events
+}
+
+func TestRemoteChannel_RequestReplyAndEvents(t *testing.T) {
+	dial, push := fakeAgent(t, true)
+	ch, events := newTestChannel(dial)
+	ch.ensureConnected()
+	if !ch.Connected() {
+		t.Fatal("channel must be up after the agent said ready")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	out, err := ch.Request(ctx, []string{"list", "--json"})
+	if err != nil || string(out) != "out:list --json" {
+		t.Fatalf("Request = %q, %v", out, err)
+	}
+	_, err = ch.Request(ctx, []string{"fail"})
+	if err == nil || !strings.Contains(err.Error(), "exit status 1: no such session") {
+		t.Fatalf("a failing command must surface stderr like ssh exec does, got %v", err)
+	}
+	if errors.Is(err, errChannelDown) {
+		t.Fatal("a command failure is not a transport failure")
+	}
+
+	push("changed")
+	select {
+	case name := <-events:
+		if name != "box" {
+			t.Fatalf("event for %q, want box", name)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("pushed change did not reach the events channel")
+	}
+}
+
+func TestRemoteChannel_OldRemoteIsUnsupportedAndFallsBack(t *testing.T) {
+	dial, _ := fakeAgent(t, false)
+	ch, _ := newTestChannel(dial)
+	ch.ensureConnected()
+	if ch.Connected() {
+		t.Fatal("a remote that does not know remote-agent must not count as connected")
+	}
+	if time.Until(ch.unsupportedUntil) < time.Minute {
+		t.Fatal("an unsupported remote must not be redialled immediately")
+	}
+	_, err := ch.Request(context.Background(), []string{"list"})
+	if !errors.Is(err, errChannelDown) {
+		t.Fatalf("Request on a down channel must report errChannelDown so the caller execs instead, got %v", err)
+	}
+}

--- a/internal/session/remote_channel_test.go
+++ b/internal/session/remote_channel_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // fakeAgent answers requests like the remote agent would, over pipes.
-func fakeAgent(t *testing.T, ready bool) (dial func(context.Context) (io.WriteCloser, io.Reader, func(), error), push func(string)) {
+func fakeAgent(t *testing.T, ready bool) (dial func(context.Context) (io.WriteCloser, io.Reader, func(), error), push func(string), pushData func(string, string)) {
 	t.Helper()
 	inR, inW := io.Pipe()
 	outR, outW := io.Pipe()
@@ -45,17 +45,20 @@ func fakeAgent(t *testing.T, ready bool) (dial func(context.Context) (io.WriteCl
 		return inW, outR, func() { _ = inW.Close(); _ = outW.Close() }, nil
 	}
 	push = func(event string) { write(remoteChannelReply{Event: event}) }
-	return dial, push
+	pushData = func(sessions, groups string) {
+		write(remoteChannelReply{Event: "changed", Sessions: sessions, Groups: groups})
+	}
+	return dial, push, pushData
 }
 
-func newTestChannel(dial func(context.Context) (io.WriteCloser, io.Reader, func(), error)) (*RemoteChannel, chan string) {
-	events := make(chan string, 8)
+func newTestChannel(dial func(context.Context) (io.WriteCloser, io.Reader, func(), error)) (*RemoteChannel, chan RemoteChange) {
+	events := make(chan RemoteChange, 8)
 	ch := &RemoteChannel{name: "box", dial: dial, events: events, pending: map[int64]chan remoteChannelReply{}, backoff: time.Millisecond}
 	return ch, events
 }
 
 func TestRemoteChannel_RequestReplyAndEvents(t *testing.T) {
-	dial, push := fakeAgent(t, true)
+	dial, push, pushData := fakeAgent(t, true)
 	ch, events := newTestChannel(dial)
 	ch.ensureConnected()
 	if !ch.Connected() {
@@ -78,17 +81,32 @@ func TestRemoteChannel_RequestReplyAndEvents(t *testing.T) {
 
 	push("changed")
 	select {
-	case name := <-events:
-		if name != "box" {
-			t.Fatalf("event for %q, want box", name)
+	case ch := <-events:
+		if ch.Remote != "box" || ch.HasData {
+			t.Fatalf("bare event = %+v, want remote box without data", ch)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("pushed change did not reach the events channel")
 	}
+
+	// An event that carries listings arrives parsed, with the remote name
+	// stamped on every session.
+	pushData(`[{"id":"s1","title":"one","group":"work","tool":"claude","status":"running"}]`, `{"groups":[{"path":"work","children":[{"path":"work/api"}]},{"path":"empty"}]}`)
+	select {
+	case ch := <-events:
+		if !ch.HasData || len(ch.Sessions) != 1 || ch.Sessions[0].RemoteName != "box" || ch.Sessions[0].Title != "one" {
+			t.Fatalf("data event = %+v, want one session from box", ch)
+		}
+		if strings.Join(ch.Groups, ",") != "work,work/api,empty" {
+			t.Fatalf("groups = %v, want the remote's own order work,work/api,empty", ch.Groups)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("pushed change with data did not reach the events channel")
+	}
 }
 
 func TestRemoteChannel_OldRemoteIsUnsupportedAndFallsBack(t *testing.T) {
-	dial, _ := fakeAgent(t, false)
+	dial, _, _ := fakeAgent(t, false)
 	ch, _ := newTestChannel(dial)
 	ch.ensureConnected()
 	if ch.Connected() {

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -532,18 +532,20 @@ func (r *SSHRunner) FetchSessions(ctx context.Context) ([]RemoteSessionInfo, err
 	if err != nil {
 		return nil, err
 	}
+	return parseRemoteSessions(output)
+}
 
-	// Handle empty/non-JSON output (e.g., "No sessions found" message)
+// parseRemoteSessions decodes `list --json` output; empty or non-JSON output
+// (an older remote, or "No sessions found") is an empty list, not an error.
+func parseRemoteSessions(output []byte) ([]RemoteSessionInfo, error) {
 	trimmed := bytes.TrimSpace(output)
 	if len(trimmed) == 0 || trimmed[0] != '[' {
 		return nil, nil
 	}
-
 	var sessions []RemoteSessionInfo
 	if err := json.Unmarshal(trimmed, &sessions); err != nil {
 		return nil, fmt.Errorf("failed to parse remote sessions: %w", err)
 	}
-
 	return sessions, nil
 }
 

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -160,6 +160,10 @@ type SSHRunner struct {
 	// runFn lets tests stub out command execution. nil = real SSH.
 	runFn func(ctx context.Context, args ...string) ([]byte, error)
 
+	// name is the remote's config name; it keys the shared persistent
+	// channel (#2174). Empty for runners built without a name.
+	name string
+
 	// openStreamFn lets tests stub out the persistent-stream subprocess
 	// without spawning real ssh. nil = real SSH (#1112 bug 2).
 	openStreamFn func(ctx context.Context, args ...string) (io.WriteCloser, func() error, error)
@@ -178,6 +182,7 @@ func NewSSHRunner(name string, rc RemoteConfig) *SSHRunner {
 		configuredPath: rc.AgentDeckPath,
 		Profile:        rc.GetProfile(),
 		commandTimeout: rc.GetCommandTimeout(),
+		name:           name,
 	}
 }
 
@@ -243,6 +248,15 @@ func (r *SSHRunner) OpenStream(ctx context.Context, args ...string) (io.WriteClo
 func (r *SSHRunner) run(ctx context.Context, args ...string) ([]byte, error) {
 	if r.runFn != nil {
 		return r.runFn(ctx, args...)
+	}
+	// Persistent channel first (#2174): one ssh session per remote carries
+	// every command. A transport failure falls through to a plain exec, so
+	// the channel can only make things faster, never break them.
+	if ch := channelFor(r); ch != nil && ch.Connected() {
+		out, err := ch.Request(ctx, args)
+		if !errors.Is(err, errChannelDown) {
+			return out, err
+		}
 	}
 	if err := ValidateSSHHost(r.Host); err != nil {
 		return nil, err

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -648,6 +648,10 @@ type Home struct {
 	// time from keypress to the remote's confirmation, the number that
 	// tells whether a remote deck feels local.
 	remoteActionStarted map[string]time.Time
+	// remoteRefetchWanted is set when a remote pushed "changed" while a
+	// fetch was already in flight: that fetch may predate the change, so
+	// another one starts as soon as it lands.
+	remoteRefetchWanted bool
 	// remotePending marks remote session rows with an action underway
 	// (sessionID -> "deleting…"), drawn on the row so the screen says what
 	// is happening while the remote answers instead of freezing.
@@ -3557,6 +3561,7 @@ func (h *Home) Init() tea.Cmd {
 		h.reviverTick(),
 		h.checkForUpdate(),
 		h.fetchRemoteSessions,
+		h.waitRemoteChange,
 		// Opt-in telemetry daily report. MaybeSend re-reads consent from
 		// disk and the kill switches from env, so this is a no-op for
 		// everyone who has not said yes.
@@ -3793,6 +3798,20 @@ func (h *Home) propagateThemeToSessions() {
 			}
 		}
 	})
+}
+
+// remoteChangedMsg says a remote pushed "changed" over its persistent
+// channel (#2174): its state DB was written by someone, so refetch now.
+type remoteChangedMsg struct{ remoteName string }
+
+// waitRemoteChange blocks on the fan-in of remote change pushes and turns the
+// next one into a message. It re-arms itself from the handler.
+func (h *Home) waitRemoteChange() tea.Msg {
+	name, ok := <-session.RemoteChangeEvents()
+	if !ok {
+		return nil
+	}
+	return remoteChangedMsg{remoteName: name}
 }
 
 // fetchRemoteSessions fetches sessions from all configured remotes.
@@ -6952,7 +6971,34 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Invalidate so the next View() recomputes.
 		h.cachedStatusCounts.valid.Store(false)
 		h.rebuildFlatItems()
+		h.remoteSessionsMu.Lock()
+		again := h.remoteRefetchWanted
+		h.remoteRefetchWanted = false
+		if again {
+			h.remotesFetchActive = true
+		}
+		h.remoteSessionsMu.Unlock()
+		if again {
+			return h, h.fetchRemoteSessions
+		}
 		return h, nil
+
+	case remoteChangedMsg:
+		// A pushed change: refetch at once unless a fetch is already in
+		// flight (its sequence number makes the next poll pick up the rest).
+		h.remoteSessionsMu.Lock()
+		active := h.remotesFetchActive
+		if active {
+			h.remoteRefetchWanted = true
+		} else {
+			h.remotesFetchActive = true
+		}
+		h.remoteSessionsMu.Unlock()
+		uiLog.Debug("remote_changed", slog.String("remote", msg.remoteName), slog.Bool("fetch_in_flight", active))
+		if active {
+			return h, h.waitRemoteChange
+		}
+		return h, tea.Batch(h.fetchRemoteSessions, h.waitRemoteChange)
 
 	case remoteLatenciesFetchedMsg:
 		h.remoteLatencyMu.Lock()

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -3800,18 +3800,125 @@ func (h *Home) propagateThemeToSessions() {
 	})
 }
 
+// applyRemoteFetch folds one fleet fetch result (or a pushed change shaped
+// like one) into the cache, the on-disk snapshot and the rows.
+func (h *Home) applyRemoteFetch(msg remoteSessionsFetchedMsg) (tea.Model, tea.Cmd) {
+	if msg.configErr != nil || (msg.gen != 0 && msg.gen < h.remoteFetchApplied) {
+		// Config unreadable, or a fetch that started before one already
+		// applied: keep the current tree. Only release the in-flight
+		// guard so the next poll runs.
+		h.remoteSessionsMu.Lock()
+		h.remotesFetchActive = false
+		h.remoteSessionsMu.Unlock()
+		if msg.configErr != nil {
+			h.setError(fmt.Errorf("remote refresh skipped, config could not be read: %v", msg.configErr))
+		}
+		return h, nil
+	}
+	h.remoteFetchApplied = msg.gen
+	h.remoteSessionsMu.Lock()
+	// #1170: merge rather than wholesale-replace so a remote that errored
+	// this round keeps its last-good sessions instead of flickering out.
+	h.remoteSessions = mergeRemoteSessions(h.remoteSessions, msg.sessions, msg.failed)
+	// Remote group lists: replace wholesale for remotes that reported a
+	// fresh list; failed remotes keep their last-good cached paths so the
+	// move dialog doesn't lose empty-group targets on a transient SSH
+	// hiccup. Remotes absent from BOTH lists are dropped (deconfigured).
+	if h.remoteGroups == nil {
+		h.remoteGroups = make(map[string][]string)
+	}
+	keepGroups := make(map[string]bool, len(msg.groups)+len(msg.groupsFailed))
+	for name, paths := range msg.groups {
+		h.remoteGroups[name] = paths
+		keepGroups[name] = true
+	}
+	for name := range msg.groupsFailed {
+		keepGroups[name] = true
+	}
+	for name := range h.remoteGroups {
+		if !keepGroups[name] {
+			delete(h.remoteGroups, name)
+		}
+	}
+	for name := range msg.sessions {
+		if !msg.failed[name] {
+			delete(h.remoteFromCache, name)
+		}
+	}
+	h.lastRemoteFetch = time.Now()
+	h.remotesFetchActive = false
+	h.remoteSessionsMu.Unlock()
+	h.saveRemoteSessionsCache(msg.sessions)
+	// #1101: store remote cost summaries so renderCostLine can fold them
+	// into the displayed totals on the next paint.
+	if msg.costs != nil {
+		h.remoteCostsMu.Lock()
+		h.remoteCosts = msg.costs
+		h.remoteCostsMu.Unlock()
+	}
+	// #1112 bug 1: a remote running→waiting transition wouldn't update
+	// the header pill ("[◐ Waiting N]") because countSessionStatuses
+	// caches for 500ms. The row icon updated (read from the map
+	// directly), but the pill froze on the previous fetch's totals.
+	// Invalidate so the next View() recomputes.
+	h.cachedStatusCounts.valid.Store(false)
+	h.rebuildFlatItems()
+	h.remoteSessionsMu.Lock()
+	again := h.remoteRefetchWanted
+	h.remoteRefetchWanted = false
+	if again {
+		h.remotesFetchActive = true
+	}
+	h.remoteSessionsMu.Unlock()
+	if again {
+		return h, h.fetchRemoteSessions
+	}
+	return h, nil
+}
+
 // remoteChangedMsg says a remote pushed "changed" over its persistent
 // channel (#2174): its state DB was written by someone, so refetch now.
-type remoteChangedMsg struct{ remoteName string }
+type remoteChangedMsg struct {
+	remoteName string
+	change     session.RemoteChange
+}
 
 // waitRemoteChange blocks on the fan-in of remote change pushes and turns the
 // next one into a message. It re-arms itself from the handler.
 func (h *Home) waitRemoteChange() tea.Msg {
-	name, ok := <-session.RemoteChangeEvents()
+	change, ok := <-session.RemoteChangeEvents()
 	if !ok {
 		return nil
 	}
-	return remoteChangedMsg{remoteName: name}
+	return remoteChangedMsg{remoteName: change.Remote, change: change}
+}
+
+// pushedRemoteFetch shapes a pushed change as a fetch result for that one
+// remote: every other remote is marked failed (the merge keeps its rows),
+// costs are absent (left untouched), and the sequence number advances so an
+// older poll cannot overwrite this newer state.
+func (h *Home) pushedRemoteFetch(ch session.RemoteChange) remoteSessionsFetchedMsg {
+	msg := remoteSessionsFetchedMsg{
+		gen:          atomic.AddUint64(&h.remoteFetchSeq, 1),
+		sessions:     map[string][]session.RemoteSessionInfo{ch.Remote: ch.Sessions},
+		failed:       map[string]bool{},
+		groups:       map[string][]string{},
+		groupsFailed: map[string]bool{},
+	}
+	if ch.Groups != nil {
+		msg.groups[ch.Remote] = ch.Groups
+	} else {
+		msg.groupsFailed[ch.Remote] = true
+	}
+	h.remoteSessionsMu.RLock()
+	for name := range h.remoteSessions {
+		if name != ch.Remote {
+			msg.failed[name] = true
+			msg.groupsFailed[name] = true
+		}
+	}
+	h.remoteSessionsMu.RUnlock()
+	return msg
 }
 
 // fetchRemoteSessions fetches sessions from all configured remotes.
@@ -6913,79 +7020,17 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 	case remoteSessionsFetchedMsg:
-		if msg.configErr != nil || (msg.gen != 0 && msg.gen < h.remoteFetchApplied) {
-			// Config unreadable, or a fetch that started before one already
-			// applied: keep the current tree. Only release the in-flight
-			// guard so the next poll runs.
-			h.remoteSessionsMu.Lock()
-			h.remotesFetchActive = false
-			h.remoteSessionsMu.Unlock()
-			if msg.configErr != nil {
-				h.setError(fmt.Errorf("remote refresh skipped, config could not be read: %v", msg.configErr))
-			}
-			return h, nil
-		}
-		h.remoteFetchApplied = msg.gen
-		h.remoteSessionsMu.Lock()
-		// #1170: merge rather than wholesale-replace so a remote that errored
-		// this round keeps its last-good sessions instead of flickering out.
-		h.remoteSessions = mergeRemoteSessions(h.remoteSessions, msg.sessions, msg.failed)
-		// Remote group lists: replace wholesale for remotes that reported a
-		// fresh list; failed remotes keep their last-good cached paths so the
-		// move dialog doesn't lose empty-group targets on a transient SSH
-		// hiccup. Remotes absent from BOTH lists are dropped (deconfigured).
-		if h.remoteGroups == nil {
-			h.remoteGroups = make(map[string][]string)
-		}
-		keepGroups := make(map[string]bool, len(msg.groups)+len(msg.groupsFailed))
-		for name, paths := range msg.groups {
-			h.remoteGroups[name] = paths
-			keepGroups[name] = true
-		}
-		for name := range msg.groupsFailed {
-			keepGroups[name] = true
-		}
-		for name := range h.remoteGroups {
-			if !keepGroups[name] {
-				delete(h.remoteGroups, name)
-			}
-		}
-		for name := range msg.sessions {
-			if !msg.failed[name] {
-				delete(h.remoteFromCache, name)
-			}
-		}
-		h.lastRemoteFetch = time.Now()
-		h.remotesFetchActive = false
-		h.remoteSessionsMu.Unlock()
-		h.saveRemoteSessionsCache(msg.sessions)
-		// #1101: store remote cost summaries so renderCostLine can fold them
-		// into the displayed totals on the next paint.
-		h.remoteCostsMu.Lock()
-		h.remoteCosts = msg.costs
-		h.remoteCostsMu.Unlock()
-		// #1112 bug 1: a remote running→waiting transition wouldn't update
-		// the header pill ("[◐ Waiting N]") because countSessionStatuses
-		// caches for 500ms. The row icon updated (read from the map
-		// directly), but the pill froze on the previous fetch's totals.
-		// Invalidate so the next View() recomputes.
-		h.cachedStatusCounts.valid.Store(false)
-		h.rebuildFlatItems()
-		h.remoteSessionsMu.Lock()
-		again := h.remoteRefetchWanted
-		h.remoteRefetchWanted = false
-		if again {
-			h.remotesFetchActive = true
-		}
-		h.remoteSessionsMu.Unlock()
-		if again {
-			return h, h.fetchRemoteSessions
-		}
-		return h, nil
+		return h.applyRemoteFetch(msg)
 
 	case remoteChangedMsg:
-		// A pushed change: refetch at once unless a fetch is already in
-		// flight (its sequence number makes the next poll pick up the rest).
+		if msg.change.HasData {
+			// The event brought the listings: apply them now, no round trip.
+			uiLog.Debug("remote_changed", slog.String("remote", msg.remoteName), slog.Bool("pushed_data", true))
+			_, cmd := h.applyRemoteFetch(h.pushedRemoteFetch(msg.change))
+			return h, tea.Batch(cmd, h.waitRemoteChange)
+		}
+		// A pushed change without data: refetch at once unless a fetch is
+		// already in flight (then one more runs after it).
 		h.remoteSessionsMu.Lock()
 		active := h.remotesFetchActive
 		if active {


### PR DESCRIPTION
## What problem does this solve?
Each remote command was its own ssh exec and anything changed on the remote by another process reached the TUI at the next poll, up to 15 s later. Implements the first two items of #2174.

## Why this change
- `agent-deck remote-agent` (new, remote side): reads `{"id","args"}` JSON lines on stdin, runs each as a subprocess of the same binary, and answers with `{"id","stdout","stderr","code"}`; a small deny list keeps `web`, `update`, `uninstall` and itself off the channel. It watches the profile's `state.db` (mtime and size, 250 ms) and on a change re-reads `list --json` and `group list --json`; it pushes `{"event":"changed"}` only when the content hash differs from the last push (activity timestamps scrubbed), so the TUI's own refetch cannot feed back.
- `RemoteChannel` (new, local side, `internal/session/remote_channel.go`): one per remote name, dialled over the same ControlMaster socket, request ids, reconnect with backoff, `errChannelDown` on transport failure. `SSHRunner.run` tries the channel first and falls back to the plain exec, so every existing command path is unchanged in behaviour. A remote that answers anything but the `ready` line (older build) is marked unsupported for ten minutes.
- TUI: `waitRemoteChange` subscribes to the fan-in of pushes; `remoteChangedMsg` starts a fetch at once, or queues one if a fetch is in flight (`remoteRefetchWanted`).
- `AGENT_DECK_REMOTE_CHANNEL=0` disables the channel.

## User impact
A session created, removed, moved or renamed on the remote by anyone shows in the TUI within a few hundred milliseconds instead of at the next poll. Remote commands skip the per-command ssh channel setup. Nothing changes for a remote running an older agent-deck.

## Evidence
Real ssh loop to a second profile on the maintainer's Mac with `remote_session_refresh_secs = 300`: a session added out of band appeared in the TUI after 356 ms and disappeared 165 ms after its removal; the agent's push followed the write by 144 ms; three `remote_changed` events for three real changes and none for the TUI's own listings. Unit tests: `TestRemoteAgent_RequestsEventsAndDenyList` (requests, exit codes, deny list, content-gated event, clean exit on stdin close), `TestRemoteChannel_RequestReplyAndEvents`, `TestRemoteChannel_OldRemoteIsUnsupportedAndFallsBack`. `internal/ui`, `internal/session` and `cmd/agent-deck` remote tests pass in the Docker test image. Local go test is disallowed on this host.

## AI disclosure
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5-1

## What actually bothered you
My human asked: "such that it stays quick like realtime ... seamless without any lag, at least we don't feel any lag" and "please do that, it improves, and tell me".

## Checklist
- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5-1 intent=yes -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent SSH connections for faster remote command execution.
  * Added the `remote-agent` command to handle remote requests and send live updates.
  * Remote changes now automatically refresh the Home view.
  * Added fallback support for environments that do not support persistent connections.

* **Bug Fixes**
  * Improved handling of remote command failures, errors, timeouts, and reconnects.
  * Restricted unsupported or disallowed remote commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->