### PR TITLE
fix(ui): draw a remote session the moment the remote confirms its creation

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -2371,6 +2371,35 @@ func (h *Home) patchRemoteSession(remoteName, sessionID string, fn func(*session
 	h.rebuildFlatItems()
 }
 
+// insertRemoteSession adds (or replaces by id) one session in the cache and
+// redraws, so a session the remote just confirmed is on screen before any
+// fetch. Ungrouped sessions land in the default group like the remote does.
+func (h *Home) insertRemoteSession(info session.RemoteSessionInfo) {
+	if info.Group == "" {
+		info.Group = session.DefaultGroupPath
+	}
+	h.remoteSessionsMu.Lock()
+	if h.remoteSessions == nil {
+		h.remoteSessions = make(map[string][]session.RemoteSessionInfo)
+	}
+	sessions := h.remoteSessions[info.RemoteName]
+	replaced := false
+	for i := range sessions {
+		if sessions[i].ID == info.ID {
+			sessions[i] = info
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		sessions = append(sessions, info)
+	}
+	h.remoteSessions[info.RemoteName] = sessions
+	h.remoteSessionsMu.Unlock()
+	h.cachedStatusCounts.valid.Store(false)
+	h.rebuildFlatItems()
+}
+
 // dropRemoteSession removes one session from the cache and redraws.
 func (h *Home) dropRemoteSession(remoteName, sessionID string) {
 	h.remoteSessionsMu.Lock()
@@ -7140,6 +7169,12 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			h.setError(msg.err)
 		} else if msg.notice != "" {
 			h.setError(errors.New(msg.notice))
+		}
+		if msg.created != nil {
+			// Draw the confirmed row now; the fetch below reconciles the
+			// remote's own title (a quick-create gets its name there) and
+			// status.
+			h.insertRemoteSession(*msg.created)
 		}
 		// This message is returned after tea.Exec finishes the remote
 		// create+attach. Mirror the statusUpdateMsg attach-return cleanup so
@@ -14894,6 +14929,8 @@ type remoteSessionCreatedMsg struct {
 	err error
 	// notice is a non-error outcome worth a footer line (e.g. queued).
 	notice string
+	// created describes the session the remote confirmed, drawn at once.
+	created *session.RemoteSessionInfo
 }
 
 // remoteRenameResultMsg reports the remote's answer to a rename started from
@@ -15377,6 +15414,10 @@ type remoteCreateAndAttachCmd struct {
 	runner    *session.SSHRunner
 	opts      session.RemoteAddOptions
 	createCtx context.Context
+	// created receives the remote's session id once `add` succeeded, so
+	// the row can be drawn the moment the attach returns, before any
+	// fetch confirms it.
+	created *string
 	// onExit: same contract as attachCmd.onExit (#1753) — clear the attach flag
 	// while Bubble Tea's loop is still parked, so the first View() after resume
 	// never races the ExecCallback goroutine and renders blank.
@@ -15413,6 +15454,9 @@ func (r remoteCreateAndAttachCmd) Run() error {
 	if err != nil {
 		return err
 	}
+	if r.created != nil {
+		*r.created = sessionID
+	}
 	if err := r.runner.Attach(sessionID); err != nil {
 		return remoteAttachFailedError{err: err}
 	}
@@ -15441,14 +15485,26 @@ func (h *Home) createRemoteSessionWithOptions(remoteName string, opts session.Re
 	}
 	runner := session.NewSSHRunner(remoteName, rc)
 	h.isAttaching.Store(true)
+	var createdID string
 	return tea.Exec(remoteCreateAndAttachCmd{
-		runner: runner, opts: opts, createCtx: h.ctx,
+		runner: runner, opts: opts, createCtx: h.ctx, created: &createdID,
 		// Clear the flag inside Run(), before Bubble Tea restores the terminal
 		// and resumes the loop (#1753); the callback below is only the belt for
 		// the path where Run() never executes.
 		onExit: func() { h.isAttaching.Store(false) },
 	}, func(err error) tea.Msg {
 		h.isAttaching.Store(false)
+		var created *session.RemoteSessionInfo
+		if createdID != "" {
+			tool := opts.Tool
+			if tool == "" {
+				tool = "shell"
+			}
+			created = &session.RemoteSessionInfo{
+				ID: createdID, Title: opts.Title, Group: opts.Group, Tool: tool,
+				Path: opts.Path, Status: string(session.StatusRunning), RemoteName: remoteName,
+			}
+		}
 		if err != nil {
 			var attachErr remoteAttachFailedError
 			if errors.As(err, &attachErr) {
@@ -15467,7 +15523,7 @@ func (h *Home) createRemoteSessionWithOptions(remoteName string, opts session.Re
 			// tea.Exec (mouse, keyboard mode, resize) runs on failure too.
 			return remoteSessionCreatedMsg{err: fmt.Errorf("on %s: %w", remoteName, err)}
 		}
-		return remoteSessionCreatedMsg{}
+		return remoteSessionCreatedMsg{created: created}
 	})
 }
 

--- a/internal/ui/remote_correctness_test.go
+++ b/internal/ui/remote_correctness_test.go
@@ -79,3 +79,28 @@ func TestRemoteCreate_QueuedIsNoticeNotError(t *testing.T) {
 		t.Fatal("the queued outcome must be a typed error the TUI can tell apart from a failure")
 	}
 }
+
+// A session the remote just confirmed is drawn the moment the attach
+// returns, not at the next fetch (the maintainer saw the row arrive "after
+// some time" when detaching from a freshly created remote session).
+func TestRemoteCreate_ConfirmedRowIsDrawnAtOnce(t *testing.T) {
+	home := newTestHomeWithItems(100, 30, nil)
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{"box": {{ID: "a", Title: "old", Group: "work"}}}
+
+	model, cmd := home.Update(remoteSessionCreatedMsg{created: &session.RemoteSessionInfo{ID: "new", Title: "fresh", Tool: "claude", RemoteName: "box"}})
+	h := model.(*Home)
+
+	got := remoteTitles(h, "box")
+	if len(got) != 2 || got[1] != "fresh" {
+		t.Fatalf("confirmed session must be in the cache at once; titles = %v", got)
+	}
+	h.remoteSessionsMu.RLock()
+	group := h.remoteSessions["box"][1].Group
+	h.remoteSessionsMu.RUnlock()
+	if group != session.DefaultGroupPath {
+		t.Fatalf("an ungrouped session lands in the default group like the remote does; got %q", group)
+	}
+	if cmd == nil {
+		t.Fatal("the create return must still schedule the reconciling fetch")
+	}
+}


### PR DESCRIPTION
## What problem does this solve?
After `n` on a remote row, the TUI creates the session, attaches, and on detach the new row is missing until the next fleet fetch lands. The maintainer: "when I went back I cannot see the name of the launched session; it does come, but after some time." Part of #2156 / #2174.

## Why this change
`remoteCreateAndAttachCmd` hands back the id the remote assigned; the attach-return handler inserts the row into the cache (title, group, tool and path from the dialog, default group when ungrouped, status running) and redraws before scheduling the fetch that reconciles the remote's own title (quick-create names) and status. `insertRemoteSession` replaces by id if the fetch already brought it.

## User impact
The session you just created is on screen the instant you detach, on any remote build; the pushed channel (#2177) then keeps it current.

## Evidence
`internal/ui` passes in the Docker test image, including the new `TestRemoteCreate_ConfirmedRowIsDrawnAtOnce`. Local go test is disallowed on this host.

## AI disclosure
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5-1

## What actually bothered you
My human asked: "I made a new session, it goes to the terminal, and when I went back I cannot see the name of that launched session; it does come but after some time."

## Checklist
- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5-1 intent=yes -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Newly created remote sessions now appear immediately after successful creation.
  * Session details and default grouping are applied before remote state reconciliation.
  * Cached session counts and the home view refresh automatically to reflect the new session.

* **Tests**
  * Added coverage to verify immediate display and subsequent state reconciliation for newly created remote sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->