### PR TITLE
feat(remote): deliver each remote's fetch as it lands, and measure transport latency honestly

### DIFF
--- a/internal/session/issue1103_remote_latency_test.go
+++ b/internal/session/issue1103_remote_latency_test.go
@@ -4,7 +4,9 @@
 // remote in the TUI header, refreshed on the CPU/RAM cadence.
 //
 // This file owns the structural invariants of the measurement primitive:
-//   - SSHRunner.MeasureLatency calls a known cheap noop RPC (`--version`).
+//   - SSHRunner.MeasureLatency times a shell builtin (`true`) over ssh, not
+//     a remote agent-deck invocation, so the figure is transport round trip
+//     without remote process startup.
 //   - It returns a non-negative duration that reflects the round-trip.
 //   - It surfaces remote/network failure as an error so the renderer can
 //     show ` — offline` instead of misleading "0ms".
@@ -20,20 +22,26 @@ import (
 	"time"
 )
 
-// TestIssue1103_MeasureLatency_InvokesVersionAndTimesRoundTrip asserts that
-// MeasureLatency hits the cheapest possible noop on the remote (`--version`)
-// and returns a duration that reflects the stubbed delay. If a future change
-// switches to a heavier command (e.g. `list --json`), this test catches the
-// regression because the header would start ticking on a heavyweight RPC.
-func TestIssue1103_MeasureLatency_InvokesVersionAndTimesRoundTrip(t *testing.T) {
+// TestIssue1103_MeasureLatency_TimesShellBuiltinRoundTrip asserts that
+// MeasureLatency times a raw shell builtin over ssh (`true`) rather than an
+// agent-deck invocation, and returns a duration that reflects the stubbed
+// delay. Running the remote binary (even `--version`) adds its process
+// startup to the figure, which made a 97 ms link read as 110 ms or more; a
+// builtin keeps the header honest about the transport alone.
+func TestIssue1103_MeasureLatency_TimesShellBuiltinRoundTrip(t *testing.T) {
 	const stubDelay = 30 * time.Millisecond
 
-	var calledWith []string
+	var calledWith string
+	agentDeckCalls := 0
 	runner := &SSHRunner{
 		runFn: func(ctx context.Context, args ...string) ([]byte, error) {
-			calledWith = append([]string(nil), args...)
-			time.Sleep(stubDelay)
+			agentDeckCalls++
 			return []byte("agent-deck v1.9.23\n"), nil
+		},
+		remoteExecFn: func(ctx context.Context, remoteCmd string, stdin []byte) ([]byte, error) {
+			calledWith = remoteCmd
+			time.Sleep(stubDelay)
+			return nil, nil
 		},
 	}
 
@@ -42,8 +50,11 @@ func TestIssue1103_MeasureLatency_InvokesVersionAndTimesRoundTrip(t *testing.T) 
 		t.Fatalf("MeasureLatency returned err=%v", err)
 	}
 
-	if len(calledWith) != 1 || calledWith[0] != "--version" {
-		t.Fatalf("MeasureLatency must call `--version` (cheapest noop), got args=%v", calledWith)
+	if calledWith != "true" {
+		t.Fatalf("MeasureLatency must time the shell builtin `true`, got remote command %q", calledWith)
+	}
+	if agentDeckCalls != 0 {
+		t.Fatalf("MeasureLatency must not invoke the remote agent-deck binary; got %d call(s)", agentDeckCalls)
 	}
 
 	if d < stubDelay {
@@ -56,7 +67,7 @@ func TestIssue1103_MeasureLatency_InvokesVersionAndTimesRoundTrip(t *testing.T) 
 // reporting "0ms" (which would falsely indicate a healthy remote).
 func TestIssue1103_MeasureLatency_PropagatesError(t *testing.T) {
 	runner := &SSHRunner{
-		runFn: func(ctx context.Context, args ...string) ([]byte, error) {
+		remoteExecFn: func(ctx context.Context, remoteCmd string, stdin []byte) ([]byte, error) {
 			return nil, errors.New("ssh: connection refused")
 		},
 	}

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -1527,20 +1527,27 @@ type RemoteLatency struct {
 	MeasuredAt time.Time
 }
 
-// MeasureLatency measures the round-trip time of a lightweight noop call
-// to the remote agent-deck binary. Returns the elapsed duration on success.
+// MeasureLatency measures the transport round trip to the remote host and
+// returns the elapsed duration on success.
 //
-// Implementation note: we run `agent-deck --version` because it is the
-// cheapest possible call (no DB read, no tmux probe, no network back to
-// services). The ControlMaster socket is persisted across calls so we
-// measure mostly network RTT after the first hit, which is exactly what
-// the user wants to see in the header per #1103.
+// It times the shell builtin `true` over the same ssh options (and the same
+// ControlMaster socket) every other command uses, so the number is the
+// network round trip plus ssh channel setup and nothing else. It used to run
+// `agent-deck --version`, which also paid for the remote process to start:
+// the header showed ~110 ms on a 97 ms link, and ~215 ms before the
+// persistent channel (#2177) existed. Users read the header figure as "how
+// far away is this host", and only the transport answers that (#1103).
 func (r *SSHRunner) MeasureLatency(ctx context.Context) (time.Duration, error) {
 	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	start := time.Now()
-	if _, err := r.run(timeoutCtx, "--version"); err != nil {
+	if _, err := r.remoteExec(timeoutCtx, latencyProbeCommand, nil); err != nil {
 		return 0, err
 	}
 	return time.Since(start), nil
 }
+
+// latencyProbeCommand is the remote command MeasureLatency times: a shell
+// builtin, so no process is forked on the remote and the timing is pure
+// transport.
+const latencyProbeCommand = "true"

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -637,12 +637,24 @@ type Home struct {
 	remoteSessionsMu   sync.RWMutex
 	lastRemoteFetch    time.Time // When remote sessions were last fetched
 	remotesFetchActive bool      // Prevents overlapping fetches
+	// remoteFetchOutstanding counts the per-remote fetches of the running
+	// round(s) that have not answered yet; remotesFetchActive clears when
+	// the last one lands, so one wedged host cannot hold the others back
+	// but the "refreshing…" trailer still tells the truth for the round.
+	remoteFetchOutstanding int
 	// remoteFetchSeq numbers every fleet fetch as it starts; the handler
-	// applies a result only if no newer fetch has been applied already, so a
-	// slow periodic poll cannot overwrite the refresh a delete, move or
-	// archive just triggered (a stale snapshot would resurrect the row).
+	// applies a remote's result only if no newer fetch has been applied for
+	// THAT remote already, so a slow periodic poll cannot overwrite the
+	// refresh a delete, move or archive just triggered (a stale snapshot
+	// would resurrect the row). Generations are tracked per remote because
+	// each remote's result now arrives on its own: a newer answer from a
+	// fast host must not make a slower host's still-valid answer look stale.
 	remoteFetchSeq     uint64
-	remoteFetchApplied uint64
+	remoteFetchApplied map[string]uint64 // remoteName -> last applied generation
+	// newRemoteFetchRunner builds the runner one per-remote fetch talks to.
+	// nil means a real SSHRunner; tests inject stubs to prove delivery
+	// timing without ssh.
+	newRemoteFetchRunner func(name string, rc session.RemoteConfig) remoteFetchRunner
 	// remoteActionStarted records when each remote action was requested
 	// (keyed by remote, verb and target) so its footer line can report the
 	// time from keypress to the remote's confirmation, the number that
@@ -1453,10 +1465,32 @@ type sendOutputResultMsg struct {
 	err         error
 }
 
-// remoteSessionsFetchedMsg is sent when async remote sessions fetch completes.
+// remoteFetchRoundMsg starts one fleet poll: the config was read and every
+// remote gets its own fetch Cmd. Each Cmd answers with a
+// remoteSessionsFetchedMsg for that remote alone, as soon as that host
+// replies, so a slow or wedged host never delays the others (#2177).
+type remoteFetchRoundMsg struct {
+	gen     uint64
+	fetches []tea.Cmd
+}
+
+// remoteFetchRunner is what one per-remote fetch needs from an SSHRunner.
+type remoteFetchRunner interface {
+	FetchSessions(context.Context) ([]session.RemoteSessionInfo, error)
+	FetchCostSummary(context.Context) (*costs.RemoteCostSummary, error)
+	FetchGroupPaths(context.Context) ([]string, error)
+}
+
+// remoteSessionsFetchedMsg carries one remote's fetch result (or a pushed
+// change shaped like one). Every other configured remote is listed in
+// failed/groupsFailed so the merge keeps their rows untouched.
 type remoteSessionsFetchedMsg struct {
 	// gen is the fetch's sequence number (see Home.remoteFetchSeq).
 	gen uint64
+	// pushed marks a result that did not come from a poll round (a change
+	// the remote pushed over its channel), so it is not counted against the
+	// round's outstanding fetches.
+	pushed bool
 	// configErr is set when the user config could not be read; the handler
 	// then keeps every cached remote instead of treating them as removed.
 	configErr error
@@ -3829,22 +3863,30 @@ func (h *Home) propagateThemeToSessions() {
 	})
 }
 
-// applyRemoteFetch folds one fleet fetch result (or a pushed change shaped
+// applyRemoteFetch folds one remote's fetch result (or a pushed change shaped
 // like one) into the cache, the on-disk snapshot and the rows.
 func (h *Home) applyRemoteFetch(msg remoteSessionsFetchedMsg) (tea.Model, tea.Cmd) {
-	if msg.configErr != nil || (msg.gen != 0 && msg.gen < h.remoteFetchApplied) {
+	if msg.configErr != nil || h.remoteFetchIsStale(msg) {
 		// Config unreadable, or a fetch that started before one already
-		// applied: keep the current tree. Only release the in-flight
-		// guard so the next poll runs.
+		// applied for the same remote: keep the current tree. Only account
+		// for the landed fetch so the round can finish and the next poll
+		// runs.
 		h.remoteSessionsMu.Lock()
-		h.remotesFetchActive = false
+		h.remoteFetchLanded(msg)
 		h.remoteSessionsMu.Unlock()
 		if msg.configErr != nil {
 			h.setError(fmt.Errorf("remote refresh skipped, config could not be read: %v", msg.configErr))
 		}
 		return h, nil
 	}
-	h.remoteFetchApplied = msg.gen
+	if msg.gen != 0 {
+		if h.remoteFetchApplied == nil {
+			h.remoteFetchApplied = make(map[string]uint64)
+		}
+		for name := range msg.sessions {
+			h.remoteFetchApplied[name] = msg.gen
+		}
+	}
 	h.remoteSessionsMu.Lock()
 	// #1170: merge rather than wholesale-replace so a remote that errored
 	// this round keeps its last-good sessions instead of flickering out.
@@ -3875,14 +3917,14 @@ func (h *Home) applyRemoteFetch(msg remoteSessionsFetchedMsg) (tea.Model, tea.Cm
 		}
 	}
 	h.lastRemoteFetch = time.Now()
-	h.remotesFetchActive = false
+	roundDone := h.remoteFetchLanded(msg)
 	h.remoteSessionsMu.Unlock()
 	h.saveRemoteSessionsCache(msg.sessions)
 	// #1101: store remote cost summaries so renderCostLine can fold them
 	// into the displayed totals on the next paint.
 	if msg.costs != nil {
 		h.remoteCostsMu.Lock()
-		h.remoteCosts = msg.costs
+		h.remoteCosts = mergeRemoteCosts(h.remoteCosts, msg)
 		h.remoteCostsMu.Unlock()
 	}
 	// #1112 bug 1: a remote running→waiting transition wouldn't update
@@ -3892,6 +3934,9 @@ func (h *Home) applyRemoteFetch(msg remoteSessionsFetchedMsg) (tea.Model, tea.Cm
 	// Invalidate so the next View() recomputes.
 	h.cachedStatusCounts.valid.Store(false)
 	h.rebuildFlatItems()
+	if !roundDone {
+		return h, nil
+	}
 	h.remoteSessionsMu.Lock()
 	again := h.remoteRefetchWanted
 	h.remoteRefetchWanted = false
@@ -3903,6 +3948,60 @@ func (h *Home) applyRemoteFetch(msg remoteSessionsFetchedMsg) (tea.Model, tea.Cm
 		return h, h.fetchRemoteSessions
 	}
 	return h, nil
+}
+
+// remoteFetchIsStale reports whether a newer fetch has already been applied
+// for any remote this message carries data for. Remotes listed only as
+// failed carry no data, so they never make a message stale.
+func (h *Home) remoteFetchIsStale(msg remoteSessionsFetchedMsg) bool {
+	if msg.gen == 0 {
+		return false
+	}
+	for name := range msg.sessions {
+		if msg.gen < h.remoteFetchApplied[name] {
+			return true
+		}
+	}
+	return false
+}
+
+// remoteFetchLanded accounts for one per-remote result and reports whether
+// that completed the round (no fetch outstanding), clearing the in-flight
+// guard when it did. Pushed changes are not part of any round. Called with
+// remoteSessionsMu held.
+func (h *Home) remoteFetchLanded(msg remoteSessionsFetchedMsg) bool {
+	if msg.pushed {
+		return false
+	}
+	if h.remoteFetchOutstanding > 0 {
+		h.remoteFetchOutstanding--
+	}
+	if h.remoteFetchOutstanding > 0 {
+		return false
+	}
+	h.remotesFetchActive = false
+	return true
+}
+
+// mergeRemoteCosts folds one remote's cost summary into the per-remote map
+// without blanking the other remotes' figures: a remote whose result this
+// message carries either gets its fresh summary or, when its cost fetch
+// failed, contributes zero (as before); remotes still marked failed keep
+// their last-good figure; remotes absent from both lists were deconfigured.
+func mergeRemoteCosts(prev map[string]*costs.RemoteCostSummary, msg remoteSessionsFetchedMsg) map[string]*costs.RemoteCostSummary {
+	merged := make(map[string]*costs.RemoteCostSummary, len(prev)+len(msg.costs))
+	for name, summary := range prev {
+		if _, fetched := msg.sessions[name]; fetched {
+			continue
+		}
+		if msg.failed[name] {
+			merged[name] = summary
+		}
+	}
+	for name, summary := range msg.costs {
+		merged[name] = summary
+	}
+	return merged
 }
 
 // remoteChangedMsg says a remote pushed "changed" over its persistent
@@ -3929,6 +4028,7 @@ func (h *Home) waitRemoteChange() tea.Msg {
 func (h *Home) pushedRemoteFetch(ch session.RemoteChange) remoteSessionsFetchedMsg {
 	msg := remoteSessionsFetchedMsg{
 		gen:          atomic.AddUint64(&h.remoteFetchSeq, 1),
+		pushed:       true,
 		sessions:     map[string][]session.RemoteSessionInfo{ch.Remote: ch.Sessions},
 		failed:       map[string]bool{},
 		groups:       map[string][]string{},
@@ -3950,7 +4050,10 @@ func (h *Home) pushedRemoteFetch(ch session.RemoteChange) remoteSessionsFetchedM
 	return msg
 }
 
-// fetchRemoteSessions fetches sessions from all configured remotes.
+// fetchRemoteSessions starts a fleet poll. It reads the config, sweeps stale
+// ssh sockets and returns one fetch Cmd per remote; the handler batches
+// them, and each answers on its own, so the tree updates host by host as
+// answers arrive instead of after the slowest one (#2177).
 func (h *Home) fetchRemoteSessions() tea.Msg {
 	gen := atomic.AddUint64(&h.remoteFetchSeq, 1)
 	config, err := session.LoadUserConfig()
@@ -3971,104 +4074,109 @@ func (h *Home) fetchRemoteSessions() tea.Msg {
 	// make every remote session vanish until the TUI restarts.
 	session.CleanStaleSSHSockets()
 
-	results := make(map[string][]session.RemoteSessionInfo, len(config.Remotes))
-	// #1101: remote cost summaries piggy-back on the existing remote-fetch
-	// channel so the status-line cost segment doesn't lag behind the session
-	// list. nil-valued entries indicate fetch failures (e.g., older remote
-	// agent-deck without `costs summary --json`); the renderer treats those
-	// as "remote contributes zero" so a single broken remote can't poison
-	// the displayed total.
-	costResults := make(map[string]*costs.RemoteCostSummary, len(config.Remotes))
-	// Remote group lists (group list --json) ride the same fanout so the
-	// move/create dialogs can offer EMPTY remote folders — a folder that
-	// currently holds no sessions is invisible to session-derived buckets
-	// but is still a valid target. Successful fetches land in groupResults;
-	// failures in groupsFailed keep last-good cache entries (same contract
-	// as the sessions map, issue #1170).
-	groupResults := make(map[string][]string, len(config.Remotes))
-	groupsFailed := make(map[string]bool, len(config.Remotes))
-	// #1170: track remotes that errored so the handler keeps their last-good
-	// sessions instead of dropping them.
-	failed := make(map[string]bool, len(config.Remotes))
-	var mu sync.Mutex
-	var wg sync.WaitGroup
+	return remoteFetchRoundMsg{gen: gen, fetches: h.remoteFetchCmds(gen, config.Remotes)}
+}
 
-	// #1170: fetch every remote in parallel, each with its OWN timeout, so a
-	// single slow/offline remote can't starve the others. The previous code
-	// shared one 15s budget across all remotes fetched sequentially, which
-	// made healthy remotes drop out of the result map (and flicker in the
-	// TUI) whenever an earlier remote was slow.
-	for name, rc := range config.Remotes {
-		wg.Add(1)
-		go func(name string, rc session.RemoteConfig) {
-			defer wg.Done()
-			// Honor the per-remote command_timeout_seconds: hosts with large
-			// session fleets legitimately need more than the old flat 15s.
-			ctx, cancel := context.WithTimeout(h.ctx, rc.GetCommandTimeout())
-			defer cancel()
-
-			runner := session.NewSSHRunner(name, rc)
-			sessions, err := runner.FetchSessions(ctx)
-			if err != nil {
-				mu.Lock()
-				failed[name] = true
-				// The group list can't be trusted either — keep last-good.
-				groupsFailed[name] = true
-				mu.Unlock()
-				return
-			}
-			for i := range sessions {
-				sessions[i].RemoteName = name
-			}
-			// The cost summary and the group list are independent of the
-			// session list and of each other, so they run concurrently over
-			// the same ControlMaster connection: one round trip per poll
-			// instead of three in a row (#2167). Each keeps its own bound so
-			// a slow `costs summary` or `group list` on one remote cannot
-			// starve the others, and a failure degrades as before: costs to
-			// "contributes zero", groups to the session-derived fallback in
-			// remoteGroupPaths.
-			var (
-				summary    *costs.RemoteCostSummary
-				costErr    error
-				groupPaths []string
-				groupErr   error
-				side       sync.WaitGroup
-			)
-			side.Add(2)
-			go func() {
-				defer side.Done()
-				costCtx, costCancel := context.WithTimeout(h.ctx, rc.GetCommandTimeout())
-				defer costCancel()
-				summary, costErr = runner.FetchCostSummary(costCtx)
-			}()
-			go func() {
-				defer side.Done()
-				groupCtx, groupCancel := context.WithTimeout(h.ctx, rc.GetCommandTimeout())
-				defer groupCancel()
-				groupPaths, groupErr = runner.FetchGroupPaths(groupCtx)
-			}()
-			side.Wait()
-
-			mu.Lock()
-			results[name] = sessions
-			if costErr == nil && summary != nil {
-				costResults[name] = summary
-			}
-			if groupErr == nil {
-				if groupPaths == nil {
-					groupPaths = []string{}
-				}
-				groupResults[name] = groupPaths
-			} else {
-				groupsFailed[name] = true
-			}
-			mu.Unlock()
-		}(name, rc)
+// remoteFetchCmds builds one Cmd per configured remote for fetch round gen.
+func (h *Home) remoteFetchCmds(gen uint64, remotes map[string]session.RemoteConfig) []tea.Cmd {
+	names := make([]string, 0, len(remotes))
+	for name := range remotes {
+		names = append(names, name)
 	}
-	wg.Wait()
+	cmds := make([]tea.Cmd, 0, len(remotes))
+	for name, rc := range remotes {
+		cmds = append(cmds, func() tea.Msg { return h.fetchOneRemote(gen, name, rc, names) })
+	}
+	return cmds
+}
 
-	return remoteSessionsFetchedMsg{gen: gen, sessions: results, costs: costResults, groups: groupResults, groupsFailed: groupsFailed, failed: failed}
+// fetchOneRemote fetches one remote's sessions, cost summary and group list
+// and shapes them as a result for that remote alone: every other configured
+// remote is marked failed so the merge keeps its rows, and a remote missing
+// from the config altogether is absent from both lists and so drops out.
+func (h *Home) fetchOneRemote(gen uint64, name string, rc session.RemoteConfig, configured []string) remoteSessionsFetchedMsg {
+	msg := remoteSessionsFetchedMsg{
+		gen:          gen,
+		sessions:     make(map[string][]session.RemoteSessionInfo, 1),
+		costs:        make(map[string]*costs.RemoteCostSummary, 1),
+		groups:       make(map[string][]string, 1),
+		groupsFailed: make(map[string]bool, len(configured)),
+		failed:       make(map[string]bool, len(configured)),
+	}
+	for _, other := range configured {
+		if other != name {
+			msg.failed[other] = true
+			msg.groupsFailed[other] = true
+		}
+	}
+
+	// Honor the per-remote command_timeout_seconds: hosts with large
+	// session fleets legitimately need more than the old flat 15s. Each
+	// remote runs under its own bound (#1170) and answers on its own
+	// (#2177), so one slow or offline host starves nobody.
+	ctx, cancel := context.WithTimeout(h.ctx, rc.GetCommandTimeout())
+	defer cancel()
+
+	var runner remoteFetchRunner
+	if h.newRemoteFetchRunner != nil {
+		runner = h.newRemoteFetchRunner(name, rc)
+	} else {
+		runner = session.NewSSHRunner(name, rc)
+	}
+	sessions, err := runner.FetchSessions(ctx)
+	if err != nil {
+		// #1170: the handler keeps this remote's last-good sessions; the
+		// group list can't be trusted either, so keep that too.
+		msg.failed[name] = true
+		msg.groupsFailed[name] = true
+		return msg
+	}
+	for i := range sessions {
+		sessions[i].RemoteName = name
+	}
+	// The cost summary and the group list are independent of the session
+	// list and of each other, so they run concurrently over the same
+	// ControlMaster connection: one round trip per poll instead of three in
+	// a row (#2167). Each keeps its own bound, and a failure degrades as
+	// before: costs to "contributes zero", groups to the session-derived
+	// fallback in remoteGroupPaths.
+	var (
+		summary    *costs.RemoteCostSummary
+		costErr    error
+		groupPaths []string
+		groupErr   error
+		side       sync.WaitGroup
+	)
+	side.Add(2)
+	go func() {
+		defer side.Done()
+		costCtx, costCancel := context.WithTimeout(h.ctx, rc.GetCommandTimeout())
+		defer costCancel()
+		summary, costErr = runner.FetchCostSummary(costCtx)
+	}()
+	go func() {
+		defer side.Done()
+		groupCtx, groupCancel := context.WithTimeout(h.ctx, rc.GetCommandTimeout())
+		defer groupCancel()
+		groupPaths, groupErr = runner.FetchGroupPaths(groupCtx)
+	}()
+	side.Wait()
+
+	msg.sessions[name] = sessions
+	// #1101: a nil summary (older remote without `costs summary --json`)
+	// is left out so the renderer treats the remote as contributing zero.
+	if costErr == nil && summary != nil {
+		msg.costs[name] = summary
+	}
+	if groupErr == nil {
+		if groupPaths == nil {
+			groupPaths = []string{}
+		}
+		msg.groups[name] = groupPaths
+	} else {
+		msg.groupsFailed[name] = true
+	}
+	return msg
 }
 
 // mergeRemoteSessions reconciles a freshly fetched remote-session map against
@@ -7047,6 +7155,16 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			h.updateInfo = msg.info
 		}
 		return h, nil
+
+	case remoteFetchRoundMsg:
+		// Fan out: each remote answers with its own remoteSessionsFetchedMsg.
+		// Outstanding counts add up so an overlapping round (ctrl+r during
+		// a poll) keeps the guard until every fetch of both has landed.
+		h.remoteSessionsMu.Lock()
+		h.remotesFetchActive = true
+		h.remoteFetchOutstanding += len(msg.fetches)
+		h.remoteSessionsMu.Unlock()
+		return h, tea.Batch(msg.fetches...)
 
 	case remoteSessionsFetchedMsg:
 		return h.applyRemoteFetch(msg)

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1489,8 +1489,13 @@ type remoteSessionsFetchedMsg struct {
 	gen uint64
 	// pushed marks a result that did not come from a poll round (a change
 	// the remote pushed over its channel), so it is not counted against the
-	// round's outstanding fetches.
+	// round's outstanding fetches and never touches the in-flight guard.
 	pushed bool
+	// inRound marks one of the per-remote results a remoteFetchRoundMsg
+	// fanned out; only those count down remoteFetchOutstanding. A message
+	// from outside a round (config unreadable, no remotes configured) must
+	// not steal a slot from a round still in flight.
+	inRound bool
 	// configErr is set when the user config could not be read; the handler
 	// then keeps every cached remote instead of treating them as removed.
 	configErr error
@@ -3879,6 +3884,11 @@ func (h *Home) applyRemoteFetch(msg remoteSessionsFetchedMsg) (tea.Model, tea.Cm
 		}
 		return h, nil
 	}
+	h.remoteSessionsMu.Lock()
+	prevSessions := h.remoteSessions
+	// #1170: merge rather than wholesale-replace so a remote that errored
+	// this round keeps its last-good sessions instead of flickering out.
+	h.remoteSessions = mergeRemoteSessions(h.remoteSessions, msg.sessions, msg.failed)
 	if msg.gen != 0 {
 		if h.remoteFetchApplied == nil {
 			h.remoteFetchApplied = make(map[string]uint64)
@@ -3886,11 +3896,14 @@ func (h *Home) applyRemoteFetch(msg remoteSessionsFetchedMsg) (tea.Model, tea.Cm
 		for name := range msg.sessions {
 			h.remoteFetchApplied[name] = msg.gen
 		}
+		// A remote this message deconfigured (absent from both lists) must
+		// not come back when a slower result from an older round lands.
+		for name := range prevSessions {
+			if _, fetched := msg.sessions[name]; !fetched && !msg.failed[name] {
+				h.remoteFetchApplied[name] = msg.gen
+			}
+		}
 	}
-	h.remoteSessionsMu.Lock()
-	// #1170: merge rather than wholesale-replace so a remote that errored
-	// this round keeps its last-good sessions instead of flickering out.
-	h.remoteSessions = mergeRemoteSessions(h.remoteSessions, msg.sessions, msg.failed)
 	// Remote group lists: replace wholesale for remotes that reported a
 	// fresh list; failed remotes keep their last-good cached paths so the
 	// move dialog doesn't lose empty-group targets on a transient SSH
@@ -3965,15 +3978,17 @@ func (h *Home) remoteFetchIsStale(msg remoteSessionsFetchedMsg) bool {
 	return false
 }
 
-// remoteFetchLanded accounts for one per-remote result and reports whether
-// that completed the round (no fetch outstanding), clearing the in-flight
-// guard when it did. Pushed changes are not part of any round. Called with
-// remoteSessionsMu held.
+// remoteFetchLanded accounts for one fetch result and reports whether that
+// left no fetch outstanding, clearing the in-flight guard when it did. Only
+// a round's own per-remote results count down the outstanding total; a
+// message from outside a round (config unreadable, no remotes) releases the
+// guard only when no round is in flight. Pushed changes are not part of any
+// round and never touch the guard. Called with remoteSessionsMu held.
 func (h *Home) remoteFetchLanded(msg remoteSessionsFetchedMsg) bool {
 	if msg.pushed {
 		return false
 	}
-	if h.remoteFetchOutstanding > 0 {
+	if msg.inRound && h.remoteFetchOutstanding > 0 {
 		h.remoteFetchOutstanding--
 	}
 	if h.remoteFetchOutstanding > 0 {
@@ -4097,6 +4112,7 @@ func (h *Home) remoteFetchCmds(gen uint64, remotes map[string]session.RemoteConf
 func (h *Home) fetchOneRemote(gen uint64, name string, rc session.RemoteConfig, configured []string) remoteSessionsFetchedMsg {
 	msg := remoteSessionsFetchedMsg{
 		gen:          gen,
+		inRound:      true,
 		sessions:     make(map[string][]session.RemoteSessionInfo, 1),
 		costs:        make(map[string]*costs.RemoteCostSummary, 1),
 		groups:       make(map[string][]string, 1),

--- a/internal/ui/remote_per_host_delivery_test.go
+++ b/internal/ui/remote_per_host_delivery_test.go
@@ -7,6 +7,7 @@ package ui
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -208,6 +209,7 @@ func TestRemoteFetch_ActiveClearsWhenLastResultLands(t *testing.T) {
 	result := func(name string, other string) remoteSessionsFetchedMsg {
 		return remoteSessionsFetchedMsg{
 			gen:      1,
+			inRound:  true,
 			sessions: map[string][]session.RemoteSessionInfo{name: {}},
 			failed:   map[string]bool{other: true},
 		}
@@ -217,9 +219,17 @@ func TestRemoteFetch_ActiveClearsWhenLastResultLands(t *testing.T) {
 	if !h.remotesFetchActive {
 		t.Fatal("one of two results must leave the round in flight")
 	}
+	// A config error from a refetch started outside this round must not
+	// take the slow remote's slot: the round is still in flight.
+	model, _ = h.Update(remoteSessionsFetchedMsg{gen: 2, configErr: errors.New("toml: bad key")})
+	h = model.(*Home)
+	if !h.remotesFetchActive {
+		t.Fatal("a message from outside the round must not end it while a fetch is outstanding")
+	}
 	// A pushed change in between is not part of the round.
 	pushed := result("a", "b")
 	pushed.pushed = true
+	pushed.inRound = false
 	model, _ = h.Update(pushed)
 	h = model.(*Home)
 	if !h.remotesFetchActive {
@@ -229,5 +239,38 @@ func TestRemoteFetch_ActiveClearsWhenLastResultLands(t *testing.T) {
 	h = model.(*Home)
 	if h.remotesFetchActive {
 		t.Fatal("the second of two results must end the round")
+	}
+}
+
+func TestRemoteFetch_DeconfiguredRemoteDoesNotReturnFromOlderRound(t *testing.T) {
+	home := newTestHomeWithItems(100, 30, nil)
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"gone": {{ID: "g-1", Title: "gone-cached", RemoteName: "gone"}},
+	}
+	// Round 6 was built from a config that no longer lists "gone": its
+	// only result names "a" and marks nobody else failed, so "gone" drops.
+	model, _ := home.Update(remoteSessionsFetchedMsg{
+		gen:      6,
+		inRound:  true,
+		sessions: map[string][]session.RemoteSessionInfo{"a": {{ID: "a-1", Title: "a-6"}}},
+		failed:   map[string]bool{},
+	})
+	h := model.(*Home)
+	if got := remoteTitles(h, "gone"); len(got) != 0 {
+		t.Fatalf("a remote absent from the config must drop; got %v", got)
+	}
+	// A slow result for "gone" from the older round 5 lands afterwards.
+	model, _ = h.Update(remoteSessionsFetchedMsg{
+		gen:      5,
+		inRound:  true,
+		sessions: map[string][]session.RemoteSessionInfo{"gone": {{ID: "g-2", Title: "gone-5"}}},
+		failed:   map[string]bool{"a": true},
+	})
+	h = model.(*Home)
+	if got := remoteTitles(h, "gone"); len(got) != 0 {
+		t.Fatalf("an older round's result must not resurrect a deconfigured remote; got %v", got)
+	}
+	if got := remoteTitles(h, "a"); len(got) != 1 || got[0] != "a-6" {
+		t.Fatalf("the newer round's rows must stay; got %v", got)
 	}
 }

--- a/internal/ui/remote_per_host_delivery_test.go
+++ b/internal/ui/remote_per_host_delivery_test.go
@@ -1,0 +1,233 @@
+// Per-remote delivery of fleet polls (#2177 follow-up): each remote's
+// answer lands on its own, so a slow or wedged host cannot hold back the
+// others; the stale-result guard, the in-flight guard and the cost merge
+// all work per remote.
+
+package ui
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/costs"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// stubFetchRunner answers FetchSessions once release is closed (or at once
+// when release is nil).
+type stubFetchRunner struct {
+	name     string
+	sessions []session.RemoteSessionInfo
+	release  chan struct{}
+}
+
+func (s stubFetchRunner) FetchSessions(ctx context.Context) ([]session.RemoteSessionInfo, error) {
+	if s.release != nil {
+		select {
+		case <-s.release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return append([]session.RemoteSessionInfo(nil), s.sessions...), nil
+}
+
+func (s stubFetchRunner) FetchCostSummary(context.Context) (*costs.RemoteCostSummary, error) {
+	return &costs.RemoteCostSummary{}, nil
+}
+
+func (s stubFetchRunner) FetchGroupPaths(context.Context) ([]string, error) {
+	return []string{s.name}, nil
+}
+
+func runFetchCmds(cmds []tea.Cmd) <-chan remoteSessionsFetchedMsg {
+	out := make(chan remoteSessionsFetchedMsg, len(cmds))
+	for _, cmd := range cmds {
+		go func(cmd tea.Cmd) { out <- cmd().(remoteSessionsFetchedMsg) }(cmd)
+	}
+	return out
+}
+
+func TestRemoteFetch_SlowRemoteDoesNotDelayFastOne(t *testing.T) {
+	home := newTestHomeWithItems(100, 30, nil)
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"slow": {{ID: "s-old", Title: "slow-cached", RemoteName: "slow"}},
+	}
+	release := make(chan struct{})
+	home.newRemoteFetchRunner = func(name string, rc session.RemoteConfig) remoteFetchRunner {
+		if name == "slow" {
+			return stubFetchRunner{name: name, release: release, sessions: []session.RemoteSessionInfo{{ID: "s-new", Title: "slow-live"}}}
+		}
+		return stubFetchRunner{name: name, sessions: []session.RemoteSessionInfo{{ID: "f1", Title: "fast-live"}}}
+	}
+	remotes := map[string]session.RemoteConfig{"fast": {Host: "fast@x"}, "slow": {Host: "slow@x"}}
+
+	cmds := home.remoteFetchCmds(3, remotes)
+	model, _ := home.Update(remoteFetchRoundMsg{gen: 3, fetches: cmds})
+	h := model.(*Home)
+	if !h.remotesFetchActive {
+		t.Fatal("starting a round must raise the in-flight guard")
+	}
+
+	results := runFetchCmds(cmds)
+	var first remoteSessionsFetchedMsg
+	select {
+	case first = <-results:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the fast remote's result must arrive while the slow remote is still blocked")
+	}
+	if _, ok := first.sessions["fast"]; !ok {
+		t.Fatalf("first result must be the fast remote's; got sessions=%v failed=%v", first.sessions, first.failed)
+	}
+	if !first.failed["slow"] {
+		t.Fatal("a per-remote result must mark the other remotes failed so the merge keeps their rows")
+	}
+
+	model, _ = h.Update(first)
+	h = model.(*Home)
+	if got := remoteTitles(h, "fast"); len(got) != 1 || got[0] != "fast-live" {
+		t.Fatalf("fast remote must render before the slow one answers; got %v", got)
+	}
+	if got := remoteTitles(h, "slow"); len(got) != 1 || got[0] != "slow-cached" {
+		t.Fatalf("slow remote must keep its cached rows meanwhile; got %v", got)
+	}
+	if !h.remotesFetchActive {
+		t.Fatal("the round is not over while the slow remote is outstanding")
+	}
+	if got := h.remoteGroups["fast"]; len(got) != 1 || got[0] != "fast" {
+		t.Fatalf("fast remote's group list must land with its sessions; got %v", got)
+	}
+
+	close(release)
+	var second remoteSessionsFetchedMsg
+	select {
+	case second = <-results:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the slow remote's result must arrive once released")
+	}
+	model, _ = h.Update(second)
+	h = model.(*Home)
+	if got := remoteTitles(h, "slow"); len(got) != 1 || got[0] != "slow-live" {
+		t.Fatalf("slow remote must update when it finally answers; got %v", got)
+	}
+	if got := remoteTitles(h, "fast"); len(got) != 1 || got[0] != "fast-live" {
+		t.Fatalf("the slow remote's result must not disturb the fast remote's rows; got %v", got)
+	}
+	if h.remotesFetchActive {
+		t.Fatal("the last result of the round must release the in-flight guard")
+	}
+}
+
+func TestRemoteFetch_StaleGuardIsPerRemote(t *testing.T) {
+	home := newTestHomeWithItems(100, 30, nil)
+	perRemote := func(gen uint64, name, title string, others ...string) remoteSessionsFetchedMsg {
+		msg := remoteSessionsFetchedMsg{
+			gen:      gen,
+			sessions: map[string][]session.RemoteSessionInfo{name: {{ID: name + "-1", Title: title}}},
+			failed:   map[string]bool{},
+		}
+		for _, o := range others {
+			msg.failed[o] = true
+		}
+		return msg
+	}
+
+	// A newer round's fast answer lands first...
+	model, _ := home.Update(perRemote(6, "fast", "fast-6", "slow"))
+	h := model.(*Home)
+	// ...then the older round's slow answer: still the newest data for
+	// "slow", so it must apply rather than be dropped as stale.
+	model, _ = h.Update(perRemote(5, "slow", "slow-5", "fast"))
+	h = model.(*Home)
+	if got := remoteTitles(h, "slow"); len(got) != 1 || got[0] != "slow-5" {
+		t.Fatalf("an older-round result for a remote with nothing newer applied must land; got %v", got)
+	}
+	// An older answer for "fast" itself is stale and must be ignored.
+	model, _ = h.Update(perRemote(5, "fast", "fast-5", "slow"))
+	h = model.(*Home)
+	if got := remoteTitles(h, "fast"); len(got) != 1 || got[0] != "fast-6" {
+		t.Fatalf("a result older than the last applied one for the same remote must be ignored; got %v", got)
+	}
+}
+
+func TestRemoteFetch_CostsMergePerRemote(t *testing.T) {
+	home := newTestHomeWithItems(100, 30, nil)
+	home.remoteCosts = map[string]*costs.RemoteCostSummary{
+		"a": {CostTodayMicrodollars: 1},
+		"b": {CostTodayMicrodollars: 2},
+	}
+	rows := func(name string) map[string][]session.RemoteSessionInfo {
+		return map[string][]session.RemoteSessionInfo{name: {{ID: name + "-1", Title: name}}}
+	}
+
+	// a answers with a fresh summary: b's figure must survive.
+	model, _ := home.Update(remoteSessionsFetchedMsg{
+		sessions: rows("a"),
+		costs:    map[string]*costs.RemoteCostSummary{"a": {CostTodayMicrodollars: 10}},
+		failed:   map[string]bool{"b": true},
+	})
+	h := model.(*Home)
+	if h.remoteCosts["a"].CostTodayMicrodollars != 10 || h.remoteCosts["b"] == nil || h.remoteCosts["b"].CostTodayMicrodollars != 2 {
+		t.Fatalf("a per-remote cost update must not blank other remotes; got %+v", h.remoteCosts)
+	}
+
+	// a answers but its cost fetch failed: a contributes zero, b untouched.
+	model, _ = h.Update(remoteSessionsFetchedMsg{
+		sessions: rows("a"),
+		costs:    map[string]*costs.RemoteCostSummary{},
+		failed:   map[string]bool{"b": true},
+	})
+	h = model.(*Home)
+	if _, ok := h.remoteCosts["a"]; ok {
+		t.Fatalf("a remote whose cost fetch failed must contribute zero; got %+v", h.remoteCosts)
+	}
+	if h.remoteCosts["b"] == nil {
+		t.Fatalf("a remote still marked failed must keep its last-good figure; got %+v", h.remoteCosts)
+	}
+
+	// b is no longer configured (absent from both lists): its figure goes.
+	model, _ = h.Update(remoteSessionsFetchedMsg{
+		sessions: rows("a"),
+		costs:    map[string]*costs.RemoteCostSummary{"a": {CostTodayMicrodollars: 11}},
+		failed:   map[string]bool{},
+	})
+	h = model.(*Home)
+	if _, ok := h.remoteCosts["b"]; ok {
+		t.Fatalf("a deconfigured remote must drop out of the cost map; got %+v", h.remoteCosts)
+	}
+}
+
+func TestRemoteFetch_ActiveClearsWhenLastResultLands(t *testing.T) {
+	home := newTestHomeWithItems(100, 30, nil)
+	noop := func() tea.Msg { return nil }
+	model, _ := home.Update(remoteFetchRoundMsg{gen: 1, fetches: []tea.Cmd{noop, noop}})
+	h := model.(*Home)
+	result := func(name string, other string) remoteSessionsFetchedMsg {
+		return remoteSessionsFetchedMsg{
+			gen:      1,
+			sessions: map[string][]session.RemoteSessionInfo{name: {}},
+			failed:   map[string]bool{other: true},
+		}
+	}
+	model, _ = h.Update(result("a", "b"))
+	h = model.(*Home)
+	if !h.remotesFetchActive {
+		t.Fatal("one of two results must leave the round in flight")
+	}
+	// A pushed change in between is not part of the round.
+	pushed := result("a", "b")
+	pushed.pushed = true
+	model, _ = h.Update(pushed)
+	h = model.(*Home)
+	if !h.remotesFetchActive {
+		t.Fatal("a pushed change must not count as a round result")
+	}
+	model, _ = h.Update(result("b", "a"))
+	h = model.(*Home)
+	if h.remotesFetchActive {
+		t.Fatal("the second of two results must end the round")
+	}
+}


### PR DESCRIPTION
## What problem does this solve?
One slow or wedged remote delayed every remote's refresh, because the fleet fetch returned a single message after all hosts answered; and the header's latency number timed a remote process start, not the network. Items 4 and 5 of the remote latency plan (#2174, #2170 item 17/18).

## Why this change
`fetchRemoteSessions` now starts one fetch per remote and each yields its own `remoteSessionsFetchedMsg`; `applyRemoteFetch` merges per remote (sessions, groups, costs keyed by that remote; others kept), with a per-remote applied generation so a slower host's result is never dropped because another host's newer one landed, and a deconfigured remote cannot be resurrected by an older round (reviewer fix). `remotesFetchActive` clears when the last outstanding result of a round lands. `MeasureLatency` times a cheap remote builtin over the same ControlMaster so the number is the round trip. Pushed changes, ctrl+r, mutation refetches and the existing tests keep working; new tests prove a slow remote does not delay a fast one and cover the outstanding-count guard.

## User impact
A fast remote refreshes on its own schedule even when another is slow; the latency shown next to a remote header matches what the link costs.

## Evidence
Implemented and adversarially reviewed by separate agents in a workflow; the reviewer found and fixed two guard bugs (5a73279c). `internal/ui` and the remote `internal/session` tests pass in the Docker test image. Local go test is disallowed on this host.

## AI disclosure
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5-1

## What actually bothered you
My human asked: "such that it stays quick like realtime, seamless without any lag".

## Checklist
- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5-1 intent=yes -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SSH latency checks now use a lightweight remote connectivity probe, improving measurement accuracy without invoking the agent binary.
  * Remote status updates now appear independently, so a slow or unavailable host does not delay updates from healthy hosts.
  * Failed remote fetches preserve the last known session and cost information instead of clearing valid data.
  * Stale results from removed or reconfigured remotes are prevented from reappearing.
  * Refresh indicators now remain active until all remote results for the current update are received.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->