### PR TITLE
release: v1.16.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.3] - 2026-09-06
+
+Changes on a remote deck reach the local TUI within about a second instead of at the next poll, and the PR gate runs in a third of the time.
+
+### Added
+
+- One persistent channel per remote: the TUI opens a single ssh session to the new `agent-deck remote-agent` and sends every remote command over it as JSON lines; the agent pushes the fresh listings whenever the remote's state changes (content-gated, so the TUI's own reads never feed back), and the TUI applies them at once. A remote running an older build keeps working over per-command ssh; `AGENT_DECK_REMOTE_CHANNEL=0` disables the channel ([#2177](https://github.com/asheshgoplani/agent-deck/pull/2177), part of #2174).
+
+### Changed
+
+- CI: the `Full test suite (PR gate)` runs as seven shards (cmd split three ways by test name, session, ui+web+tests, the rest, and the shared-state proof) with an aggregating gate under the same required name; wall clock about 6.5 minutes instead of 12 ([#2175](https://github.com/asheshgoplani/agent-deck/pull/2175), part of #2169).
+
 ## [1.16.2] - 2026-09-06
 
 A remote deck no longer waits on the network to update the screen, and every remote action reports how long it took.

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -41,7 +41,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-var Version = "1.16.2" // overridden at build time via -ldflags "-X main.Version=..."
+var Version = "1.16.3" // overridden at build time via -ldflags "-X main.Version=..."
 
 // Table column widths for list command output
 const (


### PR DESCRIPTION
## What problem does this solve?
Cuts v1.16.3 so the maintainer gets the persistent remote channel with pushed changes (#2177) and the sharded PR gate (#2175). Version bump and CHANGELOG entry only. After merge the maintainer pushes the `v1.16.3` tag and release.yml publishes. Part of #2138.

## Why this change
Same flow as v1.16.2 (#2176): release commit on main, tag pushed, CI is the only publisher.

## User impact
`agent-deck version` reports 1.16.3 after the tag; release notes as listed in CHANGELOG.md.

## Evidence
`grep 'var Version' cmd/agent-deck/main.go` reads `1.16.3`, which release.yml validates against the tag. #2177 was measured live against the maintainer's Agent Box (change to screen about 1.2 s; 0.36 s over a LAN loop). Local go test is disallowed on this host; nothing here is Go logic.

## AI disclosure
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5-1

## What actually bothered you
My human asked: "please do that, it improves, and tell me" about realtime remote updates.

## Checklist
- [x] Targeted diff: one problem, no unrelated changes
- [ ] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5-1 intent=yes -->