### PR TITLE
feat(remote): push the focused session's pane over the channel instead of polling it

### DIFF
--- a/cmd/agent-deck/remote_agent_cmd.go
+++ b/cmd/agent-deck/remote_agent_cmd.go
@@ -39,10 +39,23 @@ import (
 // storage and refreshing every status, was most of the second between a
 // change on the remote and the local screen; the event carries the probe's
 // duration as probe_ms so that cost stays visible.
+//
+// Pane watch (#2177 follow-up): {"id":2,"watch":"<sessionID>"} asks the
+// agent to follow one session's tmux pane. The agent captures it in-process
+// every ~300ms and pushes {"event":"pane","session":"<id>","stdout":<text>}
+// whenever the capture differs from the last push (the first capture is
+// always pushed); a capture failure is pushed once as {"event":"pane",
+// "session":"<id>","error":"..."}. Only one session is watched at a time:
+// a new watch replaces the previous one, {"id":3,"unwatch":true} stops it,
+// and closing stdin stops it. Both are acknowledged with {"id":N,"code":0}.
+// The local TUI uses this for the preview pane of the focused remote row
+// instead of polling `session output --pane` over ssh.
 
 type remoteAgentRequest struct {
-	ID   int64    `json:"id"`
-	Args []string `json:"args"`
+	ID      int64    `json:"id"`
+	Args    []string `json:"args,omitempty"`
+	Watch   string   `json:"watch,omitempty"`
+	Unwatch bool     `json:"unwatch,omitempty"`
 }
 
 type remoteAgentReply struct {
@@ -58,12 +71,19 @@ type remoteAgentReply struct {
 	Groups   string `json:"groups,omitempty"`
 	// ProbeMS is how long the "changed" event's listings took to build.
 	ProbeMS int64 `json:"probe_ms,omitempty"`
+	// A "pane" event names the watched session; its text is in Stdout.
+	Session string `json:"session,omitempty"`
 }
 
 // remoteAgentProbeFunc builds the current `list --json` and `group list
 // --json` bodies for the change feed. The in-process one is the default;
 // tests inject their own.
 type remoteAgentProbeFunc func() (listJSON, groupJSON string, err error)
+
+// remoteAgentPaneEvery is how often the watched session's pane is captured.
+// Pushes only go out when the text changed, so an idle pane costs one local
+// capture per tick and nothing on the wire.
+const remoteAgentPaneEvery = 300 * time.Millisecond
 
 // remoteAgentDeniedVerbs are never run through the channel: they need a
 // terminal, or must not be reachable from a remote TUI at all.
@@ -78,6 +98,8 @@ func handleRemoteAgent(profile string, args []string) {
 			fmt.Println()
 			fmt.Println("Serve JSON-line requests on stdin for a local agent-deck TUI (one persistent")
 			fmt.Println("channel per remote) and push {\"event\":\"changed\"} when the profile's state changes.")
+			fmt.Println("{\"id\":N,\"watch\":\"<session>\"} follows one session's pane ({\"event\":\"pane\"} on change);")
+			fmt.Println("{\"id\":N,\"unwatch\":true} stops it.")
 			return
 		}
 	}
@@ -119,7 +141,7 @@ func handleRemoteAgent(profile string, args []string) {
 		}
 		return out.String(), errb.String(), code
 	}
-	serveRemoteAgent(context.Background(), os.Stdin, os.Stdout, runner, probe, dbPath, 250*time.Millisecond)
+	serveRemoteAgent(context.Background(), os.Stdin, os.Stdout, runner, probe, dbPath, 250*time.Millisecond, remoteAgentPaneCapturer(profile), remoteAgentPaneEvery)
 }
 
 // newRemoteAgentProbe opens the profile's storage once and returns a probe
@@ -151,9 +173,57 @@ func newRemoteAgentProbe(profile string) (remoteAgentProbeFunc, func(), error) {
 	return probe, func() { _ = storage.Close() }, nil
 }
 
+// remoteAgentPaneCapturer returns a capture func that reads the watched
+// session's pane in-process: the session list is loaded once per watched
+// session (and again, at most every few seconds, when the session cannot be
+// captured, so a session that starts or restarts after the watch began is
+// picked up), then every tick is one tmux capture, no subprocess of this
+// binary and no DB read.
+func remoteAgentPaneCapturer(profile string) func(context.Context, string) (string, error) {
+	var (
+		mu       sync.Mutex
+		loadedID string
+		loaded   *session.Instance
+		loadedAt time.Time
+	)
+	const reloadAfter = 5 * time.Second
+	find := func(sessionID string) (*session.Instance, error) {
+		_, instances, _, err := loadSessionData(profile)
+		if err != nil {
+			return nil, err
+		}
+		for _, inst := range instances {
+			if inst.ID == sessionID {
+				return inst, nil
+			}
+		}
+		return nil, fmt.Errorf("session '%s' not found", sessionID)
+	}
+	return func(_ context.Context, sessionID string) (string, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if loadedID != sessionID || (loaded == nil && time.Since(loadedAt) > reloadAfter) {
+			loadedID, loadedAt = sessionID, time.Now()
+			loaded, _ = find(sessionID)
+		}
+		if loaded == nil {
+			return "", fmt.Errorf("session '%s' not found", sessionID)
+		}
+		content, err := loaded.PreviewFull()
+		if err != nil && time.Since(loadedAt) > reloadAfter {
+			// The pane may belong to a restarted session: reload once the
+			// grace period is over instead of failing forever.
+			loaded = nil
+		}
+		return content, err
+	}
+}
+
 // serveRemoteAgent is the agent loop, separated from process wiring so it is
-// testable with pipes. It returns when stdin closes.
-func serveRemoteAgent(ctx context.Context, in io.Reader, out io.Writer, run func(context.Context, []string) (string, string, int), probe remoteAgentProbeFunc, watchPath string, watchEvery time.Duration) {
+// testable with pipes. It returns when stdin closes. capture reads one
+// session's pane text for the pane watch; nil disables watching (a watch
+// request is then answered with an error).
+func serveRemoteAgent(ctx context.Context, in io.Reader, out io.Writer, run func(context.Context, []string) (string, string, int), probe remoteAgentProbeFunc, watchPath string, watchEvery time.Duration, capture func(context.Context, string) (string, error), paneEvery time.Duration) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	var wmu sync.Mutex
@@ -212,6 +282,39 @@ func serveRemoteAgent(ctx context.Context, in io.Reader, out io.Writer, run func
 		}()
 	}
 
+	// Pane watch: one goroutine at a time, replaced by the next watch and
+	// stopped by unwatch or by stdin closing (ctx).
+	var (
+		watchMu     sync.Mutex
+		stopWatch   context.CancelFunc
+		watchDone   chan struct{}
+		watchTarget string
+	)
+	setWatch := func(sessionID string) {
+		watchMu.Lock()
+		defer watchMu.Unlock()
+		if sessionID == watchTarget {
+			return
+		}
+		if stopWatch != nil {
+			stopWatch()
+			<-watchDone
+			stopWatch, watchDone = nil, nil
+		}
+		watchTarget = sessionID
+		if sessionID == "" {
+			return
+		}
+		wctx, wcancel := context.WithCancel(ctx)
+		done := make(chan struct{})
+		stopWatch, watchDone = wcancel, done
+		go func() {
+			defer close(done)
+			watchRemotePane(wctx, sessionID, capture, paneEvery, write)
+		}()
+	}
+	defer setWatch("")
+
 	var wg sync.WaitGroup
 	sc := bufio.NewScanner(in)
 	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
@@ -223,6 +326,21 @@ func serveRemoteAgent(ctx context.Context, in io.Reader, out io.Writer, run func
 		var req remoteAgentRequest
 		if err := json.Unmarshal([]byte(line), &req); err != nil {
 			write(remoteAgentReply{Code: 2, Error: "bad request: " + err.Error()})
+			continue
+		}
+		if req.Watch != "" || req.Unwatch {
+			switch {
+			case capture == nil:
+				write(remoteAgentReply{ID: req.ID, Code: 2, Error: "pane watch not available"})
+			case req.Unwatch:
+				setWatch("")
+				write(remoteAgentReply{ID: req.ID})
+			default:
+				// Acknowledge first so the first pane push always follows
+				// the ack on the wire.
+				write(remoteAgentReply{ID: req.ID})
+				setWatch(req.Watch)
+			}
 			continue
 		}
 		if !remoteAgentArgsAllowed(req.Args) {
@@ -240,6 +358,39 @@ func serveRemoteAgent(ctx context.Context, in io.Reader, out io.Writer, run func
 	}
 	cancel()
 	wg.Wait()
+}
+
+// watchRemotePane captures sessionID's pane every paneEvery until ctx ends
+// and pushes a "pane" event when the text (or the failure) differs from the
+// last push. The first capture is always pushed so the watcher starts with
+// the current screen.
+func watchRemotePane(ctx context.Context, sessionID string, capture func(context.Context, string) (string, error), paneEvery time.Duration, write func(remoteAgentReply)) {
+	var lastHash string
+	first := true
+	t := time.NewTicker(paneEvery)
+	defer t.Stop()
+	for {
+		content, err := capture(ctx, sessionID)
+		if ctx.Err() != nil {
+			return
+		}
+		reply := remoteAgentReply{Event: "pane", Session: sessionID, Stdout: content}
+		if err != nil {
+			reply = remoteAgentReply{Event: "pane", Session: sessionID, Error: err.Error()}
+		}
+		sum := sha256.Sum256([]byte(reply.Error + "\x00" + reply.Stdout))
+		h := hex.EncodeToString(sum[:8])
+		if first || h != lastHash {
+			first = false
+			lastHash = h
+			write(reply)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+		}
+	}
 }
 
 // remoteAgentArgsAllowed admits only a known CLI verb that is not on the

--- a/cmd/agent-deck/remote_agent_cmd.go
+++ b/cmd/agent-deck/remote_agent_cmd.go
@@ -40,14 +40,17 @@ import (
 // change on the remote and the local screen; the event carries the probe's
 // duration as probe_ms so that cost stays visible.
 //
-// Pane watch (#2177 follow-up): {"id":2,"watch":"<sessionID>"} asks the
-// agent to follow one session's tmux pane. The agent captures it in-process
-// every ~300ms and pushes {"event":"pane","session":"<id>","stdout":<text>}
-// whenever the capture differs from the last push (the first capture is
-// always pushed); a capture failure is pushed once as {"event":"pane",
-// "session":"<id>","error":"..."}. Only one session is watched at a time:
-// a new watch replaces the previous one, {"id":3,"unwatch":true} stops it,
-// and closing stdin stops it. Both are acknowledged with {"id":N,"code":0}.
+// Pane watch (#2177 follow-up): {"id":2,"watch":"<sessionID>","lines":200}
+// asks the agent to follow one session's tmux pane. The agent captures it
+// in-process every ~300ms, keeps the last "lines" lines (all of them when
+// the field is absent) and pushes {"event":"pane","session":"<id>",
+// "stdout":<text>} whenever that text differs from the last push (the
+// first capture is always pushed); a capture failure is pushed once as
+// {"event":"pane","session":"<id>","error":"..."}. Only one session is
+// watched at a time: a new watch replaces the previous one (a watch for the
+// session already watched restarts it, so the current screen is pushed
+// again), {"id":3,"unwatch":true} stops it, and closing stdin stops it.
+// Both are acknowledged with {"id":N,"code":0}.
 // The local TUI uses this for the preview pane of the focused remote row
 // instead of polling `session output --pane` over ssh.
 
@@ -55,6 +58,7 @@ type remoteAgentRequest struct {
 	ID      int64    `json:"id"`
 	Args    []string `json:"args,omitempty"`
 	Watch   string   `json:"watch,omitempty"`
+	Lines   int      `json:"lines,omitempty"`
 	Unwatch bool     `json:"unwatch,omitempty"`
 }
 
@@ -98,7 +102,7 @@ func handleRemoteAgent(profile string, args []string) {
 			fmt.Println()
 			fmt.Println("Serve JSON-line requests on stdin for a local agent-deck TUI (one persistent")
 			fmt.Println("channel per remote) and push {\"event\":\"changed\"} when the profile's state changes.")
-			fmt.Println("{\"id\":N,\"watch\":\"<session>\"} follows one session's pane ({\"event\":\"pane\"} on change);")
+			fmt.Println("{\"id\":N,\"watch\":\"<session>\",\"lines\":200} follows one session's pane ({\"event\":\"pane\"} on change);")
 			fmt.Println("{\"id\":N,\"unwatch\":true} stops it.")
 			return
 		}
@@ -188,10 +192,13 @@ func remoteAgentPaneCapturer(profile string) func(context.Context, string) (stri
 	)
 	const reloadAfter = 5 * time.Second
 	find := func(sessionID string) (*session.Instance, error) {
-		_, instances, _, err := loadSessionData(profile)
+		storage, instances, _, err := loadSessionData(profile)
 		if err != nil {
 			return nil, err
 		}
+		// The instances are fully in memory; this process lives as long as
+		// the channel, so the DB handle must not be left open per reload.
+		_ = storage.Close()
 		for _, inst := range instances {
 			if inst.ID == sessionID {
 				return inst, nil
@@ -282,26 +289,23 @@ func serveRemoteAgent(ctx context.Context, in io.Reader, out io.Writer, run func
 		}()
 	}
 
-	// Pane watch: one goroutine at a time, replaced by the next watch and
+	// Pane watch: one goroutine at a time, replaced by the next watch
+	// (every watch request starts afresh, so the peer always gets the
+	// current screen back even when it re-asks for the same session) and
 	// stopped by unwatch or by stdin closing (ctx).
 	var (
-		watchMu     sync.Mutex
-		stopWatch   context.CancelFunc
-		watchDone   chan struct{}
-		watchTarget string
+		watchMu   sync.Mutex
+		stopWatch context.CancelFunc
+		watchDone chan struct{}
 	)
-	setWatch := func(sessionID string) {
+	setWatch := func(sessionID string, lines int) {
 		watchMu.Lock()
 		defer watchMu.Unlock()
-		if sessionID == watchTarget {
-			return
-		}
 		if stopWatch != nil {
 			stopWatch()
 			<-watchDone
 			stopWatch, watchDone = nil, nil
 		}
-		watchTarget = sessionID
 		if sessionID == "" {
 			return
 		}
@@ -310,10 +314,10 @@ func serveRemoteAgent(ctx context.Context, in io.Reader, out io.Writer, run func
 		stopWatch, watchDone = wcancel, done
 		go func() {
 			defer close(done)
-			watchRemotePane(wctx, sessionID, capture, paneEvery, write)
+			watchRemotePane(wctx, sessionID, lines, capture, paneEvery, write)
 		}()
 	}
-	defer setWatch("")
+	defer setWatch("", 0)
 
 	var wg sync.WaitGroup
 	sc := bufio.NewScanner(in)
@@ -333,13 +337,13 @@ func serveRemoteAgent(ctx context.Context, in io.Reader, out io.Writer, run func
 			case capture == nil:
 				write(remoteAgentReply{ID: req.ID, Code: 2, Error: "pane watch not available"})
 			case req.Unwatch:
-				setWatch("")
+				setWatch("", 0)
 				write(remoteAgentReply{ID: req.ID})
 			default:
 				// Acknowledge first so the first pane push always follows
 				// the ack on the wire.
 				write(remoteAgentReply{ID: req.ID})
-				setWatch(req.Watch)
+				setWatch(req.Watch, req.Lines)
 			}
 			continue
 		}
@@ -362,9 +366,11 @@ func serveRemoteAgent(ctx context.Context, in io.Reader, out io.Writer, run func
 
 // watchRemotePane captures sessionID's pane every paneEvery until ctx ends
 // and pushes a "pane" event when the text (or the failure) differs from the
-// last push. The first capture is always pushed so the watcher starts with
-// the current screen.
-func watchRemotePane(ctx context.Context, sessionID string, capture func(context.Context, string) (string, error), paneEvery time.Duration, write func(remoteAgentReply)) {
+// last push. Only the last lines lines are kept (all when lines <= 0): the
+// capture is up to 2000 lines of scrollback and a busy pane changes on
+// every tick, so the peer says how much of it it renders. The first capture
+// is always pushed so the watcher starts with the current screen.
+func watchRemotePane(ctx context.Context, sessionID string, lines int, capture func(context.Context, string) (string, error), paneEvery time.Duration, write func(remoteAgentReply)) {
 	var lastHash string
 	first := true
 	t := time.NewTicker(paneEvery)
@@ -374,7 +380,7 @@ func watchRemotePane(ctx context.Context, sessionID string, capture func(context
 		if ctx.Err() != nil {
 			return
 		}
-		reply := remoteAgentReply{Event: "pane", Session: sessionID, Stdout: content}
+		reply := remoteAgentReply{Event: "pane", Session: sessionID, Stdout: tailLines(content, lines)}
 		if err != nil {
 			reply = remoteAgentReply{Event: "pane", Session: sessionID, Error: err.Error()}
 		}
@@ -391,6 +397,25 @@ func watchRemotePane(ctx context.Context, sessionID string, capture func(context
 		case <-t.C:
 		}
 	}
+}
+
+// tailLines keeps the last n lines of s (all of s when n <= 0).
+func tailLines(s string, n int) string {
+	if n <= 0 || s == "" {
+		return s
+	}
+	end := len(s)
+	if strings.HasSuffix(s, "\n") {
+		end--
+	}
+	for i := 0; i < n; i++ {
+		cut := strings.LastIndexByte(s[:end], '\n')
+		if cut < 0 {
+			return s
+		}
+		end = cut
+	}
+	return s[end+1:]
 }
 
 // remoteAgentArgsAllowed admits only a known CLI verb that is not on the

--- a/cmd/agent-deck/remote_agent_cmd_test.go
+++ b/cmd/agent-deck/remote_agent_cmd_test.go
@@ -295,6 +295,30 @@ func TestRemoteAgent_WatchPushesPaneOnChange(t *testing.T) {
 		t.Fatalf("changed pane push = %+v", r)
 	}
 
+	// Asking again for the watched session restarts the watch: the current
+	// screen is pushed again even though it did not change (the local side
+	// re-asks after a lost ack and needs a frame to start from).
+	send(remoteAgentRequest{ID: 5, Watch: "s1"})
+	if r := next("rewatch ack"); r.ID != 5 || r.Code != 0 {
+		t.Fatalf("rewatch ack = %+v", r)
+	}
+	if r := next("pane after rewatch"); r.Event != "pane" || r.Session != "s1" || r.Stdout != "one-b" {
+		t.Fatalf("a repeated watch must push the current screen again, got %+v", r)
+	}
+
+	// The peer says how many lines it renders; the push keeps only those.
+	setPane("s1", "l1\nl2\nl3\nl4\n")
+	send(remoteAgentRequest{ID: 6, Watch: "s1", Lines: 2})
+	if r := next("lines ack"); r.ID != 6 || r.Code != 0 {
+		t.Fatalf("lines watch ack = %+v", r)
+	}
+	if r := next("trimmed pane"); r.Event != "pane" || r.Stdout != "l3\nl4\n" {
+		t.Fatalf("pane push must be trimmed to the last 2 lines, got %q", r.Stdout)
+	}
+	// A change above the kept tail is not a change on the wire.
+	setPane("s1", "L1\nl2\nl3\nl4\n")
+	noneWithin(50*time.Millisecond, "silence when only trimmed lines changed")
+
 	// Replacing the watch: s2's screen arrives, s1 changes go unnoticed.
 	send(remoteAgentRequest{ID: 2, Watch: "s2"})
 	if r := next("watch ack"); r.ID != 2 || r.Code != 0 {
@@ -353,4 +377,27 @@ func TestRemoteAgent_WatchRefusedWithoutCapture(t *testing.T) {
 		t.Fatalf("watch without capture must be refused with an error, got %+v", r)
 	}
 	_ = inW.Close()
+}
+
+func TestTailLines(t *testing.T) {
+	cases := []struct {
+		in   string
+		n    int
+		want string
+	}{
+		{"", 3, ""},
+		{"a", 3, "a"},
+		{"a\nb\nc", 0, "a\nb\nc"},
+		{"a\nb\nc", 5, "a\nb\nc"},
+		{"a\nb\nc", 2, "b\nc"},
+		{"a\nb\nc\n", 2, "b\nc\n"},
+		{"a\nb\nc", 1, "c"},
+		{"\nb", 1, "b"},
+		{"\n", 1, "\n"},
+	}
+	for _, c := range cases {
+		if got := tailLines(c.in, c.n); got != c.want {
+			t.Errorf("tailLines(%q, %d) = %q, want %q", c.in, c.n, got, c.want)
+		}
+	}
 }

--- a/cmd/agent-deck/remote_agent_cmd_test.go
+++ b/cmd/agent-deck/remote_agent_cmd_test.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -47,7 +49,7 @@ func TestRemoteAgent_RequestsEventsAndDenyList(t *testing.T) {
 	}
 	done := make(chan struct{})
 	go func() {
-		serveRemoteAgent(context.Background(), inR, outW, run, probe, db, 20*time.Millisecond)
+		serveRemoteAgent(context.Background(), inR, outW, run, probe, db, 20*time.Millisecond, nil, 0)
 		_ = outW.Close()
 		close(done)
 	}()
@@ -140,7 +142,7 @@ func TestRemoteAgent_ProbeTimingAndFailureFallback(t *testing.T) {
 	}
 	done := make(chan struct{})
 	go func() {
-		serveRemoteAgent(context.Background(), inR, outW, run, probe, db, 20*time.Millisecond)
+		serveRemoteAgent(context.Background(), inR, outW, run, probe, db, 20*time.Millisecond, nil, 0)
 		_ = outW.Close()
 		close(done)
 	}()
@@ -201,4 +203,154 @@ func TestRemoteAgent_ProbeTimingAndFailureFallback(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("agent did not exit when stdin closed")
 	}
+}
+
+// A watch request starts pushing the session's pane: the first capture at
+// once, then only when the text changes; a new watch replaces the old one,
+// a capture failure is pushed once, and unwatch stops the pushes.
+func TestRemoteAgent_WatchPushesPaneOnChange(t *testing.T) {
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+	var mu sync.Mutex
+	panes := map[string]string{"s1": "one-a", "s2": "two-a"}
+	var captures atomic.Int32
+	capture := func(_ context.Context, id string) (string, error) {
+		captures.Add(1)
+		mu.Lock()
+		defer mu.Unlock()
+		p, ok := panes[id]
+		if !ok {
+			return "", errors.New("session '" + id + "' not found")
+		}
+		return p, nil
+	}
+	setPane := func(id, text string) {
+		mu.Lock()
+		panes[id] = text
+		mu.Unlock()
+	}
+	run := func(ctx context.Context, args []string) (string, string, int) { return "", "", 0 }
+	done := make(chan struct{})
+	go func() {
+		serveRemoteAgent(context.Background(), inR, outW, run, nil, "", 0, capture, 10*time.Millisecond)
+		_ = outW.Close()
+		close(done)
+	}()
+	sc := bufio.NewScanner(outR)
+	replies := make(chan remoteAgentReply, 64)
+	go func() {
+		for sc.Scan() {
+			var r remoteAgentReply
+			if json.Unmarshal(sc.Bytes(), &r) == nil {
+				replies <- r
+			}
+		}
+		close(replies)
+	}()
+	next := func(what string) remoteAgentReply {
+		t.Helper()
+		select {
+		case r, ok := <-replies:
+			if !ok {
+				t.Fatalf("agent closed while waiting for %s", what)
+			}
+			return r
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timeout waiting for %s", what)
+		}
+		return remoteAgentReply{}
+	}
+	noneWithin := func(d time.Duration, what string) {
+		t.Helper()
+		select {
+		case r := <-replies:
+			t.Fatalf("unexpected %+v while expecting %s", r, what)
+		case <-time.After(d):
+		}
+	}
+	send := func(req remoteAgentRequest) {
+		b, _ := json.Marshal(req)
+		if _, err := inW.Write(append(b, '\n')); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if r := next("ready"); r.Event != "ready" {
+		t.Fatalf("first line must announce ready, got %+v", r)
+	}
+
+	send(remoteAgentRequest{ID: 1, Watch: "s1"})
+	if r := next("watch ack"); r.ID != 1 || r.Code != 0 || r.Error != "" {
+		t.Fatalf("watch ack = %+v", r)
+	}
+	if r := next("first pane"); r.Event != "pane" || r.Session != "s1" || r.Stdout != "one-a" {
+		t.Fatalf("first pane push = %+v, want the current screen of s1", r)
+	}
+	// Unchanged pane: silence, however often it is captured.
+	noneWithin(60*time.Millisecond, "silence on an unchanged pane")
+	if captures.Load() < 3 {
+		t.Fatalf("the pane must be polled while watched, got %d captures", captures.Load())
+	}
+	setPane("s1", "one-b")
+	if r := next("changed pane"); r.Event != "pane" || r.Session != "s1" || r.Stdout != "one-b" {
+		t.Fatalf("changed pane push = %+v", r)
+	}
+
+	// Replacing the watch: s2's screen arrives, s1 changes go unnoticed.
+	send(remoteAgentRequest{ID: 2, Watch: "s2"})
+	if r := next("watch ack"); r.ID != 2 || r.Code != 0 {
+		t.Fatalf("second watch ack = %+v", r)
+	}
+	if r := next("pane of s2"); r.Event != "pane" || r.Session != "s2" || r.Stdout != "two-a" {
+		t.Fatalf("pane after rewatch = %+v", r)
+	}
+	setPane("s1", "one-c")
+	noneWithin(50*time.Millisecond, "silence for the replaced session")
+
+	// A capture failure is pushed once, as an error on the pane event.
+	mu.Lock()
+	delete(panes, "s2")
+	mu.Unlock()
+	if r := next("pane error"); r.Event != "pane" || r.Session != "s2" || !strings.Contains(r.Error, "not found") || r.Stdout != "" {
+		t.Fatalf("pane failure push = %+v", r)
+	}
+	noneWithin(50*time.Millisecond, "one push per distinct failure")
+
+	// Unwatch: acknowledged, then nothing more even when the pane changes.
+	send(remoteAgentRequest{ID: 3, Unwatch: true})
+	if r := next("unwatch ack"); r.ID != 3 || r.Code != 0 {
+		t.Fatalf("unwatch ack = %+v", r)
+	}
+	setPane("s2", "two-b")
+	noneWithin(50*time.Millisecond, "silence after unwatch")
+
+	_ = inW.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("agent did not exit when stdin closed")
+	}
+}
+
+// An agent started without a capture func (or an old build, which sees a
+// request with no args) refuses the watch so the local side keeps polling.
+func TestRemoteAgent_WatchRefusedWithoutCapture(t *testing.T) {
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+	go func() {
+		serveRemoteAgent(context.Background(), inR, outW, func(context.Context, []string) (string, string, int) { return "", "", 0 }, nil, "", 0, nil, 0)
+		_ = outW.Close()
+	}()
+	sc := bufio.NewScanner(outR)
+	sc.Scan() // ready
+	b, _ := json.Marshal(remoteAgentRequest{ID: 4, Watch: "s1"})
+	_, _ = inW.Write(append(b, '\n'))
+	if !sc.Scan() {
+		t.Fatal("no reply")
+	}
+	var r remoteAgentReply
+	_ = json.Unmarshal(sc.Bytes(), &r)
+	if r.ID != 4 || r.Code == 0 || r.Error == "" {
+		t.Fatalf("watch without capture must be refused with an error, got %+v", r)
+	}
+	_ = inW.Close()
 }

--- a/cmd/agent-deck/remote_agent_cmd_test.go
+++ b/cmd/agent-deck/remote_agent_cmd_test.go
@@ -21,7 +21,7 @@ import (
 func TestRemoteAgent_RequestsEventsAndDenyList(t *testing.T) {
 	dir := t.TempDir()
 	db := filepath.Join(dir, "state.db")
-	if err := os.WriteFile(db, []byte("v1"), 0o600); err != nil {
+	if err := writeFileAtomic(db, "v1"); err != nil {
 		t.Fatal(err)
 	}
 	inR, inW := io.Pipe()
@@ -90,7 +90,7 @@ func TestRemoteAgent_RequestsEventsAndDenyList(t *testing.T) {
 	// A write that does not change the listing (same content, new mtime)
 	// produces no event; a write that does produces one.
 	time.Sleep(30 * time.Millisecond)
-	if err := os.WriteFile(db, []byte("v1"), 0o600); err != nil {
+	if err := writeFileAtomic(db, "v1"); err != nil {
 		t.Fatal(err)
 	}
 	time.Sleep(120 * time.Millisecond)
@@ -98,7 +98,7 @@ func TestRemoteAgent_RequestsEventsAndDenyList(t *testing.T) {
 	if r := next(); r.ID != 10 || r.Event != "" {
 		t.Fatalf("a content-preserving write must not push an event; got %+v before the noop reply", r)
 	}
-	if err := os.WriteFile(db, []byte("v2-longer"), 0o600); err != nil {
+	if err := writeFileAtomic(db, "v2-longer"); err != nil {
 		t.Fatal(err)
 	}
 	deadline := time.After(2 * time.Second)
@@ -126,7 +126,7 @@ func TestRemoteAgent_RequestsEventsAndDenyList(t *testing.T) {
 func TestRemoteAgent_ProbeTimingAndFailureFallback(t *testing.T) {
 	dir := t.TempDir()
 	db := filepath.Join(dir, "state.db")
-	if err := os.WriteFile(db, []byte("v1"), 0o600); err != nil {
+	if err := writeFileAtomic(db, "v1"); err != nil {
 		t.Fatal(err)
 	}
 	inR, inW := io.Pipe()
@@ -175,7 +175,7 @@ func TestRemoteAgent_ProbeTimingAndFailureFallback(t *testing.T) {
 	}
 
 	time.Sleep(30 * time.Millisecond)
-	if err := os.WriteFile(db, []byte("v2-longer"), 0o600); err != nil {
+	if err := writeFileAtomic(db, "v2-longer"); err != nil {
 		t.Fatal(err)
 	}
 	r := next()
@@ -189,7 +189,7 @@ func TestRemoteAgent_ProbeTimingAndFailureFallback(t *testing.T) {
 	// The feed re-reads the stamp after a probe to absorb the probe's own
 	// writes; give it that moment so this write is not taken as seen.
 	time.Sleep(30 * time.Millisecond)
-	if err := os.WriteFile(db, []byte("broken"), 0o600); err != nil {
+	if err := writeFileAtomic(db, "broken"); err != nil {
 		t.Fatal(err)
 	}
 	r = next()
@@ -400,4 +400,14 @@ func TestTailLines(t *testing.T) {
 			t.Errorf("tailLines(%q, %d) = %q, want %q", c.in, c.n, got, c.want)
 		}
 	}
+}
+
+// writeFileAtomic replaces the watched file in one rename, so a probe running
+// concurrently never observes a truncated, half-written file.
+func writeFileAtomic(path, content string) error {
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(content), 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
 }

--- a/internal/session/remote_channel.go
+++ b/internal/session/remote_channel.go
@@ -51,6 +51,7 @@ type remoteChannelRequest struct {
 	ID      int64    `json:"id"`
 	Args    []string `json:"args,omitempty"`
 	Watch   string   `json:"watch,omitempty"`
+	Lines   int      `json:"lines,omitempty"`
 	Unwatch bool     `json:"unwatch,omitempty"`
 }
 
@@ -369,11 +370,12 @@ func (c *RemoteChannel) PaneWatchSupported() bool {
 
 // Watch asks the remote agent to push pane events for sessionID (replacing
 // any previous watch on this channel; the agent follows one pane at a
-// time). A watch already in place for the same session is a no-op. The
-// session is recorded as watched before the request goes out so concurrent
-// callers do not send it twice; a refusal by the agent clears it and marks
-// pane watching unsupported on this channel.
-func (c *RemoteChannel) Watch(ctx context.Context, sessionID string) error {
+// time), trimmed to the last lines lines (0 for the whole capture). A watch
+// already in place for the same session is a no-op. The session is recorded
+// as watched before the request goes out so concurrent callers do not send
+// it twice; a refusal by the agent clears it and marks pane watching
+// unsupported on this channel.
+func (c *RemoteChannel) Watch(ctx context.Context, sessionID string, lines int) error {
 	if sessionID == "" {
 		return c.Unwatch(ctx)
 	}
@@ -388,7 +390,7 @@ func (c *RemoteChannel) Watch(ctx context.Context, sessionID string) error {
 	}
 	c.watching = sessionID
 	c.mu.Unlock()
-	_, err := c.roundTrip(ctx, remoteChannelRequest{Watch: sessionID})
+	_, err := c.roundTrip(ctx, remoteChannelRequest{Watch: sessionID, Lines: lines})
 	if err != nil {
 		c.mu.Lock()
 		if c.watching == sessionID {

--- a/internal/session/remote_channel.go
+++ b/internal/session/remote_channel.go
@@ -38,11 +38,20 @@ type RemoteChannel struct {
 	lastAttempt      time.Time
 	backoff          time.Duration
 	dialing          bool
+	// watching is the session whose pane the remote agent is pushing for
+	// this channel ("" for none); reset when the transport drops, because
+	// the agent's watch dies with it. watchUnsupported is set when the
+	// agent answered a watch request with an error (a build that predates
+	// pane watching): the caller then polls the preview as before.
+	watching         string
+	watchUnsupported bool
 }
 
 type remoteChannelRequest struct {
-	ID   int64    `json:"id"`
-	Args []string `json:"args"`
+	ID      int64    `json:"id"`
+	Args    []string `json:"args,omitempty"`
+	Watch   string   `json:"watch,omitempty"`
+	Unwatch bool     `json:"unwatch,omitempty"`
 }
 
 type remoteChannelReply struct {
@@ -55,16 +64,28 @@ type remoteChannelReply struct {
 	Sessions string `json:"sessions,omitempty"`
 	Groups   string `json:"groups,omitempty"`
 	ProbeMS  int64  `json:"probe_ms,omitempty"`
+	Session  string `json:"session,omitempty"`
 }
 
-// RemoteChange is one pushed change from a remote. Sessions and Groups are
-// the remote's fresh listings when the agent sent them (nil when it did
-// not, in which case the receiver fetches).
+// RemoteChange is one pushed event from a remote. For a "changed" event,
+// Sessions and Groups are the remote's fresh listings when the agent sent
+// them (nil when it did not, in which case the receiver fetches). For a
+// "pane" event, Pane is set and the listing fields are empty.
 type RemoteChange struct {
 	Remote   string
 	Sessions []RemoteSessionInfo
 	Groups   []string
 	HasData  bool
+	Pane     *RemotePaneEvent
+}
+
+// RemotePaneEvent is one pushed pane capture for the watched session: the
+// pane text after a change, or the capture failure (Err) when the pane
+// could not be read.
+type RemotePaneEvent struct {
+	Session string
+	Content string
+	Err     string
 }
 
 // errChannelDown means the transport failed, not the remote command; callers
@@ -83,6 +104,15 @@ var (
 	remoteChannelsMu sync.Mutex
 	remoteChannels   = map[string]*RemoteChannel{}
 )
+
+// RemoteChannelFor returns the channel already opened for a named remote,
+// or nil when none has been started yet (the first command to that remote
+// starts it). It never dials.
+func RemoteChannelFor(name string) *RemoteChannel {
+	remoteChannelsMu.Lock()
+	defer remoteChannelsMu.Unlock()
+	return remoteChannels[name]
+}
 
 // remoteChannelsEnabled lets AGENT_DECK_REMOTE_CHANNEL=0 turn the channel off
 // (every command then runs as its own ssh exec, the pre-#2174 behaviour).
@@ -234,10 +264,11 @@ func (c *RemoteChannel) readLoop(r *bufio.Reader) {
 				slog.String("remote", c.name),
 				slog.Bool("pushed_data", strings.TrimSpace(reply.Sessions) != ""),
 				slog.Int64("probe_ms", reply.ProbeMS))
-			select {
-			case c.events <- c.changeFromReply(reply):
-			default:
-			}
+			c.publish(c.changeFromReply(reply))
+			continue
+		}
+		if reply.Event == "pane" {
+			c.publish(RemoteChange{Remote: c.name, Pane: &RemotePaneEvent{Session: reply.Session, Content: reply.Stdout, Err: reply.Error}})
 			continue
 		}
 		if reply.ID == 0 {
@@ -250,6 +281,16 @@ func (c *RemoteChannel) readLoop(r *bufio.Reader) {
 		if ok {
 			ch <- reply
 		}
+	}
+}
+
+// publish hands an event to the fan-in without ever blocking the reader: a
+// full buffer drops the event (a "changed" push is followed by a poll, a
+// "pane" push by the next change of that pane).
+func (c *RemoteChannel) publish(ch RemoteChange) {
+	select {
+	case c.events <- ch:
+	default:
 	}
 }
 
@@ -289,6 +330,7 @@ func (c *RemoteChannel) markDown() {
 		c.closeFn = nil
 	}
 	c.stdin = nil
+	c.watching = ""
 	pending := c.pending
 	c.pending = map[int64]chan remoteChannelReply{}
 	c.mu.Unlock()
@@ -301,11 +343,87 @@ func (c *RemoteChannel) markDown() {
 // stdout, or an error that names the exit status and stderr (the same shape
 // SSHRunner.run produces), or errChannelDown when the transport failed.
 func (c *RemoteChannel) Request(ctx context.Context, args []string) ([]byte, error) {
+	r, err := c.roundTrip(ctx, remoteChannelRequest{Args: args})
+	if err != nil {
+		return nil, err
+	}
+	return []byte(r.Stdout), nil
+}
+
+// Watching returns the session whose pane the remote is pushing over this
+// channel, or "" when none is (also after a reconnect: the agent's watch
+// did not survive, so the caller asks again).
+func (c *RemoteChannel) Watching() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.watching
+}
+
+// PaneWatchSupported is false once the remote agent refused a watch request
+// (older build); callers then keep polling the preview.
+func (c *RemoteChannel) PaneWatchSupported() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return !c.watchUnsupported
+}
+
+// Watch asks the remote agent to push pane events for sessionID (replacing
+// any previous watch on this channel; the agent follows one pane at a
+// time). A watch already in place for the same session is a no-op. The
+// session is recorded as watched before the request goes out so concurrent
+// callers do not send it twice; a refusal by the agent clears it and marks
+// pane watching unsupported on this channel.
+func (c *RemoteChannel) Watch(ctx context.Context, sessionID string) error {
+	if sessionID == "" {
+		return c.Unwatch(ctx)
+	}
+	c.mu.Lock()
+	if c.watchUnsupported {
+		c.mu.Unlock()
+		return errors.New("pane watch not supported by this remote")
+	}
+	if c.watching == sessionID {
+		c.mu.Unlock()
+		return nil
+	}
+	c.watching = sessionID
+	c.mu.Unlock()
+	_, err := c.roundTrip(ctx, remoteChannelRequest{Watch: sessionID})
+	if err != nil {
+		c.mu.Lock()
+		if c.watching == sessionID {
+			c.watching = ""
+		}
+		if !errors.Is(err, errChannelDown) && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			c.watchUnsupported = true
+		}
+		c.mu.Unlock()
+	}
+	return err
+}
+
+// Unwatch stops the pane watch on this channel, if any.
+func (c *RemoteChannel) Unwatch(ctx context.Context) error {
+	c.mu.Lock()
+	if c.watching == "" {
+		c.mu.Unlock()
+		return nil
+	}
+	c.watching = ""
+	c.mu.Unlock()
+	_, err := c.roundTrip(ctx, remoteChannelRequest{Unwatch: true})
+	return err
+}
+
+// roundTrip sends one request and waits for its reply, mapping a failed
+// command to the same error shape SSHRunner.run produces and a dead
+// transport to errChannelDown.
+func (c *RemoteChannel) roundTrip(ctx context.Context, req remoteChannelRequest) (remoteChannelReply, error) {
 	if !c.up.Load() {
 		// The channel outlives this request, so its dial is not bound to
 		// the request's context.
 		go c.ensureConnected() //nolint:gosec // see comment above
-		return nil, errChannelDown
+		return remoteChannelReply{}, errChannelDown
 	}
 	id := c.nextID.Add(1)
 	reply := make(chan remoteChannelReply, 1)
@@ -313,37 +431,38 @@ func (c *RemoteChannel) Request(ctx context.Context, args []string) ([]byte, err
 	stdin := c.stdin
 	if stdin == nil {
 		c.mu.Unlock()
-		return nil, errChannelDown
+		return remoteChannelReply{}, errChannelDown
 	}
 	c.pending[id] = reply
 	c.mu.Unlock()
 
-	line, _ := json.Marshal(remoteChannelRequest{ID: id, Args: args})
+	req.ID = id
+	line, _ := json.Marshal(req)
 	if _, err := stdin.Write(append(line, '\n')); err != nil {
 		c.markDown()
-		return nil, errChannelDown
+		return remoteChannelReply{}, errChannelDown
 	}
 	select {
 	case r := <-reply:
 		if r.Code == -1 && r.Error == errChannelDown.Error() {
-			return nil, errChannelDown
+			return r, errChannelDown
 		}
 		if r.Error != "" {
-			return nil, fmt.Errorf("ssh command failed: %s", r.Error)
+			return r, fmt.Errorf("ssh command failed: %s", r.Error)
 		}
 		if r.Code != 0 {
 			detail := r.Stderr
 			if strings.TrimSpace(detail) == "" {
 				detail = strings.TrimSpace(r.Stdout)
 			}
-			return nil, fmt.Errorf("ssh command failed: exit status %d: %s", r.Code, detail)
+			return r, fmt.Errorf("ssh command failed: exit status %d: %s", r.Code, detail)
 		}
-		return []byte(r.Stdout), nil
+		return r, nil
 	case <-ctx.Done():
 		c.mu.Lock()
 		delete(c.pending, id)
 		c.mu.Unlock()
-		return nil, ctx.Err()
+		return remoteChannelReply{}, ctx.Err()
 	}
 }
 

--- a/internal/session/remote_channel_test.go
+++ b/internal/session/remote_channel_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -18,8 +19,10 @@ type fakeAgentT struct {
 	push     func(string)
 	pushData func(string, string)
 	pushPane func(session, content, errText string)
-	// watched receives every watch ("<id>") and unwatch ("") request.
+	// watched receives every watch ("<id>") and unwatch ("") request;
+	// lines is what the last watch asked for.
 	watched chan string
+	lines   atomic.Int64
 	// refuseWatch makes the agent answer watch requests like an old build.
 	refuseWatch bool
 }
@@ -61,6 +64,7 @@ func newFakeAgent(t *testing.T, ready, refuseWatch bool) *fakeAgentT {
 					write(remoteChannelReply{ID: req.ID, Code: 2, Error: "verb not allowed over the channel"})
 					continue
 				}
+				a.lines.Store(int64(req.Lines))
 				a.watched <- req.Watch
 				write(remoteChannelReply{ID: req.ID})
 				continue
@@ -176,14 +180,17 @@ func TestRemoteChannel_WatchAndPaneEvents(t *testing.T) {
 			t.Fatalf("agent never received the watch request for %q", want)
 		}
 	}
-	if err := ch.Watch(ctx, "s1"); err != nil {
+	if err := ch.Watch(ctx, "s1", 200); err != nil {
 		t.Fatalf("Watch: %v", err)
 	}
 	expectWatched("s1")
 	if ch.Watching() != "s1" {
 		t.Fatalf("Watching = %q, want s1", ch.Watching())
 	}
-	if err := ch.Watch(ctx, "s1"); err != nil {
+	if got := agent.lines.Load(); got != 200 {
+		t.Fatalf("the watch request must carry the line budget, agent got %d", got)
+	}
+	if err := ch.Watch(ctx, "s1", 200); err != nil {
 		t.Fatalf("repeat Watch: %v", err)
 	}
 	select {
@@ -221,7 +228,7 @@ func TestRemoteChannel_WatchAndPaneEvents(t *testing.T) {
 		t.Fatal("changed push did not reach the events channel")
 	}
 
-	if err := ch.Watch(ctx, "s2"); err != nil {
+	if err := ch.Watch(ctx, "s2", 200); err != nil {
 		t.Fatalf("Watch s2: %v", err)
 	}
 	expectWatched("s2")
@@ -243,7 +250,7 @@ func TestRemoteChannel_WatchAndPaneEvents(t *testing.T) {
 
 	// The watch dies with the transport: after markDown nothing is watched,
 	// so the caller asks again once reconnected.
-	if err := ch.Watch(ctx, "s3"); err != nil {
+	if err := ch.Watch(ctx, "s3", 200); err != nil {
 		t.Fatalf("Watch s3: %v", err)
 	}
 	expectWatched("s3")
@@ -251,7 +258,7 @@ func TestRemoteChannel_WatchAndPaneEvents(t *testing.T) {
 	if ch.Watching() != "" {
 		t.Fatalf("Watching after the transport dropped = %q, want none", ch.Watching())
 	}
-	if err := ch.Watch(ctx, "s3"); !errors.Is(err, errChannelDown) {
+	if err := ch.Watch(ctx, "s3", 200); !errors.Is(err, errChannelDown) {
 		t.Fatalf("Watch on a down channel must report errChannelDown, got %v", err)
 	}
 	if !ch.PaneWatchSupported() {
@@ -267,14 +274,14 @@ func TestRemoteChannel_WatchRefusedMarksUnsupported(t *testing.T) {
 	ch.ensureConnected()
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	err := ch.Watch(ctx, "s1")
+	err := ch.Watch(ctx, "s1", 200)
 	if err == nil || errors.Is(err, errChannelDown) {
 		t.Fatalf("a refused watch must fail without looking like a transport failure, got %v", err)
 	}
 	if ch.Watching() != "" || ch.PaneWatchSupported() {
 		t.Fatalf("after a refusal: Watching=%q supported=%v, want none/false", ch.Watching(), ch.PaneWatchSupported())
 	}
-	if err := ch.Watch(ctx, "s2"); err == nil {
+	if err := ch.Watch(ctx, "s2", 200); err == nil {
 		t.Fatal("watch must not be retried on a remote that refused it")
 	}
 	if ch.Connected() {

--- a/internal/session/remote_channel_test.go
+++ b/internal/session/remote_channel_test.go
@@ -7,19 +7,42 @@ import (
 	"errors"
 	"io"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
 
+// fakeAgentT is the test's handle on a fake remote agent.
+type fakeAgentT struct {
+	dial     func(context.Context) (io.WriteCloser, io.Reader, func(), error)
+	push     func(string)
+	pushData func(string, string)
+	pushPane func(session, content, errText string)
+	// watched receives every watch ("<id>") and unwatch ("") request.
+	watched chan string
+	// refuseWatch makes the agent answer watch requests like an old build.
+	refuseWatch bool
+}
+
 // fakeAgent answers requests like the remote agent would, over pipes.
 func fakeAgent(t *testing.T, ready bool) (dial func(context.Context) (io.WriteCloser, io.Reader, func(), error), push func(string), pushData func(string, string)) {
 	t.Helper()
+	a := newFakeAgent(t, ready, false)
+	return a.dial, a.push, a.pushData
+}
+
+func newFakeAgent(t *testing.T, ready, refuseWatch bool) *fakeAgentT {
+	t.Helper()
 	inR, inW := io.Pipe()
 	outR, outW := io.Pipe()
+	var wmu sync.Mutex
 	write := func(v any) {
 		b, _ := json.Marshal(v)
+		wmu.Lock()
 		_, _ = outW.Write(append(b, '\n'))
+		wmu.Unlock()
 	}
+	a := &fakeAgentT{watched: make(chan string, 16), refuseWatch: refuseWatch}
 	go func() {
 		if ready {
 			write(remoteChannelReply{Event: "ready"})
@@ -33,6 +56,15 @@ func fakeAgent(t *testing.T, ready bool) (dial func(context.Context) (io.WriteCl
 			if json.Unmarshal(sc.Bytes(), &req) != nil {
 				continue
 			}
+			if req.Watch != "" || req.Unwatch {
+				if a.refuseWatch {
+					write(remoteChannelReply{ID: req.ID, Code: 2, Error: "verb not allowed over the channel"})
+					continue
+				}
+				a.watched <- req.Watch
+				write(remoteChannelReply{ID: req.ID})
+				continue
+			}
 			switch req.Args[0] {
 			case "fail":
 				write(remoteChannelReply{ID: req.ID, Code: 1, Stderr: "no such session"})
@@ -41,14 +73,17 @@ func fakeAgent(t *testing.T, ready bool) (dial func(context.Context) (io.WriteCl
 			}
 		}
 	}()
-	dial = func(context.Context) (io.WriteCloser, io.Reader, func(), error) {
+	a.dial = func(context.Context) (io.WriteCloser, io.Reader, func(), error) {
 		return inW, outR, func() { _ = inW.Close(); _ = outW.Close() }, nil
 	}
-	push = func(event string) { write(remoteChannelReply{Event: event}) }
-	pushData = func(sessions, groups string) {
+	a.push = func(event string) { write(remoteChannelReply{Event: event}) }
+	a.pushData = func(sessions, groups string) {
 		write(remoteChannelReply{Event: "changed", Sessions: sessions, Groups: groups})
 	}
-	return dial, push, pushData
+	a.pushPane = func(session, content, errText string) {
+		write(remoteChannelReply{Event: "pane", Session: session, Stdout: content, Error: errText})
+	}
+	return a
 }
 
 func newTestChannel(dial func(context.Context) (io.WriteCloser, io.Reader, func(), error)) (*RemoteChannel, chan RemoteChange) {
@@ -118,5 +153,134 @@ func TestRemoteChannel_OldRemoteIsUnsupportedAndFallsBack(t *testing.T) {
 	_, err := ch.Request(context.Background(), []string{"list"})
 	if !errors.Is(err, errChannelDown) {
 		t.Fatalf("Request on a down channel must report errChannelDown so the caller execs instead, got %v", err)
+	}
+}
+
+// Watch sends the watch request once per session, Unwatch releases it, and
+// pushed "pane" events arrive typed on the same fan-in as "changed".
+func TestRemoteChannel_WatchAndPaneEvents(t *testing.T) {
+	agent := newFakeAgent(t, true, false)
+	ch, events := newTestChannel(agent.dial)
+	ch.ensureConnected()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	expectWatched := func(want string) {
+		t.Helper()
+		select {
+		case got := <-agent.watched:
+			if got != want {
+				t.Fatalf("agent got watch %q, want %q", got, want)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("agent never received the watch request for %q", want)
+		}
+	}
+	if err := ch.Watch(ctx, "s1"); err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	expectWatched("s1")
+	if ch.Watching() != "s1" {
+		t.Fatalf("Watching = %q, want s1", ch.Watching())
+	}
+	if err := ch.Watch(ctx, "s1"); err != nil {
+		t.Fatalf("repeat Watch: %v", err)
+	}
+	select {
+	case got := <-agent.watched:
+		t.Fatalf("a repeated watch of the same session must not be sent again, agent got %q", got)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	agent.pushPane("s1", "screen text", "")
+	select {
+	case ev := <-events:
+		if ev.Remote != "box" || ev.Pane == nil || ev.Pane.Session != "s1" || ev.Pane.Content != "screen text" || ev.Pane.Err != "" || ev.HasData {
+			t.Fatalf("pane event = %+v (pane %+v)", ev, ev.Pane)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("pane push did not reach the events channel")
+	}
+	agent.pushPane("s1", "", "session 's1' not found")
+	select {
+	case ev := <-events:
+		if ev.Pane == nil || ev.Pane.Err == "" || ev.Pane.Content != "" {
+			t.Fatalf("failed capture must arrive as a pane event with Err, got %+v", ev.Pane)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("pane failure push did not reach the events channel")
+	}
+	// "changed" keeps flowing on the same channel, untyped as pane.
+	agent.push("changed")
+	select {
+	case ev := <-events:
+		if ev.Pane != nil || ev.Remote != "box" {
+			t.Fatalf("changed event = %+v, must not carry a pane", ev)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("changed push did not reach the events channel")
+	}
+
+	if err := ch.Watch(ctx, "s2"); err != nil {
+		t.Fatalf("Watch s2: %v", err)
+	}
+	expectWatched("s2")
+	if err := ch.Unwatch(ctx); err != nil {
+		t.Fatalf("Unwatch: %v", err)
+	}
+	expectWatched("")
+	if ch.Watching() != "" {
+		t.Fatalf("Watching after Unwatch = %q", ch.Watching())
+	}
+	if err := ch.Unwatch(ctx); err != nil {
+		t.Fatalf("second Unwatch: %v", err)
+	}
+	select {
+	case got := <-agent.watched:
+		t.Fatalf("Unwatch with nothing watched must not send, agent got %q", got)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// The watch dies with the transport: after markDown nothing is watched,
+	// so the caller asks again once reconnected.
+	if err := ch.Watch(ctx, "s3"); err != nil {
+		t.Fatalf("Watch s3: %v", err)
+	}
+	expectWatched("s3")
+	ch.markDown()
+	if ch.Watching() != "" {
+		t.Fatalf("Watching after the transport dropped = %q, want none", ch.Watching())
+	}
+	if err := ch.Watch(ctx, "s3"); !errors.Is(err, errChannelDown) {
+		t.Fatalf("Watch on a down channel must report errChannelDown, got %v", err)
+	}
+	if !ch.PaneWatchSupported() {
+		t.Fatal("a transport failure must not mark pane watching unsupported")
+	}
+}
+
+// An agent that does not know watch requests (older build) answers with an
+// error; the channel remembers that so the caller polls instead.
+func TestRemoteChannel_WatchRefusedMarksUnsupported(t *testing.T) {
+	agent := newFakeAgent(t, true, true)
+	ch, _ := newTestChannel(agent.dial)
+	ch.ensureConnected()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err := ch.Watch(ctx, "s1")
+	if err == nil || errors.Is(err, errChannelDown) {
+		t.Fatalf("a refused watch must fail without looking like a transport failure, got %v", err)
+	}
+	if ch.Watching() != "" || ch.PaneWatchSupported() {
+		t.Fatalf("after a refusal: Watching=%q supported=%v, want none/false", ch.Watching(), ch.PaneWatchSupported())
+	}
+	if err := ch.Watch(ctx, "s2"); err == nil {
+		t.Fatal("watch must not be retried on a remote that refused it")
+	}
+	if ch.Connected() {
+		out, err := ch.Request(ctx, []string{"list"})
+		if err != nil || string(out) != "out:list" {
+			t.Fatalf("ordinary requests must keep working after a refused watch, got %q, %v", out, err)
+		}
 	}
 }

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -4835,7 +4835,7 @@ func (h *Home) remotePaneWatchCmd(ch *session.RemoteChannel, target remotePaneWa
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(h.ctx, 10*time.Second)
 		defer cancel()
-		err := ch.Watch(ctx, target.session)
+		err := ch.Watch(ctx, target.session, remotePreviewMaxLines)
 		if err != nil {
 			uiLog.Debug("remote_pane_watch_failed", slog.String("remote", target.remote), slog.String("session", target.session), slog.String("err", err.Error()))
 		}
@@ -4854,9 +4854,13 @@ func (h *Home) remotePaneUnwatchCmd(ch *session.RemoteChannel) tea.Cmd {
 
 // applyRemotePane stores a pushed pane capture as the preview of that
 // remote session, the same way a fetched preview lands, so the renderer and
-// the TTL logic see no difference. A capture failure counts as a fetch
-// failure: the last content stays, the TTL advances.
-func (h *Home) applyRemotePane(remoteName string, pane *session.RemotePaneEvent) {
+// the TTL logic see no difference. A capture failure or an empty screen
+// counts as a fetch failure, as on the poll path: the last content stays,
+// the TTL advances. It reports whether the preview is blank afterwards
+// (nothing cached and no pane text: the session is stopped, or its screen
+// is empty), in which case the caller polls once so the transcript fallback
+// of the poll path still shows something, as it did before pushes existed.
+func (h *Home) applyRemotePane(remoteName string, pane *session.RemotePaneEvent) (blank bool) {
 	key := remotePreviewCacheKey(remoteName, pane.Session)
 	h.previewCacheMu.Lock()
 	defer h.previewCacheMu.Unlock()
@@ -4864,9 +4868,30 @@ func (h *Home) applyRemotePane(remoteName string, pane *session.RemotePaneEvent)
 		h.previewFetchingID = ""
 	}
 	h.previewCacheTime[key] = time.Now()
-	if pane.Err == "" {
-		h.previewCache[key] = expandTabs(truncateRemotePreviewContent(pane.Content))
+	if content := expandTabs(truncateRemotePreviewContent(pane.Content)); pane.Err == "" && strings.TrimSpace(content) != "" {
+		h.previewCache[key] = content
 	}
+	return strings.TrimSpace(h.previewCache[key]) == ""
+}
+
+// pollRemotePreviewIfSelected starts one ssh poll of the remote session's
+// preview when that session is still under the cursor and no poll for it
+// is in flight; nil otherwise.
+func (h *Home) pollRemotePreviewIfSelected(target remotePaneWatchTarget) tea.Cmd {
+	_, _, key, ok := h.selectedRemotePreviewTarget()
+	if !ok || key != remotePreviewCacheKey(target.remote, target.session) {
+		return nil
+	}
+	h.previewCacheMu.Lock()
+	needsFetch := h.previewFetchingID != key
+	if needsFetch {
+		h.previewFetchingID = key
+	}
+	h.previewCacheMu.Unlock()
+	if !needsFetch {
+		return nil
+	}
+	return h.fetchRemotePreview(target.remote, target.session, key)
 }
 
 // selectedPreviewTarget returns the instance, cache key, and window index for the currently
@@ -7337,7 +7362,12 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// under the cursor are ignored (the unwatch may still be in
 			// flight).
 			if h.remotePaneWatch.remote == msg.remoteName && h.remotePaneWatch.session == msg.change.Pane.Session {
-				h.applyRemotePane(msg.remoteName, msg.change.Pane)
+				if h.applyRemotePane(msg.remoteName, msg.change.Pane) {
+					// Nothing to show from the pane (stopped session, empty
+					// screen): one poll, whose transcript fallback fills
+					// the preview the way it did before pushes existed.
+					return h, tea.Batch(h.waitRemoteChange, h.pollRemotePreviewIfSelected(h.remotePaneWatch))
+				}
 			}
 			return h, h.waitRemoteChange
 		}
@@ -7370,20 +7400,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// The agent refused or the channel dropped: poll this preview as
 		// before. The next tick re-evaluates once the channel is back.
 		h.remotePaneWatch = remotePaneWatchTarget{}
-		_, _, key, ok := h.selectedRemotePreviewTarget()
-		if !ok || key != remotePreviewCacheKey(msg.target.remote, msg.target.session) {
-			return h, nil
-		}
-		h.previewCacheMu.Lock()
-		needsFetch := h.previewFetchingID != key
-		if needsFetch {
-			h.previewFetchingID = key
-		}
-		h.previewCacheMu.Unlock()
-		if needsFetch {
-			return h, h.fetchRemotePreview(msg.target.remote, msg.target.session, key)
-		}
-		return h, nil
+		return h, h.pollRemotePreviewIfSelected(msg.target)
 
 	case remoteLatenciesFetchedMsg:
 		h.remoteLatencyMu.Lock()

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -353,6 +353,17 @@ type Home struct {
 	pendingPreviewKey string     // Preview key waiting for debounced fetch
 	previewDebounceMu sync.Mutex // Protects pendingPreviewKey
 
+	// Remote preview over the channel (#2177 follow-up): the remote agent
+	// pushes the focused remote session's pane, so no ssh poll runs for it
+	// while the watch holds. remotePaneWatch is what the TUI last asked a
+	// remote to watch; it is read and written only from Update.
+	remotePaneWatch remotePaneWatchTarget
+	// remotePaneUnsupported remembers, per remote, that `session output
+	// --pane` is unknown to that remote's build, so the poll path takes the
+	// transcript fallback directly instead of trying --pane every cycle.
+	remotePaneUnsupported   map[string]bool
+	remotePaneUnsupportedMu sync.Mutex
+
 	// Round-robin status updates (Priority 1A optimization)
 	// Instead of updating ALL sessions every tick, we update batches of 5-10 sessions
 	// This reduces CPU usage by 90%+ while maintaining responsiveness
@@ -1377,6 +1388,20 @@ type previewFetchedMsg struct {
 	previewKey string // cache key: sessionID or sessionID:windowIndex
 	content    string
 	err        error
+}
+
+// remotePaneWatchTarget names the remote session whose pane the TUI asked
+// the remote agent to push ("" fields when none).
+type remotePaneWatchTarget struct {
+	remote  string
+	session string
+}
+
+// remotePaneWatchMsg reports the outcome of a Watch request on a remote
+// channel; on failure the preview poll takes over for that session.
+type remotePaneWatchMsg struct {
+	target remotePaneWatchTarget
+	err    error
 }
 
 // previewDebounceMsg signals debounce period elapsed for preview fetch
@@ -4711,16 +4736,136 @@ func (h *Home) fetchRemotePreview(remoteName, sessionID, key string) tea.Cmd {
 		// tool UI chrome) instead of FetchSessionOutput (parsed transcript
 		// text) so claude-formatted previews render the same way local
 		// sessions do. If the remote agent-deck predates --pane, fall back
-		// to the transcript path so the preview is at least non-empty.
-		content, fetchErr := runner.FetchSessionPane(ctx, sessionID)
-		if fetchErr != nil || strings.TrimSpace(content) == "" {
-			if fallback, fbErr := runner.FetchSessionOutput(ctx, sessionID); fbErr == nil && strings.TrimSpace(fallback) != "" {
-				content = fallback
-				fetchErr = nil
+		// to the transcript path so the preview is at least non-empty, and
+		// remember that for the remote so later cycles go there directly.
+		var content string
+		var fetchErr error
+		if h.remotePaneIsUnsupported(remoteName) {
+			content, fetchErr = runner.FetchSessionOutput(ctx, sessionID)
+		} else {
+			content, fetchErr = runner.FetchSessionPane(ctx, sessionID)
+			if fetchErr != nil && remotePaneFlagUnknown(fetchErr) {
+				h.setRemotePaneUnsupported(remoteName)
+			}
+			if fetchErr != nil || strings.TrimSpace(content) == "" {
+				if fallback, fbErr := runner.FetchSessionOutput(ctx, sessionID); fbErr == nil && strings.TrimSpace(fallback) != "" {
+					content = fallback
+					fetchErr = nil
+				}
 			}
 		}
 		content = truncateRemotePreviewContent(content)
 		return previewFetchedMsg{previewKey: key, content: content, err: fetchErr}
+	}
+}
+
+// remotePaneFlagUnknown recognises the flag package's complaint from a remote
+// build that predates `session output --pane`.
+func remotePaneFlagUnknown(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "flag provided but not defined") && strings.Contains(msg, "pane")
+}
+
+func (h *Home) remotePaneIsUnsupported(remoteName string) bool {
+	h.remotePaneUnsupportedMu.Lock()
+	defer h.remotePaneUnsupportedMu.Unlock()
+	return h.remotePaneUnsupported[remoteName]
+}
+
+func (h *Home) setRemotePaneUnsupported(remoteName string) {
+	h.remotePaneUnsupportedMu.Lock()
+	defer h.remotePaneUnsupportedMu.Unlock()
+	if h.remotePaneUnsupported == nil {
+		h.remotePaneUnsupported = map[string]bool{}
+	}
+	h.remotePaneUnsupported[remoteName] = true
+}
+
+// remotePaneWatchActive reports whether the remote agent is pushing the
+// pane of this remote session over a live channel, in which case the
+// preview needs no poll.
+func remotePaneWatchActive(remoteName, sessionID string) bool {
+	ch := session.RemoteChannelFor(remoteName)
+	return ch != nil && ch.Connected() && ch.Watching() == sessionID
+}
+
+// syncRemotePaneWatch makes the remote agents' pane watch follow the cursor:
+// the focused remote session is watched over its channel (when the channel
+// is up and the agent knows how), any previously watched session on another
+// remote is released, and a channel that reconnected (its watch died with
+// the transport) is asked again. Returns the commands that talk to the
+// remotes; callers batch them.
+func (h *Home) syncRemotePaneWatch() tea.Cmd {
+	var want remotePaneWatchTarget
+	if remoteName, sessionID, _, ok := h.selectedRemotePreviewTarget(); ok && h.getLayoutMode() != LayoutModeSingle {
+		want = remotePaneWatchTarget{remote: remoteName, session: sessionID}
+	}
+	var cmds []tea.Cmd
+	have := h.remotePaneWatch
+	h.remotePaneWatch = remotePaneWatchTarget{}
+	// Another session on the same remote needs no release: the agent
+	// replaces its watch when the new one arrives.
+	if have.remote != "" && have.remote != want.remote {
+		if ch := session.RemoteChannelFor(have.remote); ch != nil {
+			cmds = append(cmds, h.remotePaneUnwatchCmd(ch))
+		}
+	}
+	if want.remote == "" {
+		return batchCmds(cmds)
+	}
+	ch := session.RemoteChannelFor(want.remote)
+	if ch == nil || !ch.Connected() || !ch.PaneWatchSupported() {
+		return batchCmds(cmds)
+	}
+	h.remotePaneWatch = want
+	if ch.Watching() != want.session {
+		cmds = append(cmds, h.remotePaneWatchCmd(ch, want))
+	}
+	return batchCmds(cmds)
+}
+
+func batchCmds(cmds []tea.Cmd) tea.Cmd {
+	if len(cmds) == 0 {
+		return nil
+	}
+	return tea.Batch(cmds...)
+}
+
+func (h *Home) remotePaneWatchCmd(ch *session.RemoteChannel, target remotePaneWatchTarget) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(h.ctx, 10*time.Second)
+		defer cancel()
+		err := ch.Watch(ctx, target.session)
+		if err != nil {
+			uiLog.Debug("remote_pane_watch_failed", slog.String("remote", target.remote), slog.String("session", target.session), slog.String("err", err.Error()))
+		}
+		return remotePaneWatchMsg{target: target, err: err}
+	}
+}
+
+func (h *Home) remotePaneUnwatchCmd(ch *session.RemoteChannel) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(h.ctx, 10*time.Second)
+		defer cancel()
+		_ = ch.Unwatch(ctx)
+		return nil
+	}
+}
+
+// applyRemotePane stores a pushed pane capture as the preview of that
+// remote session, the same way a fetched preview lands, so the renderer and
+// the TTL logic see no difference. A capture failure counts as a fetch
+// failure: the last content stays, the TTL advances.
+func (h *Home) applyRemotePane(remoteName string, pane *session.RemotePaneEvent) {
+	key := remotePreviewCacheKey(remoteName, pane.Session)
+	h.previewCacheMu.Lock()
+	defer h.previewCacheMu.Unlock()
+	if h.previewFetchingID == key {
+		h.previewFetchingID = ""
+	}
+	h.previewCacheTime[key] = time.Now()
+	if pane.Err == "" {
+		h.previewCache[key] = expandTabs(truncateRemotePreviewContent(pane.Content))
 	}
 }
 
@@ -7186,6 +7331,16 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return h.applyRemoteFetch(msg)
 
 	case remoteChangedMsg:
+		if msg.change.Pane != nil {
+			// The focused remote session's pane, pushed by the agent: apply
+			// it to the preview and re-arm. Pushes for a session no longer
+			// under the cursor are ignored (the unwatch may still be in
+			// flight).
+			if h.remotePaneWatch.remote == msg.remoteName && h.remotePaneWatch.session == msg.change.Pane.Session {
+				h.applyRemotePane(msg.remoteName, msg.change.Pane)
+			}
+			return h, h.waitRemoteChange
+		}
 		if msg.change.HasData {
 			// The event brought the listings: apply them now, no round trip.
 			uiLog.Debug("remote_changed", slog.String("remote", msg.remoteName), slog.Bool("pushed_data", true))
@@ -7207,6 +7362,28 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return h, h.waitRemoteChange
 		}
 		return h, tea.Batch(h.fetchRemoteSessions, h.waitRemoteChange)
+
+	case remotePaneWatchMsg:
+		if msg.err == nil || h.remotePaneWatch != msg.target {
+			return h, nil
+		}
+		// The agent refused or the channel dropped: poll this preview as
+		// before. The next tick re-evaluates once the channel is back.
+		h.remotePaneWatch = remotePaneWatchTarget{}
+		_, _, key, ok := h.selectedRemotePreviewTarget()
+		if !ok || key != remotePreviewCacheKey(msg.target.remote, msg.target.session) {
+			return h, nil
+		}
+		h.previewCacheMu.Lock()
+		needsFetch := h.previewFetchingID != key
+		if needsFetch {
+			h.previewFetchingID = key
+		}
+		h.previewCacheMu.Unlock()
+		if needsFetch {
+			return h, h.fetchRemotePreview(msg.target.remote, msg.target.session, key)
+		}
+		return h, nil
 
 	case remoteLatenciesFetchedMsg:
 		h.remoteLatencyMu.Lock()
@@ -7798,6 +7975,15 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.remoteName != "" {
 			var cmds []tea.Cmd
 
+			// Over a live channel the agent pushes this pane (the first
+			// capture arrives as soon as the watch is set), so no fetch.
+			if cmd := h.syncRemotePaneWatch(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+			if h.remotePaneWatch == (remotePaneWatchTarget{remote: msg.remoteName, session: msg.sessionID}) {
+				return h, batchCmds(cmds)
+			}
+
 			// Preview fetch
 			h.previewCacheMu.Lock()
 			needsPreviewFetch := h.previewFetchingID != msg.previewKey
@@ -8360,7 +8546,10 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			h.previewCacheMu.Unlock()
 		} else {
 			remoteName, remoteSessionID, remoteKey, ok := h.selectedRemotePreviewTarget()
-			if ok {
+			// The remote agent pushes the focused pane over the channel;
+			// the ssh poll only runs while that is not the case (channel
+			// down, old remote, watch still being set up).
+			if ok && !remotePaneWatchActive(remoteName, remoteSessionID) {
 				h.previewCacheMu.Lock()
 				cachedTime, hasCached := h.previewCacheTime[remoteKey]
 				cacheExpired := !hasCached || time.Since(cachedTime) > remotePreviewCacheTTL
@@ -8371,7 +8560,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 				h.previewCacheMu.Unlock()
 			}
 		}
-		cmds := []tea.Cmd{h.tick(), previewCmd, remoteFetchCmd, remoteLatencyCmd}
+		cmds := []tea.Cmd{h.tick(), previewCmd, remoteFetchCmd, remoteLatencyCmd, h.syncRemotePaneWatch()}
 		if h.fullRepaint {
 			cmds = append(cmds, tea.ClearScreen)
 		}

--- a/internal/ui/remote_pane_watch_test.go
+++ b/internal/ui/remote_pane_watch_test.go
@@ -66,6 +66,40 @@ func TestRemotePaneWatch_PushedPaneUpdatesPreview(t *testing.T) {
 	}
 }
 
+// A pushed pane that leaves the preview blank (the session is stopped and
+// has no pane, or its screen is empty) starts one poll, whose transcript
+// fallback fills the preview as it did before pushes existed; the watch
+// stays. A blank push for a session with cached content polls nothing.
+func TestRemotePaneWatch_BlankPanePollsOnce(t *testing.T) {
+	home := remotePaneTestHome(t, "box", "s1")
+	target := remotePaneWatchTarget{remote: "box", session: "s1"}
+	home.remotePaneWatch = target
+	key := remotePreviewCacheKey("box", "s1")
+
+	_, cmd := home.Update(remoteChangedMsg{remoteName: "box", change: session.RemoteChange{Remote: "box", Pane: &session.RemotePaneEvent{Session: "s1", Err: "tmux session not initialized"}}})
+	if cmd == nil {
+		t.Fatal("a capture failure with nothing cached must poll the preview")
+	}
+	home.previewCacheMu.RLock()
+	fetching := home.previewFetchingID
+	home.previewCacheMu.RUnlock()
+	if fetching != key {
+		t.Fatalf("poll must be marked in flight for the remote key, got %q", fetching)
+	}
+	if home.remotePaneWatch != target {
+		t.Fatalf("the watch must survive a capture failure, got %+v", home.remotePaneWatch)
+	}
+	// The poll lands: from now on a blank push keeps the transcript.
+	home.Update(previewFetchedMsg{previewKey: key, content: "transcript text"})
+	home.Update(remoteChangedMsg{remoteName: "box", change: session.RemoteChange{Remote: "box", Pane: &session.RemotePaneEvent{Session: "s1", Content: "  \n"}}})
+	home.previewCacheMu.RLock()
+	content, fetching := home.previewCache[key], home.previewFetchingID
+	home.previewCacheMu.RUnlock()
+	if content != "transcript text" || fetching != "" {
+		t.Fatalf("an empty screen must keep the transcript and not poll again; content=%q fetching=%q", content, fetching)
+	}
+}
+
 // When the watch request fails the TUI forgets the watch and polls that
 // preview once more, so the pane is never left blank on an old remote or a
 // dropped channel.

--- a/internal/ui/remote_pane_watch_test.go
+++ b/internal/ui/remote_pane_watch_test.go
@@ -1,0 +1,134 @@
+package ui
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func remotePaneTestHome(t *testing.T, remoteName, sessionID string) *Home {
+	t.Helper()
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+	remote := session.RemoteSessionInfo{ID: sessionID, Title: "one", Status: "running", Tool: "claude", RemoteName: remoteName}
+	home.flatItems = []session.Item{{Type: session.ItemTypeRemoteSession, RemoteName: remoteName, RemoteSession: &remote}}
+	home.cursor = 0
+	return home
+}
+
+// A pushed pane for the watched remote session lands in the preview cache
+// exactly like a fetched preview would (content, TTL stamp, fetching flag
+// cleared); a push for any other session is ignored; the change waiter is
+// re-armed either way.
+func TestRemotePaneWatch_PushedPaneUpdatesPreview(t *testing.T) {
+	home := remotePaneTestHome(t, "box", "s1")
+	home.remotePaneWatch = remotePaneWatchTarget{remote: "box", session: "s1"}
+	key := remotePreviewCacheKey("box", "s1")
+	home.previewCacheMu.Lock()
+	home.previewFetchingID = key
+	home.previewCacheMu.Unlock()
+
+	_, cmd := home.Update(remoteChangedMsg{remoteName: "box", change: session.RemoteChange{Remote: "box", Pane: &session.RemotePaneEvent{Session: "s1", Content: "line\tone\n> "}}})
+	if cmd == nil {
+		t.Fatal("a pane event must re-arm the remote change waiter")
+	}
+	home.previewCacheMu.RLock()
+	content, stamped := home.previewCache[key], !home.previewCacheTime[key].IsZero()
+	fetching := home.previewFetchingID
+	home.previewCacheMu.RUnlock()
+	if content != expandTabs("line\tone\n> ") || !stamped {
+		t.Fatalf("pane push must fill the preview cache (tabs expanded) and stamp its TTL; got %q stamped=%v", content, stamped)
+	}
+	if fetching != "" {
+		t.Fatalf("a pane push for the key being fetched must clear the fetching flag, got %q", fetching)
+	}
+
+	// A capture failure keeps the last content and still advances the TTL.
+	before := time.Now()
+	home.Update(remoteChangedMsg{remoteName: "box", change: session.RemoteChange{Remote: "box", Pane: &session.RemotePaneEvent{Session: "s1", Err: "pane gone"}}})
+	home.previewCacheMu.RLock()
+	kept, at := home.previewCache[key], home.previewCacheTime[key]
+	home.previewCacheMu.RUnlock()
+	if kept != content || at.Before(before) {
+		t.Fatalf("a failed capture must keep the last content and advance the TTL; got %q at %v", kept, at)
+	}
+
+	// A push for a session that is not under the cursor is dropped.
+	home.Update(remoteChangedMsg{remoteName: "box", change: session.RemoteChange{Remote: "box", Pane: &session.RemotePaneEvent{Session: "s9", Content: "other"}}})
+	home.previewCacheMu.RLock()
+	_, leaked := home.previewCache[remotePreviewCacheKey("box", "s9")]
+	home.previewCacheMu.RUnlock()
+	if leaked {
+		t.Fatal("a pane push for an unwatched session must not enter the cache")
+	}
+}
+
+// When the watch request fails the TUI forgets the watch and polls that
+// preview once more, so the pane is never left blank on an old remote or a
+// dropped channel.
+func TestRemotePaneWatch_FailedWatchFallsBackToPoll(t *testing.T) {
+	home := remotePaneTestHome(t, "box", "s1")
+	target := remotePaneWatchTarget{remote: "box", session: "s1"}
+	home.remotePaneWatch = target
+
+	_, cmd := home.Update(remotePaneWatchMsg{target: target, err: errors.New("verb not allowed over the channel")})
+	if home.remotePaneWatch != (remotePaneWatchTarget{}) {
+		t.Fatalf("a failed watch must be forgotten, still %+v", home.remotePaneWatch)
+	}
+	if cmd == nil {
+		t.Fatal("a failed watch must trigger a preview poll for the focused remote session")
+	}
+	home.previewCacheMu.RLock()
+	fetching := home.previewFetchingID
+	home.previewCacheMu.RUnlock()
+	if fetching != remotePreviewCacheKey("box", "s1") {
+		t.Fatalf("poll must be marked in flight for the remote key, got %q", fetching)
+	}
+
+	// A stale failure (the cursor moved on) changes nothing.
+	home.remotePaneWatch = remotePaneWatchTarget{remote: "box", session: "s2"}
+	_, cmd = home.Update(remotePaneWatchMsg{target: target, err: errors.New("late")})
+	if cmd != nil || home.remotePaneWatch.session != "s2" {
+		t.Fatalf("a failure for an old target must be ignored; cmd=%v watch=%+v", cmd, home.remotePaneWatch)
+	}
+}
+
+// With no channel open for the remote (old remote, channels disabled, or
+// not yet dialled) the cursor sync asks for nothing and the poll path is
+// used; leaving the remote row releases a watch it had asked for.
+func TestRemotePaneWatch_NoChannelMeansPoll(t *testing.T) {
+	home := remotePaneTestHome(t, "no-such-remote", "s1")
+	if cmd := home.syncRemotePaneWatch(); cmd != nil || home.remotePaneWatch != (remotePaneWatchTarget{}) {
+		t.Fatalf("without a channel nothing must be watched; cmd=%v watch=%+v", cmd, home.remotePaneWatch)
+	}
+	if remotePaneWatchActive("no-such-remote", "s1") {
+		t.Fatal("no channel, no active watch")
+	}
+	home.remotePaneWatch = remotePaneWatchTarget{remote: "no-such-remote", session: "s1"}
+	home.flatItems = nil
+	if cmd := home.syncRemotePaneWatch(); home.remotePaneWatch != (remotePaneWatchTarget{}) {
+		t.Fatalf("moving off the remote row must drop the watch target; cmd=%v watch=%+v", cmd, home.remotePaneWatch)
+	}
+}
+
+// The transcript fallback is chosen once per remote: after --pane is seen
+// to be unknown on a remote, the poll path stops trying it.
+func TestRemotePaneWatch_PaneFlagUnsupportedIsRemembered(t *testing.T) {
+	home := NewHome()
+	if home.remotePaneIsUnsupported("box") {
+		t.Fatal("no remote is unsupported before anything was fetched")
+	}
+	if !remotePaneFlagUnknown(errors.New("ssh command failed: exit status 2: flag provided but not defined: -pane")) {
+		t.Fatal("the flag package's complaint about --pane must be recognised")
+	}
+	if remotePaneFlagUnknown(errors.New("ssh command failed: exit status 1: tmux session not initialized")) {
+		t.Fatal("an ordinary failure must not mark --pane unsupported")
+	}
+	home.setRemotePaneUnsupported("box")
+	if !home.remotePaneIsUnsupported("box") || home.remotePaneIsUnsupported("other") {
+		t.Fatal("unsupported must be remembered per remote")
+	}
+}


### PR DESCRIPTION
## What problem does this solve?
The remote preview pane polled the selected session's pane over its own SSH calls every few seconds, and fell back to the transcript on every cycle when `--pane` was unsupported. Item 3 of the remote latency plan (#2174). Stacked on #2181 and #2182; merge those first.

## Why this change
The agent accepts a watch for one session (with a line cap the TUI sets), captures the tmux pane in-process every ~300 ms, hash-gated, and pushes `{"event":"pane",...}`; a new watch replaces the previous one and always sends a fresh frame; unwatch stops it. `RemoteChannel` gains `Watch`/`Unwatch` and forwards pane events as a typed event on the same fan-in. With the cursor on a remote session and the channel up, the TUI watches it and applies frames directly; when the channel is down or the remote predates the watch, it polls as before and remembers per remote that `--pane` is unsupported. Reviewer fixes: keep the transcript fallback for stopped or empty panes, trim pushes to the rendered line count, free the DB handle per capture.

## User impact
The preview follows a remote session live, at the cost of pane-sized pushes only while it changes, with no extra SSH calls.

## Evidence
Implemented and adversarially reviewed by separate agents; tests for the agent watch/pane events, channel parsing, and the TUI watch lifecycle pass in the Docker test image (`cmd/agent-deck`, `internal/session`, `internal/ui`). A flaky base test was made deterministic (atomic file replace). Local go test is disallowed on this host.

## AI disclosure
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5-1

## What actually bothered you
My human asked: "such that it stays quick like realtime, seamless without any lag".

## Checklist
- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5-1 intent=yes -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added live remote session pane watching, with automatic updates, line limits, watch replacement, and fallback support for older remote versions.
  - Remote pane updates now refresh the focused session preview without requiring repeated polling.
- **Improvements**
  - Remote session results appear independently as each host responds, so slower hosts no longer delay faster ones.
  - Remote change monitoring now reports probe timing and handles probe failures more gracefully.
  - Improved JSON output consistency for session and group listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->