### PR TITLE
perf(remote): the agent's change probe lists in-process instead of spawning the CLI

### DIFF
--- a/cmd/agent-deck/group_cmd.go
+++ b/cmd/agent-deck/group_cmd.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -111,6 +112,106 @@ func printGroupHelp() {
 	fmt.Println("  agent-deck group reorder mobile --position 0")
 }
 
+// buildGroupListJSON is the body of `group list --json`: the group tree with
+// recursive session and status counts, as the indented object the CLI
+// prints, trailing newline included. handleGroupList prints it and the
+// remote agent's change probe (#2177) pushes it, so both sides of the
+// channel see the same bytes. Callers warm the status caches first
+// (session.RefreshInstancesForCLIStatus).
+func buildGroupListJSON(groupTree *session.GroupTree) ([]byte, error) {
+	// Build JSON output structure
+	type groupStatusJSON struct {
+		Running int `json:"running"`
+		Waiting int `json:"waiting"`
+		Idle    int `json:"idle"`
+		Error   int `json:"error"`
+		Stopped int `json:"stopped"`
+	}
+
+	type groupJSON struct {
+		Name         string           `json:"name"`
+		Path         string           `json:"path"`
+		SessionCount int              `json:"session_count"`
+		Status       *groupStatusJSON `json:"status,omitempty"`
+		Children     []groupJSON      `json:"children,omitempty"`
+	}
+
+	// Build hierarchical structure (with recursive session counts - Issue #48)
+	buildGroupJSON := func(g *session.Group) groupJSON {
+		// Count status recursively for this group and all subgroups
+		status := groupStatusJSON{}
+		for path, subGroup := range groupTree.Groups {
+			if path == g.Path || strings.HasPrefix(path, g.Path+"/") {
+				for _, sess := range subGroup.Sessions {
+					_ = sess.UpdateStatus() // Refresh status
+					switch sess.Status {
+					case session.StatusRunning:
+						status.Running++
+					case session.StatusWaiting:
+						status.Waiting++
+					case session.StatusIdle:
+						status.Idle++
+					case session.StatusError:
+						status.Error++
+					case session.StatusStopped:
+						status.Stopped++
+					}
+				}
+			}
+		}
+
+		// Use recursive session count
+		sessCount := groupTree.SessionCountForGroup(g.Path)
+		gj := groupJSON{
+			Name:         g.Name,
+			Path:         g.Path,
+			SessionCount: sessCount,
+		}
+		if sessCount > 0 {
+			gj.Status = &status
+		}
+		return gj
+	}
+
+	// Build the tree recursively: each group carries its direct children
+	// (one level deeper, same prefix), which carry theirs, so a group at
+	// any depth appears, including empty ones the session list cannot
+	// reveal. GroupList is already ordered (a parent before its children,
+	// siblings by their persisted Order), so sibling order is preserved.
+	var buildSubtree func(g *session.Group) groupJSON
+	buildSubtree = func(g *session.Group) groupJSON {
+		gj := buildGroupJSON(g)
+		childLevel := session.GetGroupLevel(g.Path) + 1
+		for _, child := range groupTree.GroupList {
+			if strings.HasPrefix(child.Path, g.Path+"/") && session.GetGroupLevel(child.Path) == childLevel {
+				gj.Children = append(gj.Children, buildSubtree(child))
+			}
+		}
+		return gj
+	}
+
+	groupsJSON := []groupJSON{}
+	for _, g := range groupTree.GroupList {
+		if session.GetGroupLevel(g.Path) == 0 {
+			groupsJSON = append(groupsJSON, buildSubtree(g))
+		}
+	}
+
+	// Count totals
+	totalGroups := len(groupTree.Groups)
+	totalSessions := groupTree.SessionCount()
+
+	output, err := json.MarshalIndent(map[string]interface{}{
+		"groups":         groupsJSON,
+		"total_groups":   totalGroups,
+		"total_sessions": totalSessions,
+	}, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(output, '\n'), nil
+}
+
 // handleGroupList lists all groups with session counts and status
 func handleGroupList(profile string, args []string) {
 	fs := flag.NewFlagSet("group list", flag.ExitOnError)
@@ -156,93 +257,14 @@ func handleGroupList(profile string, args []string) {
 	groupTree := session.NewGroupTreeWithGroups(instances, groups)
 
 	if *jsonOutput {
-		// Build JSON output structure
-		type groupStatusJSON struct {
-			Running int `json:"running"`
-			Waiting int `json:"waiting"`
-			Idle    int `json:"idle"`
-			Error   int `json:"error"`
-			Stopped int `json:"stopped"`
+		output, err := buildGroupListJSON(groupTree)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to format JSON: %v\n", err)
+			os.Exit(1)
 		}
-
-		type groupJSON struct {
-			Name         string           `json:"name"`
-			Path         string           `json:"path"`
-			SessionCount int              `json:"session_count"`
-			Status       *groupStatusJSON `json:"status,omitempty"`
-			Children     []groupJSON      `json:"children,omitempty"`
+		if !*quiet && !*quietShort {
+			fmt.Print(string(output))
 		}
-
-		// Build hierarchical structure (with recursive session counts - Issue #48)
-		buildGroupJSON := func(g *session.Group) groupJSON {
-			// Count status recursively for this group and all subgroups
-			status := groupStatusJSON{}
-			for path, subGroup := range groupTree.Groups {
-				if path == g.Path || strings.HasPrefix(path, g.Path+"/") {
-					for _, sess := range subGroup.Sessions {
-						_ = sess.UpdateStatus() // Refresh status
-						switch sess.Status {
-						case session.StatusRunning:
-							status.Running++
-						case session.StatusWaiting:
-							status.Waiting++
-						case session.StatusIdle:
-							status.Idle++
-						case session.StatusError:
-							status.Error++
-						case session.StatusStopped:
-							status.Stopped++
-						}
-					}
-				}
-			}
-
-			// Use recursive session count
-			sessCount := groupTree.SessionCountForGroup(g.Path)
-			gj := groupJSON{
-				Name:         g.Name,
-				Path:         g.Path,
-				SessionCount: sessCount,
-			}
-			if sessCount > 0 {
-				gj.Status = &status
-			}
-			return gj
-		}
-
-		// Build the tree recursively: each group carries its direct children
-		// (one level deeper, same prefix), which carry theirs, so a group at
-		// any depth appears, including empty ones the session list cannot
-		// reveal. GroupList is already ordered (a parent before its children,
-		// siblings by their persisted Order), so sibling order is preserved.
-		var buildSubtree func(g *session.Group) groupJSON
-		buildSubtree = func(g *session.Group) groupJSON {
-			gj := buildGroupJSON(g)
-			childLevel := session.GetGroupLevel(g.Path) + 1
-			for _, child := range groupTree.GroupList {
-				if strings.HasPrefix(child.Path, g.Path+"/") && session.GetGroupLevel(child.Path) == childLevel {
-					gj.Children = append(gj.Children, buildSubtree(child))
-				}
-			}
-			return gj
-		}
-
-		groupsJSON := []groupJSON{}
-		for _, g := range groupTree.GroupList {
-			if session.GetGroupLevel(g.Path) == 0 {
-				groupsJSON = append(groupsJSON, buildSubtree(g))
-			}
-		}
-
-		// Count totals
-		totalGroups := len(groupTree.Groups)
-		totalSessions := groupTree.SessionCount()
-
-		out.Print("", map[string]interface{}{
-			"groups":         groupsJSON,
-			"total_groups":   totalGroups,
-			"total_sessions": totalSessions,
-		})
 		return
 	}
 

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -2348,83 +2348,15 @@ func handleList(profile string, args []string) {
 	}
 
 	if *jsonOutput {
-		// JSON output for scripting
-		type sessionJSON struct {
-			ID                string    `json:"id"`
-			ParentSessionID   string    `json:"parent_session_id,omitempty"`
-			ParentProjectPath string    `json:"parent_project_path,omitempty"`
-			Title             string    `json:"title"`
-			Path              string    `json:"path"`
-			Group             string    `json:"group"`
-			Tool              string    `json:"tool"`
-			Account           string    `json:"account"`
-			Command           string    `json:"command,omitempty"`
-			ModelID           string    `json:"model_id,omitempty"`
-			Model             string    `json:"model,omitempty"`
-			ModelVersion      string    `json:"model_version,omitempty"`
-			Status            string    `json:"status"`
-			Substate          string    `json:"substate,omitempty"` // Honest Status v2: additive refinement
-			TmuxSession       string    `json:"tmux_session,omitempty"`
-			Profile           string    `json:"profile"`
-			CreatedAt         time.Time `json:"created_at"`
-			SSHHost           string    `json:"ssh_host,omitempty"`
-			SSHRemotePath     string    `json:"ssh_remote_path,omitempty"`
-			Channels          []string  `json:"channels,omitempty"`
-			ExtraArgs         []string  `json:"extra_args,omitempty"`
-			Color             string    `json:"color,omitempty"` // issue #391
-			Archived          bool      `json:"archived"`
-			ArchivedAt        time.Time `json:"archived_at,omitempty"`
-			// LastActivityAt lets a remote caller (session.RemoteSessionInfo)
-			// apply the local recency filter (session.TimeFilterMode) to this
-			// session, the same way it applies to a local one.
-			LastActivityAt string `json:"last_activity_at,omitempty"`
-		}
 		// Warm tmux pane-title cache + load hook statuses so the CLI
 		// reports the same Status the TUI and /api/menu do (issue #610).
 		session.RefreshInstancesForCLIStatus(instances)
-		sessions := make([]sessionJSON, len(instances))
-		for i, inst := range instances {
-			_ = inst.UpdateStatus()
-			parentProjectPath := listParentProjectPath(inst, instances)
-			sj := sessionJSON{
-				ID:                inst.ID,
-				ParentSessionID:   inst.ParentSessionID,
-				ParentProjectPath: parentProjectPath,
-				Title:             inst.Title,
-				Path:              inst.ProjectPath,
-				Group:             inst.GroupPath,
-				Tool:              inst.Tool,
-				Account:           inst.Account,
-				Command:           inst.Command,
-				Status:            StatusString(inst.Status),
-				Substate:          string(inst.Substate()),
-				Profile:           storage.Profile(),
-				CreatedAt:         inst.CreatedAt,
-				SSHHost:           inst.SSHHost,
-				SSHRemotePath:     inst.SSHRemotePath,
-				Channels:          inst.Channels,
-				ExtraArgs:         inst.ExtraArgs,
-				Color:             inst.Color,
-				Archived:          inst.IsArchived(),
-				ArchivedAt:        inst.ArchivedAt,
-				LastActivityAt:    inst.DisplayLastActivityTime().Format(time.RFC3339Nano),
-			}
-			if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil {
-				sj.TmuxSession = tmuxSess.Name
-			}
-			if modelInfo := inst.LaunchModelInfo(); modelInfo.ModelID != "" {
-				sj.ModelID = modelInfo.ModelID
-				sj.Model = modelInfo.ModelID
-				sj.ModelVersion = modelInfo.Version
-			}
-			sessions[i] = sj
-		}
-		output, err := json.MarshalIndent(sessions, "", "  ")
+		output, err := buildListJSON(storage.Profile(), instances)
 		if err != nil {
 			fmt.Printf("Error: failed to format JSON output: %v\n", err)
 			os.Exit(1)
 		}
-		fmt.Println(string(output))
+		fmt.Print(string(output))
 		return
 	}
 
@@ -2447,6 +2379,87 @@ func handleList(profile string, args []string) {
 
 	// Show update notice if available
 	printUpdateNotice()
+}
+
+// buildListJSON is the body of `list --json`: every session with its status
+// refreshed, as the indented array the CLI prints, trailing newline included.
+// handleList prints it and the remote agent's change probe (#2177) pushes it,
+// so a listing that arrives by push is byte-identical to one that was
+// fetched. Callers warm the status caches first
+// (session.RefreshInstancesForCLIStatus); an empty profile yields "[]".
+func buildListJSON(profileName string, instances []*session.Instance) ([]byte, error) {
+	type sessionJSON struct {
+		ID                string    `json:"id"`
+		ParentSessionID   string    `json:"parent_session_id,omitempty"`
+		ParentProjectPath string    `json:"parent_project_path,omitempty"`
+		Title             string    `json:"title"`
+		Path              string    `json:"path"`
+		Group             string    `json:"group"`
+		Tool              string    `json:"tool"`
+		Account           string    `json:"account"`
+		Command           string    `json:"command,omitempty"`
+		ModelID           string    `json:"model_id,omitempty"`
+		Model             string    `json:"model,omitempty"`
+		ModelVersion      string    `json:"model_version,omitempty"`
+		Status            string    `json:"status"`
+		Substate          string    `json:"substate,omitempty"` // Honest Status v2: additive refinement
+		TmuxSession       string    `json:"tmux_session,omitempty"`
+		Profile           string    `json:"profile"`
+		CreatedAt         time.Time `json:"created_at"`
+		SSHHost           string    `json:"ssh_host,omitempty"`
+		SSHRemotePath     string    `json:"ssh_remote_path,omitempty"`
+		Channels          []string  `json:"channels,omitempty"`
+		ExtraArgs         []string  `json:"extra_args,omitempty"`
+		Color             string    `json:"color,omitempty"` // issue #391
+		Archived          bool      `json:"archived"`
+		ArchivedAt        time.Time `json:"archived_at,omitempty"`
+		// LastActivityAt lets a remote caller (session.RemoteSessionInfo)
+		// apply the local recency filter (session.TimeFilterMode) to this
+		// session, the same way it applies to a local one.
+		LastActivityAt string `json:"last_activity_at,omitempty"`
+	}
+	sessions := make([]sessionJSON, len(instances))
+	for i, inst := range instances {
+		_ = inst.UpdateStatus()
+		parentProjectPath := listParentProjectPath(inst, instances)
+		sj := sessionJSON{
+			ID:                inst.ID,
+			ParentSessionID:   inst.ParentSessionID,
+			ParentProjectPath: parentProjectPath,
+			Title:             inst.Title,
+			Path:              inst.ProjectPath,
+			Group:             inst.GroupPath,
+			Tool:              inst.Tool,
+			Account:           inst.Account,
+			Command:           inst.Command,
+			Status:            StatusString(inst.Status),
+			Substate:          string(inst.Substate()),
+			Profile:           profileName,
+			CreatedAt:         inst.CreatedAt,
+			SSHHost:           inst.SSHHost,
+			SSHRemotePath:     inst.SSHRemotePath,
+			Channels:          inst.Channels,
+			ExtraArgs:         inst.ExtraArgs,
+			Color:             inst.Color,
+			Archived:          inst.IsArchived(),
+			ArchivedAt:        inst.ArchivedAt,
+			LastActivityAt:    inst.DisplayLastActivityTime().Format(time.RFC3339Nano),
+		}
+		if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil {
+			sj.TmuxSession = tmuxSess.Name
+		}
+		if modelInfo := inst.LaunchModelInfo(); modelInfo.ModelID != "" {
+			sj.ModelID = modelInfo.ModelID
+			sj.Model = modelInfo.ModelID
+			sj.ModelVersion = modelInfo.Version
+		}
+		sessions[i] = sj
+	}
+	output, err := json.MarshalIndent(sessions, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(output, '\n'), nil
 }
 
 // handleListAllProfiles lists sessions from all profiles

--- a/cmd/agent-deck/remote_agent_cmd.go
+++ b/cmd/agent-deck/remote_agent_cmd.go
@@ -31,6 +31,14 @@ import (
 // the answer is byte-for-byte what `ssh host agent-deck <args>` would print;
 // only the ssh handshake and channel setup per command are gone, and the
 // change feed is new. Requests run concurrently; answers carry their id.
+//
+// The change feed's probe does not fork: it keeps the profile's storage open
+// in this process and builds the two listings through the same functions
+// `list --json` and `group list --json` print through (buildListJSON,
+// buildGroupListJSON). Booting the binary twice per change, each opening
+// storage and refreshing every status, was most of the second between a
+// change on the remote and the local screen; the event carries the probe's
+// duration as probe_ms so that cost stays visible.
 
 type remoteAgentRequest struct {
 	ID   int64    `json:"id"`
@@ -48,7 +56,14 @@ type remoteAgentReply struct {
 	// apply them at once instead of asking again.
 	Sessions string `json:"sessions,omitempty"`
 	Groups   string `json:"groups,omitempty"`
+	// ProbeMS is how long the "changed" event's listings took to build.
+	ProbeMS int64 `json:"probe_ms,omitempty"`
 }
+
+// remoteAgentProbeFunc builds the current `list --json` and `group list
+// --json` bodies for the change feed. The in-process one is the default;
+// tests inject their own.
+type remoteAgentProbeFunc func() (listJSON, groupJSON string, err error)
 
 // remoteAgentDeniedVerbs are never run through the channel: they need a
 // terminal, or must not be reachable from a remote TUI at all.
@@ -76,6 +91,15 @@ func handleRemoteAgent(profile string, args []string) {
 		fmt.Fprintf(os.Stderr, "remote-agent: %v\n", err)
 		os.Exit(1)
 	}
+	// The in-process probe refreshes statuses through tmux like `list` does,
+	// and `list` fixes up PATH for tmux before it starts.
+	ensureTmuxOnPath()
+	probe, closeProbe, err := newRemoteAgentProbe(profile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "remote-agent: %v\n", err)
+		os.Exit(1)
+	}
+	defer closeProbe()
 	runner := func(ctx context.Context, reqArgs []string) (string, string, int) {
 		full := append([]string{"-p", profile}, reqArgs...)
 		// The peer is the ssh-authenticated user who could run any of these
@@ -95,12 +119,41 @@ func handleRemoteAgent(profile string, args []string) {
 		}
 		return out.String(), errb.String(), code
 	}
-	serveRemoteAgent(context.Background(), os.Stdin, os.Stdout, runner, dbPath, 250*time.Millisecond)
+	serveRemoteAgent(context.Background(), os.Stdin, os.Stdout, runner, probe, dbPath, 250*time.Millisecond)
+}
+
+// newRemoteAgentProbe opens the profile's storage once and returns a probe
+// that loads it, refreshes statuses, and formats both listings exactly as
+// the CLI would, plus the close for the storage handle. Like `list --json`
+// it warms the tmux and hook-status caches once per probe, then formats
+// both listings from that one load.
+func newRemoteAgentProbe(profile string) (remoteAgentProbeFunc, func(), error) {
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		return nil, nil, err
+	}
+	probe := func() (string, string, error) {
+		instances, groups, err := storage.LoadWithGroups()
+		if err != nil {
+			return "", "", err
+		}
+		session.RefreshInstancesForCLIStatus(instances)
+		l, err := buildListJSON(storage.Profile(), instances)
+		if err != nil {
+			return "", "", err
+		}
+		g, err := buildGroupListJSON(session.NewGroupTreeWithGroups(instances, groups))
+		if err != nil {
+			return "", "", err
+		}
+		return string(l), string(g), nil
+	}
+	return probe, func() { _ = storage.Close() }, nil
 }
 
 // serveRemoteAgent is the agent loop, separated from process wiring so it is
 // testable with pipes. It returns when stdin closes.
-func serveRemoteAgent(ctx context.Context, in io.Reader, out io.Writer, run func(context.Context, []string) (string, string, int), watchPath string, watchEvery time.Duration) {
+func serveRemoteAgent(ctx context.Context, in io.Reader, out io.Writer, run func(context.Context, []string) (string, string, int), probe remoteAgentProbeFunc, watchPath string, watchEvery time.Duration) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	var wmu sync.Mutex
@@ -119,18 +172,15 @@ func serveRemoteAgent(ctx context.Context, in io.Reader, out io.Writer, run func
 	// Change feed. A cheap mtime/size poll on state.db notices any write by
 	// any process on the remote; but a status refresh by `list` itself also
 	// writes, so a bare stamp would feed back into the TUI's own refetch
-	// forever. The stamp only triggers a probe: the agent runs the two
+	// forever. The stamp only triggers a probe: the agent builds the two
 	// listings the TUI fetches and pushes "changed" only when their content
 	// differs from what it last pushed.
-	if watchPath != "" && watchEvery > 0 {
+	if watchPath != "" && watchEvery > 0 && probe != nil {
 		go func() {
 			last := remoteAgentStamp(watchPath)
 			// Seed with the current content so the first stamp change is
 			// judged against what the TUI already fetched at startup.
-			sctx, scancel := context.WithTimeout(ctx, 30*time.Second)
-			l0, _, _ := run(sctx, []string{"list", "--json"})
-			g0, _, _ := run(sctx, []string{"group", "list", "--json"})
-			scancel()
+			l0, g0, _ := probe()
 			lastHash := remoteAgentContentHash(l0, g0)
 			t := time.NewTicker(watchEvery)
 			defer t.Stop()
@@ -142,14 +192,17 @@ func serveRemoteAgent(ctx context.Context, in io.Reader, out io.Writer, run func
 					if remoteAgentStamp(watchPath) == last {
 						continue
 					}
-					pctx, pcancel := context.WithTimeout(ctx, 30*time.Second)
-					l, _, _ := run(pctx, []string{"list", "--json"})
-					g, _, _ := run(pctx, []string{"group", "list", "--json"})
-					pcancel()
-					h := remoteAgentContentHash(l, g)
-					if h != lastHash {
+					started := time.Now()
+					l, g, err := probe()
+					elapsed := time.Since(started).Milliseconds()
+					if err != nil {
+						// No listings to compare or push: tell the TUI
+						// something changed and let it fetch.
+						fmt.Fprintf(os.Stderr, "remote-agent: probe: %v\n", err)
+						write(remoteAgentReply{Event: "changed", ProbeMS: elapsed})
+					} else if h := remoteAgentContentHash(l, g); h != lastHash {
 						lastHash = h
-						write(remoteAgentReply{Event: "changed", Sessions: l, Groups: g})
+						write(remoteAgentReply{Event: "changed", Sessions: l, Groups: g, ProbeMS: elapsed})
 					}
 					// The probe's own status refresh may have touched the
 					// DB again; take that stamp as seen.

--- a/cmd/agent-deck/remote_agent_cmd_test.go
+++ b/cmd/agent-deck/remote_agent_cmd_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -37,9 +38,16 @@ func TestRemoteAgent_RequestsEventsAndDenyList(t *testing.T) {
 		}
 		return "ran:" + strings.Join(args, " "), "", 0
 	}
+	// The probe is what the change feed compares; here it is the same
+	// listing the request path returns, so the two stay in step.
+	probe := func() (string, string, error) {
+		l, _, _ := run(context.Background(), []string{"list", "--json"})
+		g, _, _ := run(context.Background(), []string{"group", "list", "--json"})
+		return l, g, nil
+	}
 	done := make(chan struct{})
 	go func() {
-		serveRemoteAgent(context.Background(), inR, outW, run, db, 20*time.Millisecond)
+		serveRemoteAgent(context.Background(), inR, outW, run, probe, db, 20*time.Millisecond)
 		_ = outW.Close()
 		close(done)
 	}()
@@ -101,6 +109,90 @@ func TestRemoteAgent_RequestsEventsAndDenyList(t *testing.T) {
 		}
 	case <-deadline:
 		t.Fatal("no changed event after the state file was written")
+	}
+
+	_ = inW.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("agent did not exit when stdin closed")
+	}
+}
+
+// The "changed" event reports how long the probe took, and a probe that
+// fails still tells the TUI to refetch: an event without listings.
+func TestRemoteAgent_ProbeTimingAndFailureFallback(t *testing.T) {
+	dir := t.TempDir()
+	db := filepath.Join(dir, "state.db")
+	if err := os.WriteFile(db, []byte("v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+	run := func(context.Context, []string) (string, string, int) { return "", "", 0 }
+	probe := func() (string, string, error) {
+		content, _ := os.ReadFile(db)
+		if string(content) == "broken" {
+			return "", "", errors.New("storage gone")
+		}
+		time.Sleep(5 * time.Millisecond)
+		return "[" + string(content) + "]", "{}", nil
+	}
+	done := make(chan struct{})
+	go func() {
+		serveRemoteAgent(context.Background(), inR, outW, run, probe, db, 20*time.Millisecond)
+		_ = outW.Close()
+		close(done)
+	}()
+	sc := bufio.NewScanner(outR)
+	next := func() remoteAgentReply {
+		t.Helper()
+		got := make(chan remoteAgentReply, 1)
+		go func() {
+			if !sc.Scan() {
+				t.Errorf("agent closed early: %v", sc.Err())
+				got <- remoteAgentReply{}
+				return
+			}
+			var r remoteAgentReply
+			if err := json.Unmarshal(sc.Bytes(), &r); err != nil {
+				t.Errorf("bad reply %q: %v", sc.Text(), err)
+			}
+			got <- r
+		}()
+		select {
+		case r := <-got:
+			return r
+		case <-time.After(2 * time.Second):
+			t.Fatal("no line from the agent within 2s")
+			return remoteAgentReply{}
+		}
+	}
+	if r := next(); r.Event != "ready" {
+		t.Fatalf("first line must announce ready, got %+v", r)
+	}
+
+	time.Sleep(30 * time.Millisecond)
+	if err := os.WriteFile(db, []byte("v2-longer"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	r := next()
+	if r.Event != "changed" || r.Sessions != "[v2-longer]" || r.Groups != "{}" {
+		t.Fatalf("expected a changed event with listings, got %+v", r)
+	}
+	if r.ProbeMS < 5 {
+		t.Fatalf("probe_ms = %d, want the probe's duration (>= 5ms)", r.ProbeMS)
+	}
+
+	// The feed re-reads the stamp after a probe to absorb the probe's own
+	// writes; give it that moment so this write is not taken as seen.
+	time.Sleep(30 * time.Millisecond)
+	if err := os.WriteFile(db, []byte("broken"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	r = next()
+	if r.Event != "changed" || r.Sessions != "" || r.Groups != "" {
+		t.Fatalf("a failing probe must push a bare changed event, got %+v", r)
 	}
 
 	_ = inW.Close()

--- a/cmd/agent-deck/remote_agent_probe_test.go
+++ b/cmd/agent-deck/remote_agent_probe_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The in-process probe must produce exactly what `list --json` and `group
+// list --json` print, since the TUI applies a pushed listing in place of a
+// fetched one: same builders, same bytes.
+func TestRemoteAgent_InProcessProbeMatchesCLI(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	project := filepath.Join(home, "proj")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"group", "create", "work", "--json"},
+		{"group", "create", "old", "--parent", "work", "--json"},
+		{"add", project, "--title", "probe-me", "--group", "work", "--no-parent", "--json"},
+	} {
+		if stdout, stderr, code := runAgentDeck(t, home, args...); code != 0 {
+			t.Fatalf("%v failed (%d)\n%s\n%s", args, code, stdout, stderr)
+		}
+	}
+	wantList, stderr, code := runAgentDeck(t, home, "list", "--json")
+	if code != 0 {
+		t.Fatalf("list --json failed (%d): %s", code, stderr)
+	}
+	wantGroups, stderr, code := runAgentDeck(t, home, "group", "list", "--json")
+	if code != 0 {
+		t.Fatalf("group list --json failed (%d): %s", code, stderr)
+	}
+
+	// Same isolation runAgentDeck gives the subprocess, applied to this
+	// process for the in-process probe.
+	t.Setenv("HOME", home)
+	t.Setenv("AGENTDECK_PROFILE", "ch_support_test")
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	probe, closeProbe, err := newRemoteAgentProbe("ch_support_test")
+	if err != nil {
+		t.Fatalf("newRemoteAgentProbe: %v", err)
+	}
+	defer closeProbe()
+	gotList, gotGroups, err := probe()
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if gotList != wantList {
+		t.Errorf("probe list differs from `list --json`:\n--- probe\n%s\n--- cli\n%s", gotList, wantList)
+	}
+	if gotGroups != wantGroups {
+		t.Errorf("probe groups differ from `group list --json`:\n--- probe\n%s\n--- cli\n%s", gotGroups, wantGroups)
+	}
+	if len(gotList) < 3 || gotList[0] != '[' {
+		t.Fatalf("probe list is not a JSON array: %q", gotList)
+	}
+}

--- a/internal/session/issue1103_remote_latency_test.go
+++ b/internal/session/issue1103_remote_latency_test.go
@@ -4,7 +4,9 @@
 // remote in the TUI header, refreshed on the CPU/RAM cadence.
 //
 // This file owns the structural invariants of the measurement primitive:
-//   - SSHRunner.MeasureLatency calls a known cheap noop RPC (`--version`).
+//   - SSHRunner.MeasureLatency times a shell builtin (`true`) over ssh, not
+//     a remote agent-deck invocation, so the figure is transport round trip
+//     without remote process startup.
 //   - It returns a non-negative duration that reflects the round-trip.
 //   - It surfaces remote/network failure as an error so the renderer can
 //     show ` — offline` instead of misleading "0ms".
@@ -20,20 +22,26 @@ import (
 	"time"
 )
 
-// TestIssue1103_MeasureLatency_InvokesVersionAndTimesRoundTrip asserts that
-// MeasureLatency hits the cheapest possible noop on the remote (`--version`)
-// and returns a duration that reflects the stubbed delay. If a future change
-// switches to a heavier command (e.g. `list --json`), this test catches the
-// regression because the header would start ticking on a heavyweight RPC.
-func TestIssue1103_MeasureLatency_InvokesVersionAndTimesRoundTrip(t *testing.T) {
+// TestIssue1103_MeasureLatency_TimesShellBuiltinRoundTrip asserts that
+// MeasureLatency times a raw shell builtin over ssh (`true`) rather than an
+// agent-deck invocation, and returns a duration that reflects the stubbed
+// delay. Running the remote binary (even `--version`) adds its process
+// startup to the figure, which made a 97 ms link read as 110 ms or more; a
+// builtin keeps the header honest about the transport alone.
+func TestIssue1103_MeasureLatency_TimesShellBuiltinRoundTrip(t *testing.T) {
 	const stubDelay = 30 * time.Millisecond
 
-	var calledWith []string
+	var calledWith string
+	agentDeckCalls := 0
 	runner := &SSHRunner{
 		runFn: func(ctx context.Context, args ...string) ([]byte, error) {
-			calledWith = append([]string(nil), args...)
-			time.Sleep(stubDelay)
+			agentDeckCalls++
 			return []byte("agent-deck v1.9.23\n"), nil
+		},
+		remoteExecFn: func(ctx context.Context, remoteCmd string, stdin []byte) ([]byte, error) {
+			calledWith = remoteCmd
+			time.Sleep(stubDelay)
+			return nil, nil
 		},
 	}
 
@@ -42,8 +50,11 @@ func TestIssue1103_MeasureLatency_InvokesVersionAndTimesRoundTrip(t *testing.T) 
 		t.Fatalf("MeasureLatency returned err=%v", err)
 	}
 
-	if len(calledWith) != 1 || calledWith[0] != "--version" {
-		t.Fatalf("MeasureLatency must call `--version` (cheapest noop), got args=%v", calledWith)
+	if calledWith != "true" {
+		t.Fatalf("MeasureLatency must time the shell builtin `true`, got remote command %q", calledWith)
+	}
+	if agentDeckCalls != 0 {
+		t.Fatalf("MeasureLatency must not invoke the remote agent-deck binary; got %d call(s)", agentDeckCalls)
 	}
 
 	if d < stubDelay {
@@ -56,7 +67,7 @@ func TestIssue1103_MeasureLatency_InvokesVersionAndTimesRoundTrip(t *testing.T) 
 // reporting "0ms" (which would falsely indicate a healthy remote).
 func TestIssue1103_MeasureLatency_PropagatesError(t *testing.T) {
 	runner := &SSHRunner{
-		runFn: func(ctx context.Context, args ...string) ([]byte, error) {
+		remoteExecFn: func(ctx context.Context, remoteCmd string, stdin []byte) ([]byte, error) {
 			return nil, errors.New("ssh: connection refused")
 		},
 	}

--- a/internal/session/remote_channel.go
+++ b/internal/session/remote_channel.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"strings"
@@ -53,6 +54,7 @@ type remoteChannelReply struct {
 	Error    string `json:"error,omitempty"`
 	Sessions string `json:"sessions,omitempty"`
 	Groups   string `json:"groups,omitempty"`
+	ProbeMS  int64  `json:"probe_ms,omitempty"`
 }
 
 // RemoteChange is one pushed change from a remote. Sessions and Groups are
@@ -228,6 +230,10 @@ func (c *RemoteChannel) readLoop(r *bufio.Reader) {
 			continue
 		}
 		if reply.Event == "changed" {
+			sessionLog.Debug("remote_channel_changed",
+				slog.String("remote", c.name),
+				slog.Bool("pushed_data", strings.TrimSpace(reply.Sessions) != ""),
+				slog.Int64("probe_ms", reply.ProbeMS))
 			select {
 			case c.events <- c.changeFromReply(reply):
 			default:

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -1527,20 +1527,27 @@ type RemoteLatency struct {
 	MeasuredAt time.Time
 }
 
-// MeasureLatency measures the round-trip time of a lightweight noop call
-// to the remote agent-deck binary. Returns the elapsed duration on success.
+// MeasureLatency measures the transport round trip to the remote host and
+// returns the elapsed duration on success.
 //
-// Implementation note: we run `agent-deck --version` because it is the
-// cheapest possible call (no DB read, no tmux probe, no network back to
-// services). The ControlMaster socket is persisted across calls so we
-// measure mostly network RTT after the first hit, which is exactly what
-// the user wants to see in the header per #1103.
+// It times the shell builtin `true` over the same ssh options (and the same
+// ControlMaster socket) every other command uses, so the number is the
+// network round trip plus ssh channel setup and nothing else. It used to run
+// `agent-deck --version`, which also paid for the remote process to start:
+// the header showed ~110 ms on a 97 ms link, and ~215 ms before the
+// persistent channel (#2177) existed. Users read the header figure as "how
+// far away is this host", and only the transport answers that (#1103).
 func (r *SSHRunner) MeasureLatency(ctx context.Context) (time.Duration, error) {
 	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	start := time.Now()
-	if _, err := r.run(timeoutCtx, "--version"); err != nil {
+	if _, err := r.remoteExec(timeoutCtx, latencyProbeCommand, nil); err != nil {
 		return 0, err
 	}
 	return time.Since(start), nil
 }
+
+// latencyProbeCommand is the remote command MeasureLatency times: a shell
+// builtin, so no process is forked on the remote and the timing is pure
+// transport.
+const latencyProbeCommand = "true"

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -637,12 +637,24 @@ type Home struct {
 	remoteSessionsMu   sync.RWMutex
 	lastRemoteFetch    time.Time // When remote sessions were last fetched
 	remotesFetchActive bool      // Prevents overlapping fetches
+	// remoteFetchOutstanding counts the per-remote fetches of the running
+	// round(s) that have not answered yet; remotesFetchActive clears when
+	// the last one lands, so one wedged host cannot hold the others back
+	// but the "refreshing…" trailer still tells the truth for the round.
+	remoteFetchOutstanding int
 	// remoteFetchSeq numbers every fleet fetch as it starts; the handler
-	// applies a result only if no newer fetch has been applied already, so a
-	// slow periodic poll cannot overwrite the refresh a delete, move or
-	// archive just triggered (a stale snapshot would resurrect the row).
+	// applies a remote's result only if no newer fetch has been applied for
+	// THAT remote already, so a slow periodic poll cannot overwrite the
+	// refresh a delete, move or archive just triggered (a stale snapshot
+	// would resurrect the row). Generations are tracked per remote because
+	// each remote's result now arrives on its own: a newer answer from a
+	// fast host must not make a slower host's still-valid answer look stale.
 	remoteFetchSeq     uint64
-	remoteFetchApplied uint64
+	remoteFetchApplied map[string]uint64 // remoteName -> last applied generation
+	// newRemoteFetchRunner builds the runner one per-remote fetch talks to.
+	// nil means a real SSHRunner; tests inject stubs to prove delivery
+	// timing without ssh.
+	newRemoteFetchRunner func(name string, rc session.RemoteConfig) remoteFetchRunner
 	// remoteActionStarted records when each remote action was requested
 	// (keyed by remote, verb and target) so its footer line can report the
 	// time from keypress to the remote's confirmation, the number that
@@ -1453,10 +1465,32 @@ type sendOutputResultMsg struct {
 	err         error
 }
 
-// remoteSessionsFetchedMsg is sent when async remote sessions fetch completes.
+// remoteFetchRoundMsg starts one fleet poll: the config was read and every
+// remote gets its own fetch Cmd. Each Cmd answers with a
+// remoteSessionsFetchedMsg for that remote alone, as soon as that host
+// replies, so a slow or wedged host never delays the others (#2177).
+type remoteFetchRoundMsg struct {
+	gen     uint64
+	fetches []tea.Cmd
+}
+
+// remoteFetchRunner is what one per-remote fetch needs from an SSHRunner.
+type remoteFetchRunner interface {
+	FetchSessions(context.Context) ([]session.RemoteSessionInfo, error)
+	FetchCostSummary(context.Context) (*costs.RemoteCostSummary, error)
+	FetchGroupPaths(context.Context) ([]string, error)
+}
+
+// remoteSessionsFetchedMsg carries one remote's fetch result (or a pushed
+// change shaped like one). Every other configured remote is listed in
+// failed/groupsFailed so the merge keeps their rows untouched.
 type remoteSessionsFetchedMsg struct {
 	// gen is the fetch's sequence number (see Home.remoteFetchSeq).
 	gen uint64
+	// pushed marks a result that did not come from a poll round (a change
+	// the remote pushed over its channel), so it is not counted against the
+	// round's outstanding fetches.
+	pushed bool
 	// configErr is set when the user config could not be read; the handler
 	// then keeps every cached remote instead of treating them as removed.
 	configErr error
@@ -3829,22 +3863,30 @@ func (h *Home) propagateThemeToSessions() {
 	})
 }
 
-// applyRemoteFetch folds one fleet fetch result (or a pushed change shaped
+// applyRemoteFetch folds one remote's fetch result (or a pushed change shaped
 // like one) into the cache, the on-disk snapshot and the rows.
 func (h *Home) applyRemoteFetch(msg remoteSessionsFetchedMsg) (tea.Model, tea.Cmd) {
-	if msg.configErr != nil || (msg.gen != 0 && msg.gen < h.remoteFetchApplied) {
+	if msg.configErr != nil || h.remoteFetchIsStale(msg) {
 		// Config unreadable, or a fetch that started before one already
-		// applied: keep the current tree. Only release the in-flight
-		// guard so the next poll runs.
+		// applied for the same remote: keep the current tree. Only account
+		// for the landed fetch so the round can finish and the next poll
+		// runs.
 		h.remoteSessionsMu.Lock()
-		h.remotesFetchActive = false
+		h.remoteFetchLanded(msg)
 		h.remoteSessionsMu.Unlock()
 		if msg.configErr != nil {
 			h.setError(fmt.Errorf("remote refresh skipped, config could not be read: %v", msg.configErr))
 		}
 		return h, nil
 	}
-	h.remoteFetchApplied = msg.gen
+	if msg.gen != 0 {
+		if h.remoteFetchApplied == nil {
+			h.remoteFetchApplied = make(map[string]uint64)
+		}
+		for name := range msg.sessions {
+			h.remoteFetchApplied[name] = msg.gen
+		}
+	}
 	h.remoteSessionsMu.Lock()
 	// #1170: merge rather than wholesale-replace so a remote that errored
 	// this round keeps its last-good sessions instead of flickering out.
@@ -3875,14 +3917,14 @@ func (h *Home) applyRemoteFetch(msg remoteSessionsFetchedMsg) (tea.Model, tea.Cm
 		}
 	}
 	h.lastRemoteFetch = time.Now()
-	h.remotesFetchActive = false
+	roundDone := h.remoteFetchLanded(msg)
 	h.remoteSessionsMu.Unlock()
 	h.saveRemoteSessionsCache(msg.sessions)
 	// #1101: store remote cost summaries so renderCostLine can fold them
 	// into the displayed totals on the next paint.
 	if msg.costs != nil {
 		h.remoteCostsMu.Lock()
-		h.remoteCosts = msg.costs
+		h.remoteCosts = mergeRemoteCosts(h.remoteCosts, msg)
 		h.remoteCostsMu.Unlock()
 	}
 	// #1112 bug 1: a remote running→waiting transition wouldn't update
@@ -3892,6 +3934,9 @@ func (h *Home) applyRemoteFetch(msg remoteSessionsFetchedMsg) (tea.Model, tea.Cm
 	// Invalidate so the next View() recomputes.
 	h.cachedStatusCounts.valid.Store(false)
 	h.rebuildFlatItems()
+	if !roundDone {
+		return h, nil
+	}
 	h.remoteSessionsMu.Lock()
 	again := h.remoteRefetchWanted
 	h.remoteRefetchWanted = false
@@ -3903,6 +3948,60 @@ func (h *Home) applyRemoteFetch(msg remoteSessionsFetchedMsg) (tea.Model, tea.Cm
 		return h, h.fetchRemoteSessions
 	}
 	return h, nil
+}
+
+// remoteFetchIsStale reports whether a newer fetch has already been applied
+// for any remote this message carries data for. Remotes listed only as
+// failed carry no data, so they never make a message stale.
+func (h *Home) remoteFetchIsStale(msg remoteSessionsFetchedMsg) bool {
+	if msg.gen == 0 {
+		return false
+	}
+	for name := range msg.sessions {
+		if msg.gen < h.remoteFetchApplied[name] {
+			return true
+		}
+	}
+	return false
+}
+
+// remoteFetchLanded accounts for one per-remote result and reports whether
+// that completed the round (no fetch outstanding), clearing the in-flight
+// guard when it did. Pushed changes are not part of any round. Called with
+// remoteSessionsMu held.
+func (h *Home) remoteFetchLanded(msg remoteSessionsFetchedMsg) bool {
+	if msg.pushed {
+		return false
+	}
+	if h.remoteFetchOutstanding > 0 {
+		h.remoteFetchOutstanding--
+	}
+	if h.remoteFetchOutstanding > 0 {
+		return false
+	}
+	h.remotesFetchActive = false
+	return true
+}
+
+// mergeRemoteCosts folds one remote's cost summary into the per-remote map
+// without blanking the other remotes' figures: a remote whose result this
+// message carries either gets its fresh summary or, when its cost fetch
+// failed, contributes zero (as before); remotes still marked failed keep
+// their last-good figure; remotes absent from both lists were deconfigured.
+func mergeRemoteCosts(prev map[string]*costs.RemoteCostSummary, msg remoteSessionsFetchedMsg) map[string]*costs.RemoteCostSummary {
+	merged := make(map[string]*costs.RemoteCostSummary, len(prev)+len(msg.costs))
+	for name, summary := range prev {
+		if _, fetched := msg.sessions[name]; fetched {
+			continue
+		}
+		if msg.failed[name] {
+			merged[name] = summary
+		}
+	}
+	for name, summary := range msg.costs {
+		merged[name] = summary
+	}
+	return merged
 }
 
 // remoteChangedMsg says a remote pushed "changed" over its persistent
@@ -3929,6 +4028,7 @@ func (h *Home) waitRemoteChange() tea.Msg {
 func (h *Home) pushedRemoteFetch(ch session.RemoteChange) remoteSessionsFetchedMsg {
 	msg := remoteSessionsFetchedMsg{
 		gen:          atomic.AddUint64(&h.remoteFetchSeq, 1),
+		pushed:       true,
 		sessions:     map[string][]session.RemoteSessionInfo{ch.Remote: ch.Sessions},
 		failed:       map[string]bool{},
 		groups:       map[string][]string{},
@@ -3950,7 +4050,10 @@ func (h *Home) pushedRemoteFetch(ch session.RemoteChange) remoteSessionsFetchedM
 	return msg
 }
 
-// fetchRemoteSessions fetches sessions from all configured remotes.
+// fetchRemoteSessions starts a fleet poll. It reads the config, sweeps stale
+// ssh sockets and returns one fetch Cmd per remote; the handler batches
+// them, and each answers on its own, so the tree updates host by host as
+// answers arrive instead of after the slowest one (#2177).
 func (h *Home) fetchRemoteSessions() tea.Msg {
 	gen := atomic.AddUint64(&h.remoteFetchSeq, 1)
 	config, err := session.LoadUserConfig()
@@ -3971,104 +4074,109 @@ func (h *Home) fetchRemoteSessions() tea.Msg {
 	// make every remote session vanish until the TUI restarts.
 	session.CleanStaleSSHSockets()
 
-	results := make(map[string][]session.RemoteSessionInfo, len(config.Remotes))
-	// #1101: remote cost summaries piggy-back on the existing remote-fetch
-	// channel so the status-line cost segment doesn't lag behind the session
-	// list. nil-valued entries indicate fetch failures (e.g., older remote
-	// agent-deck without `costs summary --json`); the renderer treats those
-	// as "remote contributes zero" so a single broken remote can't poison
-	// the displayed total.
-	costResults := make(map[string]*costs.RemoteCostSummary, len(config.Remotes))
-	// Remote group lists (group list --json) ride the same fanout so the
-	// move/create dialogs can offer EMPTY remote folders — a folder that
-	// currently holds no sessions is invisible to session-derived buckets
-	// but is still a valid target. Successful fetches land in groupResults;
-	// failures in groupsFailed keep last-good cache entries (same contract
-	// as the sessions map, issue #1170).
-	groupResults := make(map[string][]string, len(config.Remotes))
-	groupsFailed := make(map[string]bool, len(config.Remotes))
-	// #1170: track remotes that errored so the handler keeps their last-good
-	// sessions instead of dropping them.
-	failed := make(map[string]bool, len(config.Remotes))
-	var mu sync.Mutex
-	var wg sync.WaitGroup
+	return remoteFetchRoundMsg{gen: gen, fetches: h.remoteFetchCmds(gen, config.Remotes)}
+}
 
-	// #1170: fetch every remote in parallel, each with its OWN timeout, so a
-	// single slow/offline remote can't starve the others. The previous code
-	// shared one 15s budget across all remotes fetched sequentially, which
-	// made healthy remotes drop out of the result map (and flicker in the
-	// TUI) whenever an earlier remote was slow.
-	for name, rc := range config.Remotes {
-		wg.Add(1)
-		go func(name string, rc session.RemoteConfig) {
-			defer wg.Done()
-			// Honor the per-remote command_timeout_seconds: hosts with large
-			// session fleets legitimately need more than the old flat 15s.
-			ctx, cancel := context.WithTimeout(h.ctx, rc.GetCommandTimeout())
-			defer cancel()
-
-			runner := session.NewSSHRunner(name, rc)
-			sessions, err := runner.FetchSessions(ctx)
-			if err != nil {
-				mu.Lock()
-				failed[name] = true
-				// The group list can't be trusted either — keep last-good.
-				groupsFailed[name] = true
-				mu.Unlock()
-				return
-			}
-			for i := range sessions {
-				sessions[i].RemoteName = name
-			}
-			// The cost summary and the group list are independent of the
-			// session list and of each other, so they run concurrently over
-			// the same ControlMaster connection: one round trip per poll
-			// instead of three in a row (#2167). Each keeps its own bound so
-			// a slow `costs summary` or `group list` on one remote cannot
-			// starve the others, and a failure degrades as before: costs to
-			// "contributes zero", groups to the session-derived fallback in
-			// remoteGroupPaths.
-			var (
-				summary    *costs.RemoteCostSummary
-				costErr    error
-				groupPaths []string
-				groupErr   error
-				side       sync.WaitGroup
-			)
-			side.Add(2)
-			go func() {
-				defer side.Done()
-				costCtx, costCancel := context.WithTimeout(h.ctx, rc.GetCommandTimeout())
-				defer costCancel()
-				summary, costErr = runner.FetchCostSummary(costCtx)
-			}()
-			go func() {
-				defer side.Done()
-				groupCtx, groupCancel := context.WithTimeout(h.ctx, rc.GetCommandTimeout())
-				defer groupCancel()
-				groupPaths, groupErr = runner.FetchGroupPaths(groupCtx)
-			}()
-			side.Wait()
-
-			mu.Lock()
-			results[name] = sessions
-			if costErr == nil && summary != nil {
-				costResults[name] = summary
-			}
-			if groupErr == nil {
-				if groupPaths == nil {
-					groupPaths = []string{}
-				}
-				groupResults[name] = groupPaths
-			} else {
-				groupsFailed[name] = true
-			}
-			mu.Unlock()
-		}(name, rc)
+// remoteFetchCmds builds one Cmd per configured remote for fetch round gen.
+func (h *Home) remoteFetchCmds(gen uint64, remotes map[string]session.RemoteConfig) []tea.Cmd {
+	names := make([]string, 0, len(remotes))
+	for name := range remotes {
+		names = append(names, name)
 	}
-	wg.Wait()
+	cmds := make([]tea.Cmd, 0, len(remotes))
+	for name, rc := range remotes {
+		cmds = append(cmds, func() tea.Msg { return h.fetchOneRemote(gen, name, rc, names) })
+	}
+	return cmds
+}
 
-	return remoteSessionsFetchedMsg{gen: gen, sessions: results, costs: costResults, groups: groupResults, groupsFailed: groupsFailed, failed: failed}
+// fetchOneRemote fetches one remote's sessions, cost summary and group list
+// and shapes them as a result for that remote alone: every other configured
+// remote is marked failed so the merge keeps its rows, and a remote missing
+// from the config altogether is absent from both lists and so drops out.
+func (h *Home) fetchOneRemote(gen uint64, name string, rc session.RemoteConfig, configured []string) remoteSessionsFetchedMsg {
+	msg := remoteSessionsFetchedMsg{
+		gen:          gen,
+		sessions:     make(map[string][]session.RemoteSessionInfo, 1),
+		costs:        make(map[string]*costs.RemoteCostSummary, 1),
+		groups:       make(map[string][]string, 1),
+		groupsFailed: make(map[string]bool, len(configured)),
+		failed:       make(map[string]bool, len(configured)),
+	}
+	for _, other := range configured {
+		if other != name {
+			msg.failed[other] = true
+			msg.groupsFailed[other] = true
+		}
+	}
+
+	// Honor the per-remote command_timeout_seconds: hosts with large
+	// session fleets legitimately need more than the old flat 15s. Each
+	// remote runs under its own bound (#1170) and answers on its own
+	// (#2177), so one slow or offline host starves nobody.
+	ctx, cancel := context.WithTimeout(h.ctx, rc.GetCommandTimeout())
+	defer cancel()
+
+	var runner remoteFetchRunner
+	if h.newRemoteFetchRunner != nil {
+		runner = h.newRemoteFetchRunner(name, rc)
+	} else {
+		runner = session.NewSSHRunner(name, rc)
+	}
+	sessions, err := runner.FetchSessions(ctx)
+	if err != nil {
+		// #1170: the handler keeps this remote's last-good sessions; the
+		// group list can't be trusted either, so keep that too.
+		msg.failed[name] = true
+		msg.groupsFailed[name] = true
+		return msg
+	}
+	for i := range sessions {
+		sessions[i].RemoteName = name
+	}
+	// The cost summary and the group list are independent of the session
+	// list and of each other, so they run concurrently over the same
+	// ControlMaster connection: one round trip per poll instead of three in
+	// a row (#2167). Each keeps its own bound, and a failure degrades as
+	// before: costs to "contributes zero", groups to the session-derived
+	// fallback in remoteGroupPaths.
+	var (
+		summary    *costs.RemoteCostSummary
+		costErr    error
+		groupPaths []string
+		groupErr   error
+		side       sync.WaitGroup
+	)
+	side.Add(2)
+	go func() {
+		defer side.Done()
+		costCtx, costCancel := context.WithTimeout(h.ctx, rc.GetCommandTimeout())
+		defer costCancel()
+		summary, costErr = runner.FetchCostSummary(costCtx)
+	}()
+	go func() {
+		defer side.Done()
+		groupCtx, groupCancel := context.WithTimeout(h.ctx, rc.GetCommandTimeout())
+		defer groupCancel()
+		groupPaths, groupErr = runner.FetchGroupPaths(groupCtx)
+	}()
+	side.Wait()
+
+	msg.sessions[name] = sessions
+	// #1101: a nil summary (older remote without `costs summary --json`)
+	// is left out so the renderer treats the remote as contributing zero.
+	if costErr == nil && summary != nil {
+		msg.costs[name] = summary
+	}
+	if groupErr == nil {
+		if groupPaths == nil {
+			groupPaths = []string{}
+		}
+		msg.groups[name] = groupPaths
+	} else {
+		msg.groupsFailed[name] = true
+	}
+	return msg
 }
 
 // mergeRemoteSessions reconciles a freshly fetched remote-session map against
@@ -7047,6 +7155,16 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			h.updateInfo = msg.info
 		}
 		return h, nil
+
+	case remoteFetchRoundMsg:
+		// Fan out: each remote answers with its own remoteSessionsFetchedMsg.
+		// Outstanding counts add up so an overlapping round (ctrl+r during
+		// a poll) keeps the guard until every fetch of both has landed.
+		h.remoteSessionsMu.Lock()
+		h.remotesFetchActive = true
+		h.remoteFetchOutstanding += len(msg.fetches)
+		h.remoteSessionsMu.Unlock()
+		return h, tea.Batch(msg.fetches...)
 
 	case remoteSessionsFetchedMsg:
 		return h.applyRemoteFetch(msg)

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1489,8 +1489,13 @@ type remoteSessionsFetchedMsg struct {
 	gen uint64
 	// pushed marks a result that did not come from a poll round (a change
 	// the remote pushed over its channel), so it is not counted against the
-	// round's outstanding fetches.
+	// round's outstanding fetches and never touches the in-flight guard.
 	pushed bool
+	// inRound marks one of the per-remote results a remoteFetchRoundMsg
+	// fanned out; only those count down remoteFetchOutstanding. A message
+	// from outside a round (config unreadable, no remotes configured) must
+	// not steal a slot from a round still in flight.
+	inRound bool
 	// configErr is set when the user config could not be read; the handler
 	// then keeps every cached remote instead of treating them as removed.
 	configErr error
@@ -3879,6 +3884,11 @@ func (h *Home) applyRemoteFetch(msg remoteSessionsFetchedMsg) (tea.Model, tea.Cm
 		}
 		return h, nil
 	}
+	h.remoteSessionsMu.Lock()
+	prevSessions := h.remoteSessions
+	// #1170: merge rather than wholesale-replace so a remote that errored
+	// this round keeps its last-good sessions instead of flickering out.
+	h.remoteSessions = mergeRemoteSessions(h.remoteSessions, msg.sessions, msg.failed)
 	if msg.gen != 0 {
 		if h.remoteFetchApplied == nil {
 			h.remoteFetchApplied = make(map[string]uint64)
@@ -3886,11 +3896,14 @@ func (h *Home) applyRemoteFetch(msg remoteSessionsFetchedMsg) (tea.Model, tea.Cm
 		for name := range msg.sessions {
 			h.remoteFetchApplied[name] = msg.gen
 		}
+		// A remote this message deconfigured (absent from both lists) must
+		// not come back when a slower result from an older round lands.
+		for name := range prevSessions {
+			if _, fetched := msg.sessions[name]; !fetched && !msg.failed[name] {
+				h.remoteFetchApplied[name] = msg.gen
+			}
+		}
 	}
-	h.remoteSessionsMu.Lock()
-	// #1170: merge rather than wholesale-replace so a remote that errored
-	// this round keeps its last-good sessions instead of flickering out.
-	h.remoteSessions = mergeRemoteSessions(h.remoteSessions, msg.sessions, msg.failed)
 	// Remote group lists: replace wholesale for remotes that reported a
 	// fresh list; failed remotes keep their last-good cached paths so the
 	// move dialog doesn't lose empty-group targets on a transient SSH
@@ -3965,15 +3978,17 @@ func (h *Home) remoteFetchIsStale(msg remoteSessionsFetchedMsg) bool {
 	return false
 }
 
-// remoteFetchLanded accounts for one per-remote result and reports whether
-// that completed the round (no fetch outstanding), clearing the in-flight
-// guard when it did. Pushed changes are not part of any round. Called with
-// remoteSessionsMu held.
+// remoteFetchLanded accounts for one fetch result and reports whether that
+// left no fetch outstanding, clearing the in-flight guard when it did. Only
+// a round's own per-remote results count down the outstanding total; a
+// message from outside a round (config unreadable, no remotes) releases the
+// guard only when no round is in flight. Pushed changes are not part of any
+// round and never touch the guard. Called with remoteSessionsMu held.
 func (h *Home) remoteFetchLanded(msg remoteSessionsFetchedMsg) bool {
 	if msg.pushed {
 		return false
 	}
-	if h.remoteFetchOutstanding > 0 {
+	if msg.inRound && h.remoteFetchOutstanding > 0 {
 		h.remoteFetchOutstanding--
 	}
 	if h.remoteFetchOutstanding > 0 {
@@ -4097,6 +4112,7 @@ func (h *Home) remoteFetchCmds(gen uint64, remotes map[string]session.RemoteConf
 func (h *Home) fetchOneRemote(gen uint64, name string, rc session.RemoteConfig, configured []string) remoteSessionsFetchedMsg {
 	msg := remoteSessionsFetchedMsg{
 		gen:          gen,
+		inRound:      true,
 		sessions:     make(map[string][]session.RemoteSessionInfo, 1),
 		costs:        make(map[string]*costs.RemoteCostSummary, 1),
 		groups:       make(map[string][]string, 1),

--- a/internal/ui/remote_per_host_delivery_test.go
+++ b/internal/ui/remote_per_host_delivery_test.go
@@ -7,6 +7,7 @@ package ui
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -208,6 +209,7 @@ func TestRemoteFetch_ActiveClearsWhenLastResultLands(t *testing.T) {
 	result := func(name string, other string) remoteSessionsFetchedMsg {
 		return remoteSessionsFetchedMsg{
 			gen:      1,
+			inRound:  true,
 			sessions: map[string][]session.RemoteSessionInfo{name: {}},
 			failed:   map[string]bool{other: true},
 		}
@@ -217,9 +219,17 @@ func TestRemoteFetch_ActiveClearsWhenLastResultLands(t *testing.T) {
 	if !h.remotesFetchActive {
 		t.Fatal("one of two results must leave the round in flight")
 	}
+	// A config error from a refetch started outside this round must not
+	// take the slow remote's slot: the round is still in flight.
+	model, _ = h.Update(remoteSessionsFetchedMsg{gen: 2, configErr: errors.New("toml: bad key")})
+	h = model.(*Home)
+	if !h.remotesFetchActive {
+		t.Fatal("a message from outside the round must not end it while a fetch is outstanding")
+	}
 	// A pushed change in between is not part of the round.
 	pushed := result("a", "b")
 	pushed.pushed = true
+	pushed.inRound = false
 	model, _ = h.Update(pushed)
 	h = model.(*Home)
 	if !h.remotesFetchActive {
@@ -229,5 +239,38 @@ func TestRemoteFetch_ActiveClearsWhenLastResultLands(t *testing.T) {
 	h = model.(*Home)
 	if h.remotesFetchActive {
 		t.Fatal("the second of two results must end the round")
+	}
+}
+
+func TestRemoteFetch_DeconfiguredRemoteDoesNotReturnFromOlderRound(t *testing.T) {
+	home := newTestHomeWithItems(100, 30, nil)
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"gone": {{ID: "g-1", Title: "gone-cached", RemoteName: "gone"}},
+	}
+	// Round 6 was built from a config that no longer lists "gone": its
+	// only result names "a" and marks nobody else failed, so "gone" drops.
+	model, _ := home.Update(remoteSessionsFetchedMsg{
+		gen:      6,
+		inRound:  true,
+		sessions: map[string][]session.RemoteSessionInfo{"a": {{ID: "a-1", Title: "a-6"}}},
+		failed:   map[string]bool{},
+	})
+	h := model.(*Home)
+	if got := remoteTitles(h, "gone"); len(got) != 0 {
+		t.Fatalf("a remote absent from the config must drop; got %v", got)
+	}
+	// A slow result for "gone" from the older round 5 lands afterwards.
+	model, _ = h.Update(remoteSessionsFetchedMsg{
+		gen:      5,
+		inRound:  true,
+		sessions: map[string][]session.RemoteSessionInfo{"gone": {{ID: "g-2", Title: "gone-5"}}},
+		failed:   map[string]bool{"a": true},
+	})
+	h = model.(*Home)
+	if got := remoteTitles(h, "gone"); len(got) != 0 {
+		t.Fatalf("an older round's result must not resurrect a deconfigured remote; got %v", got)
+	}
+	if got := remoteTitles(h, "a"); len(got) != 1 || got[0] != "a-6" {
+		t.Fatalf("the newer round's rows must stay; got %v", got)
 	}
 }

--- a/internal/ui/remote_per_host_delivery_test.go
+++ b/internal/ui/remote_per_host_delivery_test.go
@@ -1,0 +1,233 @@
+// Per-remote delivery of fleet polls (#2177 follow-up): each remote's
+// answer lands on its own, so a slow or wedged host cannot hold back the
+// others; the stale-result guard, the in-flight guard and the cost merge
+// all work per remote.
+
+package ui
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/costs"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// stubFetchRunner answers FetchSessions once release is closed (or at once
+// when release is nil).
+type stubFetchRunner struct {
+	name     string
+	sessions []session.RemoteSessionInfo
+	release  chan struct{}
+}
+
+func (s stubFetchRunner) FetchSessions(ctx context.Context) ([]session.RemoteSessionInfo, error) {
+	if s.release != nil {
+		select {
+		case <-s.release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return append([]session.RemoteSessionInfo(nil), s.sessions...), nil
+}
+
+func (s stubFetchRunner) FetchCostSummary(context.Context) (*costs.RemoteCostSummary, error) {
+	return &costs.RemoteCostSummary{}, nil
+}
+
+func (s stubFetchRunner) FetchGroupPaths(context.Context) ([]string, error) {
+	return []string{s.name}, nil
+}
+
+func runFetchCmds(cmds []tea.Cmd) <-chan remoteSessionsFetchedMsg {
+	out := make(chan remoteSessionsFetchedMsg, len(cmds))
+	for _, cmd := range cmds {
+		go func(cmd tea.Cmd) { out <- cmd().(remoteSessionsFetchedMsg) }(cmd)
+	}
+	return out
+}
+
+func TestRemoteFetch_SlowRemoteDoesNotDelayFastOne(t *testing.T) {
+	home := newTestHomeWithItems(100, 30, nil)
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"slow": {{ID: "s-old", Title: "slow-cached", RemoteName: "slow"}},
+	}
+	release := make(chan struct{})
+	home.newRemoteFetchRunner = func(name string, rc session.RemoteConfig) remoteFetchRunner {
+		if name == "slow" {
+			return stubFetchRunner{name: name, release: release, sessions: []session.RemoteSessionInfo{{ID: "s-new", Title: "slow-live"}}}
+		}
+		return stubFetchRunner{name: name, sessions: []session.RemoteSessionInfo{{ID: "f1", Title: "fast-live"}}}
+	}
+	remotes := map[string]session.RemoteConfig{"fast": {Host: "fast@x"}, "slow": {Host: "slow@x"}}
+
+	cmds := home.remoteFetchCmds(3, remotes)
+	model, _ := home.Update(remoteFetchRoundMsg{gen: 3, fetches: cmds})
+	h := model.(*Home)
+	if !h.remotesFetchActive {
+		t.Fatal("starting a round must raise the in-flight guard")
+	}
+
+	results := runFetchCmds(cmds)
+	var first remoteSessionsFetchedMsg
+	select {
+	case first = <-results:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the fast remote's result must arrive while the slow remote is still blocked")
+	}
+	if _, ok := first.sessions["fast"]; !ok {
+		t.Fatalf("first result must be the fast remote's; got sessions=%v failed=%v", first.sessions, first.failed)
+	}
+	if !first.failed["slow"] {
+		t.Fatal("a per-remote result must mark the other remotes failed so the merge keeps their rows")
+	}
+
+	model, _ = h.Update(first)
+	h = model.(*Home)
+	if got := remoteTitles(h, "fast"); len(got) != 1 || got[0] != "fast-live" {
+		t.Fatalf("fast remote must render before the slow one answers; got %v", got)
+	}
+	if got := remoteTitles(h, "slow"); len(got) != 1 || got[0] != "slow-cached" {
+		t.Fatalf("slow remote must keep its cached rows meanwhile; got %v", got)
+	}
+	if !h.remotesFetchActive {
+		t.Fatal("the round is not over while the slow remote is outstanding")
+	}
+	if got := h.remoteGroups["fast"]; len(got) != 1 || got[0] != "fast" {
+		t.Fatalf("fast remote's group list must land with its sessions; got %v", got)
+	}
+
+	close(release)
+	var second remoteSessionsFetchedMsg
+	select {
+	case second = <-results:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the slow remote's result must arrive once released")
+	}
+	model, _ = h.Update(second)
+	h = model.(*Home)
+	if got := remoteTitles(h, "slow"); len(got) != 1 || got[0] != "slow-live" {
+		t.Fatalf("slow remote must update when it finally answers; got %v", got)
+	}
+	if got := remoteTitles(h, "fast"); len(got) != 1 || got[0] != "fast-live" {
+		t.Fatalf("the slow remote's result must not disturb the fast remote's rows; got %v", got)
+	}
+	if h.remotesFetchActive {
+		t.Fatal("the last result of the round must release the in-flight guard")
+	}
+}
+
+func TestRemoteFetch_StaleGuardIsPerRemote(t *testing.T) {
+	home := newTestHomeWithItems(100, 30, nil)
+	perRemote := func(gen uint64, name, title string, others ...string) remoteSessionsFetchedMsg {
+		msg := remoteSessionsFetchedMsg{
+			gen:      gen,
+			sessions: map[string][]session.RemoteSessionInfo{name: {{ID: name + "-1", Title: title}}},
+			failed:   map[string]bool{},
+		}
+		for _, o := range others {
+			msg.failed[o] = true
+		}
+		return msg
+	}
+
+	// A newer round's fast answer lands first...
+	model, _ := home.Update(perRemote(6, "fast", "fast-6", "slow"))
+	h := model.(*Home)
+	// ...then the older round's slow answer: still the newest data for
+	// "slow", so it must apply rather than be dropped as stale.
+	model, _ = h.Update(perRemote(5, "slow", "slow-5", "fast"))
+	h = model.(*Home)
+	if got := remoteTitles(h, "slow"); len(got) != 1 || got[0] != "slow-5" {
+		t.Fatalf("an older-round result for a remote with nothing newer applied must land; got %v", got)
+	}
+	// An older answer for "fast" itself is stale and must be ignored.
+	model, _ = h.Update(perRemote(5, "fast", "fast-5", "slow"))
+	h = model.(*Home)
+	if got := remoteTitles(h, "fast"); len(got) != 1 || got[0] != "fast-6" {
+		t.Fatalf("a result older than the last applied one for the same remote must be ignored; got %v", got)
+	}
+}
+
+func TestRemoteFetch_CostsMergePerRemote(t *testing.T) {
+	home := newTestHomeWithItems(100, 30, nil)
+	home.remoteCosts = map[string]*costs.RemoteCostSummary{
+		"a": {CostTodayMicrodollars: 1},
+		"b": {CostTodayMicrodollars: 2},
+	}
+	rows := func(name string) map[string][]session.RemoteSessionInfo {
+		return map[string][]session.RemoteSessionInfo{name: {{ID: name + "-1", Title: name}}}
+	}
+
+	// a answers with a fresh summary: b's figure must survive.
+	model, _ := home.Update(remoteSessionsFetchedMsg{
+		sessions: rows("a"),
+		costs:    map[string]*costs.RemoteCostSummary{"a": {CostTodayMicrodollars: 10}},
+		failed:   map[string]bool{"b": true},
+	})
+	h := model.(*Home)
+	if h.remoteCosts["a"].CostTodayMicrodollars != 10 || h.remoteCosts["b"] == nil || h.remoteCosts["b"].CostTodayMicrodollars != 2 {
+		t.Fatalf("a per-remote cost update must not blank other remotes; got %+v", h.remoteCosts)
+	}
+
+	// a answers but its cost fetch failed: a contributes zero, b untouched.
+	model, _ = h.Update(remoteSessionsFetchedMsg{
+		sessions: rows("a"),
+		costs:    map[string]*costs.RemoteCostSummary{},
+		failed:   map[string]bool{"b": true},
+	})
+	h = model.(*Home)
+	if _, ok := h.remoteCosts["a"]; ok {
+		t.Fatalf("a remote whose cost fetch failed must contribute zero; got %+v", h.remoteCosts)
+	}
+	if h.remoteCosts["b"] == nil {
+		t.Fatalf("a remote still marked failed must keep its last-good figure; got %+v", h.remoteCosts)
+	}
+
+	// b is no longer configured (absent from both lists): its figure goes.
+	model, _ = h.Update(remoteSessionsFetchedMsg{
+		sessions: rows("a"),
+		costs:    map[string]*costs.RemoteCostSummary{"a": {CostTodayMicrodollars: 11}},
+		failed:   map[string]bool{},
+	})
+	h = model.(*Home)
+	if _, ok := h.remoteCosts["b"]; ok {
+		t.Fatalf("a deconfigured remote must drop out of the cost map; got %+v", h.remoteCosts)
+	}
+}
+
+func TestRemoteFetch_ActiveClearsWhenLastResultLands(t *testing.T) {
+	home := newTestHomeWithItems(100, 30, nil)
+	noop := func() tea.Msg { return nil }
+	model, _ := home.Update(remoteFetchRoundMsg{gen: 1, fetches: []tea.Cmd{noop, noop}})
+	h := model.(*Home)
+	result := func(name string, other string) remoteSessionsFetchedMsg {
+		return remoteSessionsFetchedMsg{
+			gen:      1,
+			sessions: map[string][]session.RemoteSessionInfo{name: {}},
+			failed:   map[string]bool{other: true},
+		}
+	}
+	model, _ = h.Update(result("a", "b"))
+	h = model.(*Home)
+	if !h.remotesFetchActive {
+		t.Fatal("one of two results must leave the round in flight")
+	}
+	// A pushed change in between is not part of the round.
+	pushed := result("a", "b")
+	pushed.pushed = true
+	model, _ = h.Update(pushed)
+	h = model.(*Home)
+	if !h.remotesFetchActive {
+		t.Fatal("a pushed change must not count as a round result")
+	}
+	model, _ = h.Update(result("b", "a"))
+	h = model.(*Home)
+	if h.remotesFetchActive {
+		t.Fatal("the second of two results must end the round")
+	}
+}


### PR DESCRIPTION
## What problem does this solve?
The remote agent (#2177) noticed a state change by running `list --json` and `group list --json` as subprocesses, which was most of the ~1.2 s between a change on the remote and the local screen. Item 2 of the remote latency plan (#2174). Stacked on #2181 (per-host delivery); merge that first.

## Why this change
`handleList`'s and `handleGroupList`'s JSON building are extracted into `buildListJSON` and `buildGroupListJSON`, which the CLI handlers still call (output byte-identical, proven by a test that runs the built binary). The agent opens the profile's storage once and, on a stamp change, loads and refreshes once and builds both listings in-process; content-hash gating and the seeded first hash are kept; a probe error pushes a bare "changed" so the TUI refetches. The event carries `probe_ms` and the client logs it, so the gain is visible. Requests still run as subprocesses (exact CLI semantics).

## User impact
A change on a remote reaches the local TUI in roughly a third of the time; the box does not boot the CLI twice per change.

## Evidence
Implemented and adversarially reviewed by separate agents; tests `TestRemoteAgent_InProcessProbeMatchesCLI` (byte-for-byte parity with `list --json` and `group list --json`), `TestRemoteAgent_ProbeTimingAndFailureFallback`, plus the existing agent, session and `cmd/agent-deck` group/list tests pass in the Docker test image. Local go test is disallowed on this host.

## AI disclosure
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5-1

## What actually bothered you
My human asked: "such that it stays quick like realtime, seamless without any lag".

## Checklist
- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5-1 intent=yes -->