### PR TITLE
fix: prevent multi-client tmux clipping

### DIFF
--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -301,10 +301,9 @@ func (r *SSHRunner) Attach(sessionID string) error {
 
 	// Start SSH with a local PTY pre-sized to the controlling terminal so the
 	// remote tmux client connects full-width from frame one (#1167). A bare
-	// pty.Start creates the PTY at the 80x24 default, which under the remote
-	// session's window-size=largest pins the pane to ~half a wide terminal
-	// until an async SIGWINCH grows it. Shares the local-attach helper so both
-	// paths size identically.
+	// pty.Start creates the PTY at the 80x24 default, which can size the remote
+	// session's pane to ~half a wide terminal until an async SIGWINCH grows it.
+	// Shares the local-attach helper so both paths size identically.
 	ptmx, err := tmux.StartAttachPTY(cmd, os.Stdin)
 	if err != nil {
 		return fmt.Errorf("failed to start ssh with pty: %w", err)

--- a/internal/testutil/multiclienttmux/multiclienttmux.go
+++ b/internal/testutil/multiclienttmux/multiclienttmux.go
@@ -1,6 +1,7 @@
 // Package multiclienttmux boots an isolated tmux server with
-// aggressive-resize=on and lets a test attach N pty clients at chosen
-// sizes — the harness from TEST-PLAN.md §6.1 / TUI-TEST-PLAN.md §6.8
+// window-size=smallest and aggressive-resize=on, then lets a test attach N
+// pty clients at chosen sizes — the harness from TEST-PLAN.md §6.1 /
+// TUI-TEST-PLAN.md §6.8
 // for the "two web clients hijacking pane size" regression (J4 / F2).
 //
 // Every harness instance gets its own socket under a short isolated temp
@@ -10,13 +11,14 @@
 // Usage:
 //
 //	h := multiclienttmux.New(t, "myscratch")
-//	h.AddClient(80, 24)
-//	h.AddClient(120, 40)
-//	w, hgt, _ := h.WindowSize() // expect 120x40 (largest)
+//	h.AddClient(88, 71)
+//	h.AddClient(189, 62)
+//	w, hgt, _ := h.WindowSize() // expect 88x61 (smallest, minus status row)
 package multiclienttmux
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -41,11 +43,12 @@ type Harness struct {
 
 type clientProc struct {
 	cmd *exec.Cmd
-	pty interface{ Close() error }
+	pty *os.File
 }
 
-// New boots a fresh tmux server on a per-test isolated socket and
-// creates a detached session named sessionName with aggressive-resize=on.
+// New boots a fresh tmux server on a per-test isolated socket and creates a
+// detached session named sessionName with Agent Deck's multi-client sizing
+// defaults.
 // The server and all spawned clients are torn down via t.Cleanup.
 //
 // Skips the test (via t.Skip) if the tmux binary is unavailable.
@@ -72,13 +75,14 @@ func New(t *testing.T, sessionName string) *Harness {
 		t.Fatalf("multiclienttmux: new-session: %v\n%s", err, out)
 	}
 
-	// aggressive-resize=on lets the active window match the smallest
-	// attached client *that's looking at it*; for cross-client size
-	// regression tests this is what we want.
+	// Explicitly mirror Session.Start. tmux defaults to window-size=latest,
+	// which would make this harness depend on client attach/input order instead
+	// of exercising Agent Deck's policy.
 	if out, err := exec.Command("tmux", "-S", socketPath,
+		"set-option", "-t", sessionName, "window-size", "smallest", ";",
 		"set-window-option", "-t", sessionName, "aggressive-resize", "on",
 	).CombinedOutput(); err != nil {
-		t.Fatalf("multiclienttmux: set aggressive-resize: %v\n%s", err, out)
+		t.Fatalf("multiclienttmux: set size policy: %v\n%s", err, out)
 	}
 
 	h := &Harness{
@@ -105,6 +109,24 @@ func (h *Harness) AddClient(cols, rows int) error {
 	h.mu.Unlock()
 
 	// Give tmux a beat to register the client.
+	time.Sleep(100 * time.Millisecond)
+	return nil
+}
+
+// ResizeClient changes an attached client's PTY dimensions and waits briefly
+// for tmux to process the resulting SIGWINCH.
+func (h *Harness) ResizeClient(index, cols, rows int) error {
+	h.mu.Lock()
+	if index < 0 || index >= len(h.clients) {
+		h.mu.Unlock()
+		return fmt.Errorf("multiclienttmux: client index %d out of range", index)
+	}
+	clientPTY := h.clients[index].pty
+	h.mu.Unlock()
+
+	if err := pty.Setsize(clientPTY, &pty.Winsize{Cols: uint16(cols), Rows: uint16(rows)}); err != nil { // #nosec G115 -- test helper, sizes provided by caller fit uint16
+		return fmt.Errorf("multiclienttmux: pty.Setsize: %w", err)
+	}
 	time.Sleep(100 * time.Millisecond)
 	return nil
 }

--- a/internal/testutil/multiclienttmux/multiclienttmux.go
+++ b/internal/testutil/multiclienttmux/multiclienttmux.go
@@ -11,7 +11,7 @@
 // Usage:
 //
 //	h := multiclienttmux.New(t, "myscratch")
-//	h.AddClient(88, 62)
+//	h.AddClient(100, 62)
 //	h.AddClient(189, 62)
 //	h.ResizeClient(0, 88, 71)
 //	w, hgt, _ := h.WindowSize() // expect 88x61 (smallest, minus status row)
@@ -19,6 +19,7 @@ package multiclienttmux
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
 	"strconv"
@@ -117,6 +118,10 @@ func (h *Harness) AddClient(cols, rows int) error {
 // ResizeClient changes an attached client's PTY dimensions and waits briefly
 // for tmux to process the resulting SIGWINCH.
 func (h *Harness) ResizeClient(index, cols, rows int) error {
+	if cols < 1 || cols > math.MaxUint16 || rows < 1 || rows > math.MaxUint16 {
+		return fmt.Errorf("multiclienttmux: dimensions out of range: cols=%d rows=%d (want 1..%d)", cols, rows, math.MaxUint16)
+	}
+
 	h.mu.Lock()
 	if index < 0 || index >= len(h.clients) {
 		h.mu.Unlock()
@@ -125,7 +130,7 @@ func (h *Harness) ResizeClient(index, cols, rows int) error {
 	clientPTY := h.clients[index].pty
 	h.mu.Unlock()
 
-	if err := pty.Setsize(clientPTY, &pty.Winsize{Cols: uint16(cols), Rows: uint16(rows)}); err != nil { // #nosec G115 -- test helper, sizes provided by caller fit uint16
+	if err := pty.Setsize(clientPTY, &pty.Winsize{Cols: uint16(cols), Rows: uint16(rows)}); err != nil {
 		return fmt.Errorf("multiclienttmux: pty.Setsize: %w", err)
 	}
 	time.Sleep(100 * time.Millisecond)

--- a/internal/testutil/multiclienttmux/multiclienttmux.go
+++ b/internal/testutil/multiclienttmux/multiclienttmux.go
@@ -11,8 +11,9 @@
 // Usage:
 //
 //	h := multiclienttmux.New(t, "myscratch")
-//	h.AddClient(88, 71)
+//	h.AddClient(88, 62)
 //	h.AddClient(189, 62)
+//	h.ResizeClient(0, 88, 71)
 //	w, hgt, _ := h.WindowSize() // expect 88x61 (smallest, minus status row)
 package multiclienttmux
 
@@ -82,7 +83,7 @@ func New(t *testing.T, sessionName string) *Harness {
 		"set-option", "-t", sessionName, "window-size", "smallest", ";",
 		"set-window-option", "-t", sessionName, "aggressive-resize", "on",
 	).CombinedOutput(); err != nil {
-		t.Fatalf("multiclienttmux: set size policy: %v\n%s", err, out)
+		t.Fatalf("multiclienttmux: set window-size/aggressive-resize: %v\n%s", err, out)
 	}
 
 	h := &Harness{

--- a/internal/testutil/multiclienttmux/multiclienttmux_test.go
+++ b/internal/testutil/multiclienttmux/multiclienttmux_test.go
@@ -1,7 +1,9 @@
 package multiclienttmux_test
 
 import (
+	"math"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -60,12 +62,13 @@ func TestAggregateSize_FitsCrossedClientDimensions(t *testing.T) {
 
 	h := multiclienttmux.New(t, "agg")
 
-	if err := h.AddClient(88, 62); err != nil {
-		t.Fatalf("AddClient 88x62: %v", err)
+	if err := h.AddClient(100, 62); err != nil {
+		t.Fatalf("AddClient 100x62: %v", err)
 	}
 	if err := h.AddClient(189, 62); err != nil {
 		t.Fatalf("AddClient 189x62: %v", err)
 	}
+	requireWindowSize(t, h, 100, 61)
 
 	// Simulate a font-size change making the narrow client taller. Neither
 	// client now dominates both axes; with a one-row status line, their usable
@@ -77,6 +80,35 @@ func TestAggregateSize_FitsCrossedClientDimensions(t *testing.T) {
 	// The component-wise minimum is the only shared size both viewers can show
 	// completely.
 	requireWindowSize(t, h, 88, 61)
+}
+
+func TestResizeClient_RejectsInvalidDimensions(t *testing.T) {
+	skipIfNoTmux(t)
+
+	h := multiclienttmux.New(t, "invalid-resize")
+	if err := h.AddClient(80, 24); err != nil {
+		t.Fatalf("AddClient 80x24: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		cols int
+		rows int
+	}{
+		{name: "zero columns", cols: 0, rows: 24},
+		{name: "negative columns", cols: -1, rows: 24},
+		{name: "oversized columns", cols: math.MaxUint16 + 1, rows: 24},
+		{name: "zero rows", cols: 80, rows: 0},
+		{name: "negative rows", cols: 80, rows: -1},
+		{name: "oversized rows", cols: 80, rows: math.MaxUint16 + 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := h.ResizeClient(0, tc.cols, tc.rows)
+			if err == nil || !strings.Contains(err.Error(), "dimensions out of range") {
+				t.Fatalf("ResizeClient(0, %d, %d) error = %v; want dimensions-out-of-range error", tc.cols, tc.rows, err)
+			}
+		})
+	}
 }
 
 func TestNew_Cleanup(t *testing.T) {

--- a/internal/testutil/multiclienttmux/multiclienttmux_test.go
+++ b/internal/testutil/multiclienttmux/multiclienttmux_test.go
@@ -3,6 +3,7 @@ package multiclienttmux_test
 import (
 	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/testutil/multiclienttmux"
 )
@@ -36,27 +37,46 @@ func TestNew_BootsIsolatedServer(t *testing.T) {
 	}
 }
 
-func TestAggregateSize_ReportsLargestClient(t *testing.T) {
+func requireWindowSize(t *testing.T, h *multiclienttmux.Harness, wantWidth, wantHeight int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		width, height, err := h.WindowSize()
+		if err == nil && width == wantWidth && height == wantHeight {
+			return
+		}
+		if time.Now().After(deadline) {
+			if err != nil {
+				t.Fatalf("WindowSize: %v", err)
+			}
+			t.Fatalf("WindowSize=%dx%d; want %dx%d", width, height, wantWidth, wantHeight)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+func TestAggregateSize_FitsCrossedClientDimensions(t *testing.T) {
 	skipIfNoTmux(t)
 
 	h := multiclienttmux.New(t, "agg")
 
-	// Spawn two clients of different sizes; aggregate-size = largest.
-	if err := h.AddClient(80, 24); err != nil {
-		t.Fatalf("AddClient 80x24: %v", err)
+	if err := h.AddClient(88, 62); err != nil {
+		t.Fatalf("AddClient 88x62: %v", err)
 	}
-	if err := h.AddClient(120, 40); err != nil {
-		t.Fatalf("AddClient 120x40: %v", err)
+	if err := h.AddClient(189, 62); err != nil {
+		t.Fatalf("AddClient 189x62: %v", err)
 	}
 
-	// With aggressive-resize=on, the window resizes to the largest client.
-	w, hgt, err := h.WindowSize()
-	if err != nil {
-		t.Fatalf("WindowSize: %v", err)
+	// Simulate a font-size change making the narrow client taller. Neither
+	// client now dominates both axes; with a one-row status line, their usable
+	// sizes are 88x70 and 189x61.
+	if err := h.ResizeClient(0, 88, 71); err != nil {
+		t.Fatalf("ResizeClient 88x71: %v", err)
 	}
-	if w < 80 || hgt < 24 {
-		t.Fatalf("WindowSize=%dx%d; expected at least 80x24", w, hgt)
-	}
+
+	// The component-wise minimum is the only shared size both viewers can show
+	// completely.
+	requireWindowSize(t, h, 88, 61)
 }
 
 func TestNew_Cleanup(t *testing.T) {

--- a/internal/tmux/initialsize.go
+++ b/internal/tmux/initialsize.go
@@ -12,20 +12,19 @@ import (
 // default-size, and agent-deck runs the tool as the pane's INITIAL PROCESS
 // (RunCommandAsInitialProcess), so the tool paints its first frames into an
 // 80x24 window. The attach client arrives later at the real terminal size and
-// window-size=largest grows the window — but a TUI that fixed its layout
-// geometry on the first paint keeps drawing the 80-column layout into the
-// wider pane. OpenCode does exactly that and renders visibly clipped; tools
+// tmux resizes the window — but a TUI that fixed its layout geometry on the
+// first paint keeps drawing the 80-column layout into the wider pane. OpenCode
+// does exactly that and renders visibly clipped; tools
 // that reflow on SIGWINCH (Claude Code, Codex) hid the gap for two releases.
 //
 // This is the other half of #1167, which pre-sized only the ATTACH client's
 // PTY (see StartAttachPTY) and left the session's own creation at the default.
-// aggressive-resize cannot rescue the birth size either: it is a no-op under
-// window-size=largest, which Session.Start pins.
+// aggressive-resize cannot rescue the birth size before a client attaches.
 const (
 	// tmuxDefaultCols/Rows are tmux's own birth size for a detached session.
 	// They are a floor, not a target: a host terminal narrower than this must
-	// not birth a pane MORE clipped than tmux's default already is, and
-	// window-size=largest shrinks the window to the real client on attach.
+	// not birth a pane MORE clipped than tmux's default already is. Window-size
+	// arbitration moves the window to the real client dimensions on attach.
 	tmuxDefaultCols = 80
 	tmuxDefaultRows = 24
 

--- a/internal/tmux/issue1167_attach_width_test.go
+++ b/internal/tmux/issue1167_attach_width_test.go
@@ -40,7 +40,8 @@ func tmuxCtl1167(t *testing.T, socket string, args ...string) {
 
 // newDetachedSession1167 builds the worst-case window this fix has to survive:
 // a detached session with NO -x/-y (so tmux uses its 80x24 default-size) plus
-// the window-size=largest / aggressive-resize=on options Session.Start pins.
+// the window-size=largest / aggressive-resize=on policy used when #1167 was
+// reported.
 //
 // Production no longer births sessions this way — startCommandSpec passes
 // -x/-y from InitialWindowSize (#1694) — but the attach client must still

--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -426,10 +426,10 @@ func emitScrollbackClear(w io.Writer) {
 // dimensions.
 //
 // #1167: tmux clients connect at their PTY's size, and a bare pty.Start creates
-// the attach client's PTY at tmux's 80x24 default — so window-size=largest pins
-// the window to 80 cols, ~half of a wide terminal, until an async SIGWINCH grows
-// it. Reading the controlling terminal's real size up front and starting the PTY
-// with it makes the client full-width from frame one.
+// the attach client's PTY at tmux's 80x24 default. That can size the window to
+// 80 cols, ~half of a wide terminal, until an async SIGWINCH grows it. Reading
+// the controlling terminal's real size up front and starting the PTY with it
+// makes the client full-width from frame one.
 //
 // The session's own birth size is the other half of this and is fixed
 // separately: see InitialWindowSize (#1694). Both are needed — this one keeps

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2512,17 +2512,17 @@ func (s *Session) Start(command string) error {
 	// #1625: the key-handling defaults are gated through OptionOverrides so an
 	// explicit user tmux setting wins (see gatedTmuxKeyOptionArgs).
 	startArgs = append(startArgs, gatedTmuxKeyOptionArgs(s.Name, s.OptionOverrides, s.configureTerminalFeatures)...)
-	// Multi-client size negotiation. Web's xterm.js connects via a tmux -C
-	// control client (controlpipe.go) at the same time as native `tmux attach`
-	// clients (Ghostty, iTerm). Default `window-size latest` makes the window
-	// flip to whichever client most recently sent input, so larger clients see
-	// dot-filled void cells and smaller clients clip. `largest` keeps the
-	// window sized to the biggest client; `aggressive-resize` only resizes
-	// windows that are actively viewed (avoids cross-window resize storms).
+	// Multi-client size negotiation. Web's xterm.js connects at the same time
+	// as native `tmux attach` clients (Ghostty, iTerm). `window-size=largest`
+	// maximizes each axis independently, so crossed client dimensions such as
+	// 88x71 and 189x62 produce a synthetic 189x70 pane that no client can fully
+	// display. `smallest` keeps the complete pane visible in every attached
+	// client; larger clients may show unused cells. `aggressive-resize` limits
+	// resizing to windows that are actively viewed (avoids resize storms).
 	// See tmux(1) "window-size" / "aggressive-resize" and tmux issue #2594.
 	// Both are gated through OptionOverrides so users can opt out.
 	if _, ok := s.OptionOverrides["window-size"]; !ok {
-		startArgs = append(startArgs, ";", "set-option", "-t", s.Name, "window-size", "largest")
+		startArgs = append(startArgs, ";", "set-option", "-t", s.Name, "window-size", "smallest")
 	}
 	if _, ok := s.OptionOverrides["aggressive-resize"]; !ok {
 		startArgs = append(startArgs, ";", "set-window-option", "-t", s.Name, "aggressive-resize", "on")

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -2498,28 +2498,27 @@ func TestSession_MouseMode_EnableMouseMode_Disabled_Integration(t *testing.T) {
 }
 
 // TestSession_MultiClientSizePolicy_Integration verifies that on session
-// creation agent-deck pins window-size=largest (session option) and
-// aggressive-resize=on (window option). This is the fix for the dots-in-
-// window symptom that arose when web's xterm.js control client and a native
-// `tmux attach` client had different geometries — see tmux issue #2594.
+// creation agent-deck pins window-size=smallest (session option) and
+// aggressive-resize=on (window option). This keeps the complete pane visible
+// when attached clients have different or crossed geometries.
 func TestSession_MultiClientSizePolicy_Integration(t *testing.T) {
-	if os.Getenv("AGENTDECK_TEST_PROFILE") == "" {
-		t.Skip("Skipping tmux integration test - no test profile")
-	}
+	skipIfNoTmuxBinary(t)
 
 	s := NewSession("test-size-policy", t.TempDir())
 	s.InstanceID = "test-instance-size-policy"
+	s.SocketName = fmt.Sprintf("ad-size-policy-%d", time.Now().UnixNano())
+	t.Cleanup(func() { _ = exec.Command("tmux", "-L", s.SocketName, "kill-server").Run() })
 
 	err := s.Start("sleep 3600")
 	require.NoError(t, err)
 	defer func() { _ = s.Kill() }()
 
-	winSize, err := exec.Command("tmux", "show-options", "-t", s.Name, "-A", "-v", "window-size").Output()
+	winSize, err := s.tmuxCmd("show-options", "-t", s.Name, "-A", "-v", "window-size").Output()
 	require.NoError(t, err)
-	assert.Equal(t, "largest", strings.TrimSpace(string(winSize)),
-		"new sessions must pin window-size=largest so a smaller client cannot drag the window down (tmux #2594)")
+	assert.Equal(t, "smallest", strings.TrimSpace(string(winSize)),
+		"new sessions must pin window-size=smallest so every attached client can display the complete pane")
 
-	aggResize, err := exec.Command("tmux", "show-options", "-w", "-t", s.Name+":0", "-A", "-v", "aggressive-resize").Output()
+	aggResize, err := s.tmuxCmd("show-options", "-w", "-t", s.Name+":0", "-A", "-v", "aggressive-resize").Output()
 	require.NoError(t, err)
 	assert.Equal(t, "on", strings.TrimSpace(string(aggResize)),
 		"new sessions must enable aggressive-resize so windows only resize when actively viewed")

--- a/internal/web/handlers_ws.go
+++ b/internal/web/handlers_ws.go
@@ -106,9 +106,9 @@ func (s *Server) handleSessionWS(w http.ResponseWriter, r *http.Request) {
 	// actually runs. Without this, an idle session whose client vanished
 	// (network drop, mobile app killed) leaves the read loop below blocked
 	// forever in ReadMessage, so `defer bridge.Close()` never fires and the
-	// tmux attach client leaks. Under `window-size largest` a single leaked
-	// wide client then pins the shared window geometry for every other viewer
-	// — the symptom being a phone terminal that stops wrapping to its screen.
+	// tmux attach client leaks. Because attached clients participate in window
+	// sizing, a leaked client can then distort the shared geometry for every
+	// other viewer — for example, a phone terminal may stop wrapping correctly.
 	// We send protocol-level pings and require a pong within pongWait; both
 	// browsers and URLSessionWebSocketTask answer pings automatically.
 	pongWait, pingPeriod := wsPongWait, wsPingPeriod

--- a/internal/web/terminal_bridge.go
+++ b/internal/web/terminal_bridge.go
@@ -182,14 +182,13 @@ func (b *tmuxPTYBridge) Resize(cols, rows int) error {
 	// process. Because the attach client (see tmuxAttachCommand) is no longer
 	// flagged `-f ignore-size`, the tmux server now uses this client's PTY
 	// size as its declared geometry and re-arbitrates the window dimensions
-	// per the session's `window-size` policy (`largest` — set at Session.Start
+	// per the session's `window-size` policy (`smallest` — set at Session.Start
 	// in internal/tmux/tmux.go). The previous `tmux resize-window` call here
 	// was removed because it implicitly flipped the session option to
 	// `window-size=manual` and pinned the window to the web viewport, which
 	// dragged native attached clients (Ghostty, iTerm) along with it. Letting
-	// tmux do the arbitration via `largest` keeps every client at the size of
-	// the biggest viewer; smaller clients see a clipped portion of the larger
-	// window content (no dot-filled void cells).
+	// tmux arbitrate via `smallest` keeps the complete pane visible in every
+	// attached client, with unused cells possible in larger clients.
 	if err := pty.Setsize(b.ptmx, &pty.Winsize{
 		Rows: uint16(rows), // #nosec G115 -- terminal rows fits in uint16; PTY ABI enforces this
 		Cols: uint16(cols), // #nosec G115 -- terminal cols fits in uint16; PTY ABI enforces this
@@ -308,13 +307,13 @@ func tmuxCommandContext(ctx context.Context, socketName string, args ...string) 
 
 func tmuxAttachCommand(sessionName, socketName string) *exec.Cmd {
 	// Web's attach is now a normal client whose PTY size participates in tmux's
-	// `window-size=largest` arbitration (set at Session.Start). Previously we
+	// `window-size=smallest` arbitration (set at Session.Start). Previously we
 	// passed `-f ignore-size` together with a manual `tmux resize-window` call
 	// in (*tmuxPTYBridge).Resize; the manual resize-window flipped the session
 	// option to `window-size=manual` and pinned the window to the web viewport
-	// for ALL attached clients (Ghostty, iTerm) — the dots-in-window symptom.
-	// With largest in effect, every client sees content sized to the biggest
-	// viewer; smaller clients see a clipped portion rather than dot-filled void.
+	// for ALL attached clients (Ghostty, iTerm). With smallest in effect, every
+	// client can display the complete shared pane; larger clients may show
+	// unused cells around it.
 	// `-u` forces UTF-8 output regardless of the daemon's locale. Same class of
 	// bug as the TERM handling below: when the web daemon runs under launchd/
 	// systemd its environment carries no LANG/LC_*, so tmux treats this client as

--- a/internal/web/terminal_bridge_integration_test.go
+++ b/internal/web/terminal_bridge_integration_test.go
@@ -46,7 +46,9 @@ func TestTmuxPTYBridgeResize(t *testing.T) {
 	// to the bridge's attach client size on CI's headless tmux. Production
 	// session creation always sets these (see internal/tmux/tmux.go); the
 	// test's manual `tmux new-session` bypassed that path.
-	_ = exec.Command("tmux", "set-option", "-t", sessionName, "window-size", "largest").Run()
+	if output, err := exec.Command("tmux", "set-option", "-t", sessionName, "window-size", "smallest").CombinedOutput(); err != nil {
+		t.Fatalf("tmux set-option window-size=smallest failed: %v (%s)", err, strings.TrimSpace(string(output)))
+	}
 	_ = exec.Command("tmux", "set-window-option", "-t", sessionName, "aggressive-resize", "on").Run()
 
 	srv := NewServer(Config{

--- a/internal/web/terminal_bridge_test.go
+++ b/internal/web/terminal_bridge_test.go
@@ -12,9 +12,9 @@ import (
 // flipping the session option to `window-size=manual`, dragging the window
 // for ALL attached clients (Ghostty, iTerm) — the dots-in-window bug.
 // With ignore-size removed and resize-window dropped, the web client
-// participates in tmux's `window-size=largest` arbitration set at
-// Session.Start (internal/tmux/tmux.go), so every client sees content sized
-// to the biggest viewer.
+// participates in tmux's `window-size=smallest` arbitration set at
+// Session.Start (internal/tmux/tmux.go), so every client can display the
+// complete shared pane.
 func TestTmuxAttachCommand_NoIgnoreSize(t *testing.T) {
 	t.Setenv("TMUX", "")
 
@@ -72,8 +72,8 @@ func TestTmuxAttachCommand_SocketNameOverridesEnv(t *testing.T) {
 // TestResize_RejectsNonsensicalDimensions: the web bridge must reject resize
 // requests with dimensions too small to be a real terminal. When xterm.js
 // calls fitAddon.fit() on a display:none container, it computes cols≈2 rows≈1
-// which, if forwarded to the PTY, shrinks the tmux window via window-size=largest
-// and corrupts all session output until a session restart.
+// which, if forwarded to the PTY, shrinks the tmux window via
+// window-size=smallest and corrupts all session output until a session restart.
 func TestResize_RejectsNonsensicalDimensions(t *testing.T) {
 	bridge := &tmuxPTYBridge{}
 


### PR DESCRIPTION
## What problem does this solve?

Agent Deck can clip every attached terminal when clients have crossed dimensions. For example, an `88x71` client and a `189x62` client produce a synthetic `189x70` pane under tmux's `window-size=largest`, even though neither client can display that complete pane.

## Why this change

Tmux computes `window-size=largest` independently by axis. This works when one client is both wider and taller, but crossed dimensions take the width from one client and the height from another.

This changes Agent Deck's default to `window-size=smallest`, the only built-in tmux policy that guarantees every attached client can display the complete shared pane. `aggressive-resize=on` remains unchanged, and the existing `[tmux].options` override still lets users select `largest` when maximizing the backing grid is more important than complete visibility.

The multi-client harness now explicitly configures the production policy and reproduces the resize workflow with crossed client dimensions. The previous test used nested `80x24` and `120x40` clients, did not set `window-size=largest`, and asserted only a weak lower bound, so it could not detect this failure.

## User impact

New or restarted Agent Deck sessions keep prompts, status lines, and bottom rows visible in every attached client. Larger clients may show unused cells and applications reflow to the smallest attached viewport. Users who prefer the previous maximum-canvas behavior can override `window-size` to `largest`.

## Evidence

Observed on tmux 3.7c with two live clients:

```text
clients:
88x71
189x62
largest: 189x70
smallest: 88x61
```

The new regression starts clients at `100x62` and `189x62`, verifies the initial `100x61` pane, then resizes the narrow client to `88x71` and verifies the resulting `88x61` pane. This makes the font-size-change transition observable. Invalid resize dimensions are also rejected before conversion to the PTY's `uint16` fields. With the fix:

```text
ok  github.com/asheshgoplani/agent-deck/internal/testutil/multiclienttmux
ok  github.com/asheshgoplani/agent-deck/internal/tmux
```

Targeted race runs:

```text
go test -race ./internal/testutil/multiclienttmux ./internal/tmux \
  -run 'TestAggregateSize_FitsCrossedClientDimensions|TestResizeClient_RejectsInvalidDimensions|TestSession_MultiClientSizePolicy_Integration' -count=1

go test -race -tags hostsensitive ./internal/web \
  -run TestTmuxPTYBridgeResize -count=1
```

Result: all three packages pass.

Revert-check: restoring the production `window-size=largest` setting makes `TestSession_MultiClientSizePolicy_Integration` fail with `expected: "smallest", actual: "largest"`.

Additional checks:

```text
go vet ./...                  pass
go build ./...                pass
golangci-lint run             pass (0 issues)
```

The full sandboxed suite was attempted. It encountered unrelated environment-dependent and timing failures, including `TestIsLiveTmuxClientOrServer_OneShotClient_NotLive`; that tmux failure reproduces unchanged on upstream `main`.

Performance: session startup still configures these options in the same single batched tmux invocation. The command count and control flow are unchanged; only the `window-size` argument changes.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** openai-codex/gpt-5.6-sol

**Prompt / session log (optional):** —

## What actually bothered you

I changed the terminal font size while using pi through Agent Deck, and the bottom of the TUI became unreachable. I wanted to identify which layer owned the resize bug and fix it in the right project.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=openai-codex/gpt-5.6-sol intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Multi-client terminal sessions now size shared panes to the smallest attached client, keeping the complete pane visible across viewers.
  - Resizing a client now produces more consistent shared terminal dimensions and reduces clipping or unexpected wrapping for other viewers.
  - Larger terminal clients may display unused space when accommodating smaller clients.

- **Documentation**
  - Updated terminal sizing and attachment guidance to reflect the improved multi-client behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->