### PR TITLE
fix(remote): harden the persistent channel for production fleets

### DIFF
--- a/cmd/agent-deck/remote_agent_cmd.go
+++ b/cmd/agent-deck/remote_agent_cmd.go
@@ -65,12 +65,14 @@ import (
 // older than the stamp of a mutating command's reply predates that command.
 //
 // Liveness: the agent pushes {"event":"ping"} every remoteAgentPingEvery
-// and exits when a write to stdout fails, when its outbound queue backs up
-// (the peer stopped reading), or when nothing arrives on stdin for
+// and exits when a write to stdout fails, when its outbound queue stays
+// full for remoteAgentWriteStall (the peer stopped reading), or when
+// nothing arrives on stdin for
 // remoteAgentIdleAfter. Any line counts as inbound: a request, a cancel or
 // {"id":N,"ping":true} (answered with {"id":N,"code":0}; without an id it
 // is silently absorbed). Writes go through a bounded queue drained by one
-// goroutine, so a dead pipe can never block the watcher or a reply.
+// goroutine, so a dead pipe can hold the watcher or a reply for at most
+// that stall, never for good; a slow live pipe merely backpressures them.
 //
 // Pane watch (#2177 follow-up): {"id":2,"watch":"<sessionID>","lines":200}
 // asks the agent to follow one session's tmux pane. The agent captures it
@@ -158,6 +160,9 @@ const (
 	// remoteAgentCloseWait is how long the exit waits for queued lines to
 	// reach a stdout that may no longer be read.
 	remoteAgentCloseWait = 2 * time.Second
+	// remoteAgentWriteStall is how long a producer may wait for room in a
+	// full outbound queue before the peer counts as gone.
+	remoteAgentWriteStall = 30 * time.Second
 )
 
 // remoteAgentConfig wires serveRemoteAgent. Zero durations and counts take
@@ -173,6 +178,8 @@ type remoteAgentConfig struct {
 	PaneEvery  time.Duration
 	PingEvery  time.Duration
 	IdleAfter  time.Duration
+	// WriteStall bounds how long a write may wait for a full outbound queue.
+	WriteStall time.Duration
 	// MaxConcurrent caps subprocesses; MaxPushBytes caps pushed listings.
 	MaxConcurrent int
 	MaxPushBytes  int
@@ -187,6 +194,9 @@ func (c remoteAgentConfig) withDefaults() remoteAgentConfig {
 	}
 	if c.IdleAfter <= 0 {
 		c.IdleAfter = remoteAgentIdleAfter
+	}
+	if c.WriteStall <= 0 {
+		c.WriteStall = remoteAgentWriteStall
 	}
 	if c.MaxConcurrent <= 0 {
 		c.MaxConcurrent = remoteAgentMaxConcurrent
@@ -358,23 +368,29 @@ func remoteAgentPaneCapturer(profile string) func(context.Context, string) (stri
 }
 
 // remoteAgentWriter is the one path to stdout: a bounded queue drained by a
-// single goroutine. write never blocks; when the queue is full or a write
-// fails the peer counts as gone and fail runs once (it ends the agent).
+// single goroutine. write blocks for at most stall when the queue is full:
+// a slow but live pipe (a large listing on a thin link while pane pushes
+// keep coming) only backpressures the producers, as the old blocking write
+// did; a pipe nobody reads any more, or one whose write fails, makes the
+// peer count as gone and fail runs once (it ends the agent). After that
+// every write returns at once so the shutdown never waits on the pipe.
 type remoteAgentWriter struct {
 	q        chan []byte
 	done     chan struct{}
+	failed   chan struct{}
 	failOnce sync.Once
 	fail     func()
 	closed   sync.Once
+	stall    time.Duration
 }
 
-func newRemoteAgentWriter(out io.Writer, size int, fail func()) *remoteAgentWriter {
-	w := &remoteAgentWriter{q: make(chan []byte, size), done: make(chan struct{}), fail: fail}
+func newRemoteAgentWriter(out io.Writer, size int, stall time.Duration, fail func()) *remoteAgentWriter {
+	w := &remoteAgentWriter{q: make(chan []byte, size), done: make(chan struct{}), failed: make(chan struct{}), fail: fail, stall: stall}
 	go func() {
 		defer close(w.done)
 		for b := range w.q {
 			if _, err := out.Write(b); err != nil {
-				w.failOnce.Do(w.fail)
+				w.giveUp()
 				for range w.q { // drain until the producers stop
 				}
 				return
@@ -384,15 +400,33 @@ func newRemoteAgentWriter(out io.Writer, size int, fail func()) *remoteAgentWrit
 	return w
 }
 
+func (w *remoteAgentWriter) giveUp() {
+	w.failOnce.Do(func() {
+		close(w.failed)
+		w.fail()
+	})
+}
+
 func (w *remoteAgentWriter) write(r remoteAgentReply) {
 	b, err := json.Marshal(r)
 	if err != nil {
 		return
 	}
+	line := append(b, '\n')
 	select {
-	case w.q <- append(b, '\n'):
+	case w.q <- line:
+		return
+	case <-w.failed:
+		return
 	default:
-		w.failOnce.Do(w.fail)
+	}
+	t := time.NewTimer(w.stall)
+	defer t.Stop()
+	select {
+	case w.q <- line:
+	case <-w.failed:
+	case <-t.C:
+		w.giveUp()
 	}
 }
 
@@ -415,7 +449,7 @@ func serveRemoteAgent(ctx context.Context, in io.Reader, out io.Writer, cfg remo
 	cfg = cfg.withDefaults()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	w := newRemoteAgentWriter(out, remoteAgentWriteQueue, cancel)
+	w := newRemoteAgentWriter(out, remoteAgentWriteQueue, cfg.WriteStall, cancel)
 	write := w.write
 
 	write(remoteAgentReply{Event: "ready"})
@@ -552,13 +586,16 @@ loop:
 			write(remoteAgentReply{ID: req.ID, Code: 2, Error: "verb not allowed over the channel"})
 			continue
 		}
+		// Register before handing off so a cancel line that follows the
+		// request line on stdin always finds it.
+		f := requests.start(ctx, req)
 		wg.Add(1)
-		go func(req remoteAgentRequest) {
+		go func(req remoteAgentRequest, f *remoteAgentFlight) {
 			defer wg.Done()
-			if reply, ok := requests.run(ctx, req); ok {
+			if reply, ok := requests.wait(req, f); ok {
 				write(reply)
 			}
-		}(req)
+		}(req, f)
 	}
 	cancel()
 	setWatch("", 0)
@@ -714,11 +751,11 @@ func remoteAgentReadOnly(args []string) bool {
 	return false
 }
 
-// run executes req (or joins an identical read-only run in flight) and
-// returns its reply; ok is false when the request was cancelled, in which
-// case nothing is answered.
-func (r *remoteAgentRequests) run(ctx context.Context, req remoteAgentRequest) (remoteAgentReply, bool) {
+// start registers req and begins its run (or joins an identical read-only
+// run in flight). It returns at once; wait collects the reply.
+func (r *remoteAgentRequests) start(ctx context.Context, req remoteAgentRequest) *remoteAgentFlight {
 	r.mu.Lock()
+	defer r.mu.Unlock()
 	key := ""
 	if remoteAgentReadOnly(req.Args) {
 		key = strings.Join(req.Args, "\x00")
@@ -734,8 +771,12 @@ func (r *remoteAgentRequests) run(ctx context.Context, req remoteAgentRequest) (
 	}
 	f.waiters++
 	r.byID[req.ID] = f
-	r.mu.Unlock()
+	return f
+}
 
+// wait blocks until req's run ends and returns its reply; ok is false when
+// the request was cancelled meanwhile, in which case nothing is answered.
+func (r *remoteAgentRequests) wait(req remoteAgentRequest, f *remoteAgentFlight) (remoteAgentReply, bool) {
 	<-f.done
 	r.mu.Lock()
 	cancelled := r.byID[req.ID] != f

--- a/cmd/agent-deck/remote_agent_cmd.go
+++ b/cmd/agent-deck/remote_agent_cmd.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -17,6 +18,7 @@ import (
 	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
 )
 
 // `agent-deck remote-agent` is the remote end of a persistent channel
@@ -31,6 +33,10 @@ import (
 // the answer is byte-for-byte what `ssh host agent-deck <args>` would print;
 // only the ssh handshake and channel setup per command are gone, and the
 // change feed is new. Requests run concurrently; answers carry their id.
+// At most remoteAgentMaxConcurrent subprocesses run at once (the rest wait
+// their turn), identical read-only requests that overlap share one run and
+// each get the answer under their own id, and {"id":N,"cancel":true} kills
+// the subprocess of request N (no answer follows for a cancelled request).
 //
 // The change feed's probe does not fork: it keeps the profile's storage open
 // in this process and builds the two listings through the same functions
@@ -38,7 +44,33 @@ import (
 // buildGroupListJSON). Booting the binary twice per change, each opening
 // storage and refreshing every status, was most of the second between a
 // change on the remote and the local screen; the event carries the probe's
-// duration as probe_ms so that cost stays visible.
+// duration as probe_ms so that cost stays visible. The probe is read-only:
+// this process never registers a global state DB, so the last-activity
+// flush a status refresh would otherwise do is a no-op here, and a probe
+// never moves the stamp it watches. Stamp changes are debounced: a probe
+// runs no sooner than remoteAgentProbeQuiet after the previous one ended,
+// and a change landing while a probe runs is probed again instead of being
+// taken as seen (safe only because the probe is read-only: nothing it does
+// can move the stamp and chain probes).
+//
+// The listings travel compacted (json.Marshal form, no indentation): the
+// same JSON documents `list --json` and `group list --json` print, minus
+// whitespace, so the local parser sees the same shape. A "changed" event
+// whose listings would exceed remoteAgentMaxPushBytes, whose probe failed,
+// or whose listings do not look like a JSON array and object, is pushed
+// bare (no listings) so the local side fetches instead of applying junk.
+// Each "changed" event and each command reply carries "stamp": the state
+// DB's newest mtime (remote clock, unix nanoseconds) when the listing was
+// taken, or after the command finished. A pushed listing whose stamp is
+// older than the stamp of a mutating command's reply predates that command.
+//
+// Liveness: the agent pushes {"event":"ping"} every remoteAgentPingEvery
+// and exits when a write to stdout fails, when its outbound queue backs up
+// (the peer stopped reading), or when nothing arrives on stdin for
+// remoteAgentIdleAfter. Any line counts as inbound: a request, a cancel or
+// {"id":N,"ping":true} (answered with {"id":N,"code":0}; without an id it
+// is silently absorbed). Writes go through a bounded queue drained by one
+// goroutine, so a dead pipe can never block the watcher or a reply.
 //
 // Pane watch (#2177 follow-up): {"id":2,"watch":"<sessionID>","lines":200}
 // asks the agent to follow one session's tmux pane. The agent captures it
@@ -60,6 +92,10 @@ type remoteAgentRequest struct {
 	Watch   string   `json:"watch,omitempty"`
 	Lines   int      `json:"lines,omitempty"`
 	Unwatch bool     `json:"unwatch,omitempty"`
+	// Cancel kills the subprocess of the request with this id, if any.
+	Cancel bool `json:"cancel,omitempty"`
+	// Ping is a liveness line from the peer; it resets the idle deadline.
+	Ping bool `json:"ping,omitempty"`
 }
 
 type remoteAgentReply struct {
@@ -75,6 +111,9 @@ type remoteAgentReply struct {
 	Groups   string `json:"groups,omitempty"`
 	// ProbeMS is how long the "changed" event's listings took to build.
 	ProbeMS int64 `json:"probe_ms,omitempty"`
+	// Stamp is the state DB's newest mtime (remote clock, unix nanoseconds)
+	// when a "changed" event's listing was taken, or after a command ran.
+	Stamp int64 `json:"stamp,omitempty"`
 	// A "pane" event names the watched session; its text is in Stdout.
 	Session string `json:"session,omitempty"`
 }
@@ -84,10 +123,79 @@ type remoteAgentReply struct {
 // tests inject their own.
 type remoteAgentProbeFunc func() (listJSON, groupJSON string, err error)
 
+// remoteAgentRunFunc runs one CLI request and returns its stdout, stderr
+// and exit code. ctx ends when the request is cancelled or times out.
+type remoteAgentRunFunc func(ctx context.Context, args []string) (stdout, stderr string, code int)
+
 // remoteAgentPaneEvery is how often the watched session's pane is captured.
 // Pushes only go out when the text changed, so an idle pane costs one local
 // capture per tick and nothing on the wire.
 const remoteAgentPaneEvery = 300 * time.Millisecond
+
+const (
+	// remoteAgentStampEvery is how often the state DB's stamp is checked.
+	remoteAgentStampEvery = 250 * time.Millisecond
+	// remoteAgentProbeQuiet is the least time between two probes: a burst
+	// of writes collapses into one probe after the last of them, and a
+	// probe can never start again the moment it ends.
+	remoteAgentProbeQuiet = 2 * time.Second
+	// remoteAgentPingEvery is how often {"event":"ping"} is pushed.
+	remoteAgentPingEvery = 20 * time.Second
+	// remoteAgentIdleAfter is how long stdin may stay silent before the
+	// agent decides its peer is gone and exits; the local side pings well
+	// within it.
+	remoteAgentIdleAfter = 10 * time.Minute
+	// remoteAgentMaxConcurrent caps the subprocesses running at once.
+	remoteAgentMaxConcurrent = 4
+	// remoteAgentMaxPushBytes caps the listings a "changed" event carries;
+	// above it the event goes bare and the local side fetches.
+	remoteAgentMaxPushBytes = 4 << 20
+	// remoteAgentWriteQueue is how many outbound lines may wait for the
+	// pipe before the peer counts as gone.
+	remoteAgentWriteQueue = 64
+	// remoteAgentRequestTimeout bounds one subprocess.
+	remoteAgentRequestTimeout = 5 * time.Minute
+	// remoteAgentCloseWait is how long the exit waits for queued lines to
+	// reach a stdout that may no longer be read.
+	remoteAgentCloseWait = 2 * time.Second
+)
+
+// remoteAgentConfig wires serveRemoteAgent. Zero durations and counts take
+// the defaults above; a nil probe or empty WatchPath disables the change
+// feed, a nil Capture disables pane watching.
+type remoteAgentConfig struct {
+	Run        remoteAgentRunFunc
+	Probe      remoteAgentProbeFunc
+	WatchPath  string
+	WatchEvery time.Duration
+	ProbeQuiet time.Duration
+	Capture    func(context.Context, string) (string, error)
+	PaneEvery  time.Duration
+	PingEvery  time.Duration
+	IdleAfter  time.Duration
+	// MaxConcurrent caps subprocesses; MaxPushBytes caps pushed listings.
+	MaxConcurrent int
+	MaxPushBytes  int
+}
+
+func (c remoteAgentConfig) withDefaults() remoteAgentConfig {
+	if c.ProbeQuiet <= 0 {
+		c.ProbeQuiet = remoteAgentProbeQuiet
+	}
+	if c.PingEvery <= 0 {
+		c.PingEvery = remoteAgentPingEvery
+	}
+	if c.IdleAfter <= 0 {
+		c.IdleAfter = remoteAgentIdleAfter
+	}
+	if c.MaxConcurrent <= 0 {
+		c.MaxConcurrent = remoteAgentMaxConcurrent
+	}
+	if c.MaxPushBytes <= 0 {
+		c.MaxPushBytes = remoteAgentMaxPushBytes
+	}
+	return c
+}
 
 // remoteAgentDeniedVerbs are never run through the channel: they need a
 // terminal, or must not be reachable from a remote TUI at all.
@@ -103,7 +211,9 @@ func handleRemoteAgent(profile string, args []string) {
 			fmt.Println("Serve JSON-line requests on stdin for a local agent-deck TUI (one persistent")
 			fmt.Println("channel per remote) and push {\"event\":\"changed\"} when the profile's state changes.")
 			fmt.Println("{\"id\":N,\"watch\":\"<session>\",\"lines\":200} follows one session's pane ({\"event\":\"pane\"} on change);")
-			fmt.Println("{\"id\":N,\"unwatch\":true} stops it.")
+			fmt.Println("{\"id\":N,\"unwatch\":true} stops it. {\"id\":N,\"cancel\":true} kills request N;")
+			fmt.Println("{\"id\":N,\"ping\":true} keeps the channel alive. The agent pushes {\"event\":\"ping\"} itself")
+			fmt.Println("and exits when stdout fails or stdin stays silent for 10 minutes.")
 			return
 		}
 	}
@@ -120,6 +230,13 @@ func handleRemoteAgent(profile string, args []string) {
 	// The in-process probe refreshes statuses through tmux like `list` does,
 	// and `list` fixes up PATH for tmux before it starts.
 	ensureTmuxOnPath()
+	// The probe must stay read-only (see newRemoteAgentProbe): this verb
+	// is dispatched before main registers the global state DB, and it
+	// must never be registered here.
+	if statedb.GetGlobal() != nil {
+		fmt.Fprintln(os.Stderr, "remote-agent: a global state DB is registered; the probe would write last-activity rows")
+		os.Exit(1)
+	}
 	probe, closeProbe, err := newRemoteAgentProbe(profile)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "remote-agent: %v\n", err)
@@ -145,14 +262,28 @@ func handleRemoteAgent(profile string, args []string) {
 		}
 		return out.String(), errb.String(), code
 	}
-	serveRemoteAgent(context.Background(), os.Stdin, os.Stdout, runner, probe, dbPath, 250*time.Millisecond, remoteAgentPaneCapturer(profile), remoteAgentPaneEvery)
+	serveRemoteAgent(context.Background(), os.Stdin, os.Stdout, remoteAgentConfig{
+		Run:        runner,
+		Probe:      probe,
+		WatchPath:  dbPath,
+		WatchEvery: remoteAgentStampEvery,
+		Capture:    remoteAgentPaneCapturer(profile),
+		PaneEvery:  remoteAgentPaneEvery,
+	})
 }
 
 // newRemoteAgentProbe opens the profile's storage once and returns a probe
 // that loads it, refreshes statuses, and formats both listings exactly as
 // the CLI would, plus the close for the storage handle. Like `list --json`
 // it warms the tmux and hook-status caches once per probe, then formats
-// both listings from that one load.
+// both listings from that one load. The handle stays open for the life of
+// the agent, so unlike a `list` subprocess no probe checkpoints the WAL.
+//
+// The probe is read-only. UpdateStatus flushes last-activity evidence
+// through statedb.GetGlobal(), which a `list` subprocess registers at
+// startup and this process never does (handleRemoteAgent checks), so the
+// flush is a no-op here and a probe never moves the stamp the watcher
+// compares. TestRemoteAgent_InProcessProbeMatchesCLI pins this.
 func newRemoteAgentProbe(profile string) (remoteAgentProbeFunc, func(), error) {
 	storage, err := session.NewStorageWithProfile(profile)
 	if err != nil {
@@ -226,68 +357,91 @@ func remoteAgentPaneCapturer(profile string) func(context.Context, string) (stri
 	}
 }
 
+// remoteAgentWriter is the one path to stdout: a bounded queue drained by a
+// single goroutine. write never blocks; when the queue is full or a write
+// fails the peer counts as gone and fail runs once (it ends the agent).
+type remoteAgentWriter struct {
+	q        chan []byte
+	done     chan struct{}
+	failOnce sync.Once
+	fail     func()
+	closed   sync.Once
+}
+
+func newRemoteAgentWriter(out io.Writer, size int, fail func()) *remoteAgentWriter {
+	w := &remoteAgentWriter{q: make(chan []byte, size), done: make(chan struct{}), fail: fail}
+	go func() {
+		defer close(w.done)
+		for b := range w.q {
+			if _, err := out.Write(b); err != nil {
+				w.failOnce.Do(w.fail)
+				for range w.q { // drain until the producers stop
+				}
+				return
+			}
+		}
+	}()
+	return w
+}
+
+func (w *remoteAgentWriter) write(r remoteAgentReply) {
+	b, err := json.Marshal(r)
+	if err != nil {
+		return
+	}
+	select {
+	case w.q <- append(b, '\n'):
+	default:
+		w.failOnce.Do(w.fail)
+	}
+}
+
+// close ends the drain once every producer has stopped and waits, briefly,
+// for the queued lines to reach the pipe. The wait is bounded: a peer that
+// stopped reading leaves the drain stuck in a write that only ends when the
+// pipe does, and the agent must still exit (the process ends the write).
+func (w *remoteAgentWriter) close() {
+	w.closed.Do(func() { close(w.q) })
+	select {
+	case <-w.done:
+	case <-time.After(remoteAgentCloseWait):
+	}
+}
+
 // serveRemoteAgent is the agent loop, separated from process wiring so it is
-// testable with pipes. It returns when stdin closes. capture reads one
-// session's pane text for the pane watch; nil disables watching (a watch
-// request is then answered with an error).
-func serveRemoteAgent(ctx context.Context, in io.Reader, out io.Writer, run func(context.Context, []string) (string, string, int), probe remoteAgentProbeFunc, watchPath string, watchEvery time.Duration, capture func(context.Context, string) (string, error), paneEvery time.Duration) {
+// testable with pipes. It returns when stdin closes, when stdout stops
+// taking lines, or when stdin stays silent past the idle deadline.
+func serveRemoteAgent(ctx context.Context, in io.Reader, out io.Writer, cfg remoteAgentConfig) {
+	cfg = cfg.withDefaults()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	var wmu sync.Mutex
-	write := func(r remoteAgentReply) {
-		b, err := json.Marshal(r)
-		if err != nil {
-			return
-		}
-		wmu.Lock()
-		_, _ = out.Write(append(b, '\n'))
-		wmu.Unlock()
-	}
+	w := newRemoteAgentWriter(out, remoteAgentWriteQueue, cancel)
+	write := w.write
 
 	write(remoteAgentReply{Event: "ready"})
 
-	// Change feed. A cheap mtime/size poll on state.db notices any write by
-	// any process on the remote; but a status refresh by `list` itself also
-	// writes, so a bare stamp would feed back into the TUI's own refetch
-	// forever. The stamp only triggers a probe: the agent builds the two
-	// listings the TUI fetches and pushes "changed" only when their content
-	// differs from what it last pushed.
-	if watchPath != "" && watchEvery > 0 && probe != nil {
+	var wg sync.WaitGroup
+	if cfg.WatchPath != "" && cfg.WatchEvery > 0 && cfg.Probe != nil {
+		wg.Add(1)
 		go func() {
-			last := remoteAgentStamp(watchPath)
-			// Seed with the current content so the first stamp change is
-			// judged against what the TUI already fetched at startup.
-			l0, g0, _ := probe()
-			lastHash := remoteAgentContentHash(l0, g0)
-			t := time.NewTicker(watchEvery)
-			defer t.Stop()
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				case <-t.C:
-					if remoteAgentStamp(watchPath) == last {
-						continue
-					}
-					started := time.Now()
-					l, g, err := probe()
-					elapsed := time.Since(started).Milliseconds()
-					if err != nil {
-						// No listings to compare or push: tell the TUI
-						// something changed and let it fetch.
-						fmt.Fprintf(os.Stderr, "remote-agent: probe: %v\n", err)
-						write(remoteAgentReply{Event: "changed", ProbeMS: elapsed})
-					} else if h := remoteAgentContentHash(l, g); h != lastHash {
-						lastHash = h
-						write(remoteAgentReply{Event: "changed", Sessions: l, Groups: g, ProbeMS: elapsed})
-					}
-					// The probe's own status refresh may have touched the
-					// DB again; take that stamp as seen.
-					last = remoteAgentStamp(watchPath)
-				}
-			}
+			defer wg.Done()
+			watchRemoteState(ctx, cfg, write)
 		}()
 	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		t := time.NewTicker(cfg.PingEvery)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				write(remoteAgentReply{Event: "ping"})
+			}
+		}
+	}()
 
 	// Pane watch: one goroutine at a time, replaced by the next watch
 	// (every watch request starts afresh, so the peer always gets the
@@ -314,16 +468,54 @@ func serveRemoteAgent(ctx context.Context, in io.Reader, out io.Writer, run func
 		stopWatch, watchDone = wcancel, done
 		go func() {
 			defer close(done)
-			watchRemotePane(wctx, sessionID, lines, capture, paneEvery, write)
+			watchRemotePane(wctx, sessionID, lines, cfg.Capture, cfg.PaneEvery, write)
 		}()
 	}
-	defer setWatch("", 0)
 
-	var wg sync.WaitGroup
-	sc := bufio.NewScanner(in)
-	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
-	for sc.Scan() {
-		line := strings.TrimSpace(sc.Text())
+	requests := newRemoteAgentRequests(cfg.Run, cfg.MaxConcurrent, cfg.WatchPath)
+
+	// stdin is read on its own goroutine so the loop can also leave on a
+	// dead stdout or an idle deadline while a read is blocked.
+	lines := make(chan string)
+	go func() {
+		defer close(lines)
+		sc := bufio.NewScanner(in)
+		sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+		for sc.Scan() {
+			select {
+			case lines <- sc.Text():
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	idle := time.NewTimer(cfg.IdleAfter)
+	defer idle.Stop()
+loop:
+	for {
+		var (
+			raw string
+			ok  bool
+		)
+		select {
+		case <-ctx.Done():
+			break loop
+		case <-idle.C:
+			fmt.Fprintf(os.Stderr, "remote-agent: no input for %s, exiting\n", cfg.IdleAfter)
+			break loop
+		case raw, ok = <-lines:
+			if !ok {
+				break loop
+			}
+		}
+		if !idle.Stop() {
+			select {
+			case <-idle.C:
+			default:
+			}
+		}
+		idle.Reset(cfg.IdleAfter)
+		line := strings.TrimSpace(raw)
 		if line == "" {
 			continue
 		}
@@ -332,9 +524,18 @@ func serveRemoteAgent(ctx context.Context, in io.Reader, out io.Writer, run func
 			write(remoteAgentReply{Code: 2, Error: "bad request: " + err.Error()})
 			continue
 		}
-		if req.Watch != "" || req.Unwatch {
+		switch {
+		case req.Cancel:
+			requests.cancel(req.ID)
+			continue
+		case req.Ping:
+			if req.ID != 0 {
+				write(remoteAgentReply{ID: req.ID})
+			}
+			continue
+		case req.Watch != "" || req.Unwatch:
 			switch {
-			case capture == nil:
+			case cfg.Capture == nil:
 				write(remoteAgentReply{ID: req.ID, Code: 2, Error: "pane watch not available"})
 			case req.Unwatch:
 				setWatch("", 0)
@@ -354,14 +555,236 @@ func serveRemoteAgent(ctx context.Context, in io.Reader, out io.Writer, run func
 		wg.Add(1)
 		go func(req remoteAgentRequest) {
 			defer wg.Done()
-			rctx, rcancel := context.WithTimeout(ctx, 5*time.Minute)
-			defer rcancel()
-			stdout, stderr, code := run(rctx, req.Args)
-			write(remoteAgentReply{ID: req.ID, Stdout: stdout, Stderr: stderr, Code: code})
+			if reply, ok := requests.run(ctx, req); ok {
+				write(reply)
+			}
 		}(req)
 	}
 	cancel()
+	setWatch("", 0)
 	wg.Wait()
+	w.close()
+}
+
+// watchRemoteState is the change feed. A cheap mtime/size poll on state.db
+// notices any write by any process on the remote; the stamp only triggers a
+// probe, and the agent pushes "changed" only when the two listings differ
+// from what it last pushed. Probes are debounced: one runs no sooner than
+// ProbeQuiet after the previous one ended, so a burst of writes costs one
+// probe, and a write landing while a probe runs (which that probe may or
+// may not have seen) is probed again rather than taken as seen. The probe
+// is read-only, so a stamp that moved during it was moved by someone else.
+func watchRemoteState(ctx context.Context, cfg remoteAgentConfig, write func(remoteAgentReply)) {
+	last := remoteAgentStamp(cfg.WatchPath)
+	// Seed with the current content so the first stamp change is judged
+	// against what the TUI already fetched at startup.
+	l0, g0, _ := cfg.Probe()
+	lastHash := remoteAgentContentHash(l0, g0)
+	lastProbeEnd := time.Now()
+	pending := false
+	t := time.NewTicker(cfg.WatchEvery)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+		}
+		if s := remoteAgentStamp(cfg.WatchPath); s != last {
+			last, pending = s, true
+		}
+		if !pending || time.Since(lastProbeEnd) < cfg.ProbeQuiet {
+			continue
+		}
+		pending = false
+		before := last
+		stamp := remoteAgentStampNanos(cfg.WatchPath)
+		started := time.Now()
+		l, g, err := cfg.Probe()
+		elapsed := time.Since(started).Milliseconds()
+		lastProbeEnd = time.Now()
+		if ctx.Err() != nil {
+			return
+		}
+		switch {
+		case err != nil:
+			// No listings to compare or push: tell the TUI something
+			// changed and let it fetch.
+			fmt.Fprintf(os.Stderr, "remote-agent: probe: %v\n", err)
+			write(remoteAgentReply{Event: "changed", ProbeMS: elapsed, Stamp: stamp})
+		case !remoteAgentListingsLookValid(l, g):
+			fmt.Fprintf(os.Stderr, "remote-agent: probe produced no listing (%s)\n", remoteAgentHead(l))
+			write(remoteAgentReply{Event: "changed", ProbeMS: elapsed, Stamp: stamp})
+		default:
+			if h := remoteAgentContentHash(l, g); h != lastHash {
+				lastHash = h
+				cl, cg, fits := remoteAgentCompactListings(l, g, cfg.MaxPushBytes)
+				if fits {
+					write(remoteAgentReply{Event: "changed", Sessions: cl, Groups: cg, ProbeMS: elapsed, Stamp: stamp})
+				} else {
+					write(remoteAgentReply{Event: "changed", ProbeMS: elapsed, Stamp: stamp})
+				}
+			}
+		}
+		// A write that landed while the probe ran may or may not be in
+		// the listing: probe again after the quiet interval.
+		if after := remoteAgentStamp(cfg.WatchPath); after != before {
+			last, pending = after, true
+		}
+	}
+}
+
+// remoteAgentListingsLookValid is the shape check a pushed listing must
+// pass: an array for sessions and an object for groups. A listing that is
+// an error message (say "Error: database is locked") fails it and the event
+// goes bare, so the local side fetches instead of applying an empty fleet.
+func remoteAgentListingsLookValid(listJSON, groupJSON string) bool {
+	l, g := strings.TrimSpace(listJSON), strings.TrimSpace(groupJSON)
+	return strings.HasPrefix(l, "[") && strings.HasPrefix(g, "{")
+}
+
+func remoteAgentHead(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) > 60 {
+		s = s[:60] + "..."
+	}
+	return s
+}
+
+// remoteAgentCompactListings strips the indentation the CLI prints so the
+// event carries the same JSON documents in json.Marshal form. A listing
+// that is not valid JSON is kept as it is (the local parser decides). fits
+// is false when the compact pair would exceed maxBytes.
+func remoteAgentCompactListings(listJSON, groupJSON string, maxBytes int) (string, string, bool) {
+	compact := func(s string) string {
+		var b bytes.Buffer
+		if err := json.Compact(&b, []byte(s)); err != nil {
+			return s
+		}
+		return b.String()
+	}
+	cl, cg := compact(listJSON), compact(groupJSON)
+	return cl, cg, len(cl)+len(cg) <= maxBytes
+}
+
+// remoteAgentRequests runs command requests: a semaphore caps the
+// subprocesses, identical read-only requests in flight share one run, and
+// a request can be cancelled by id.
+type remoteAgentRequests struct {
+	exec      remoteAgentRunFunc
+	sem       chan struct{}
+	stampPath string
+	mu        sync.Mutex
+	byID      map[int64]*remoteAgentFlight
+	byKey     map[string]*remoteAgentFlight
+}
+
+type remoteAgentFlight struct {
+	key     string
+	cancel  context.CancelFunc
+	done    chan struct{}
+	waiters int
+	stdout  string
+	stderr  string
+	code    int
+	stamp   int64
+}
+
+func newRemoteAgentRequests(run remoteAgentRunFunc, maxConcurrent int, stampPath string) *remoteAgentRequests {
+	return &remoteAgentRequests{
+		exec:      run,
+		sem:       make(chan struct{}, maxConcurrent),
+		stampPath: stampPath,
+		byID:      map[int64]*remoteAgentFlight{},
+		byKey:     map[string]*remoteAgentFlight{},
+	}
+}
+
+// remoteAgentReadOnlyVerbs lists the requests that only read state, so two
+// identical ones in flight can share one subprocess.
+func remoteAgentReadOnly(args []string) bool {
+	switch args[0] {
+	case "list", "ls", "costs", "status", "version":
+		return true
+	case "group":
+		return len(args) > 1 && args[1] == "list"
+	case "session":
+		return len(args) > 1 && (args[1] == "output" || args[1] == "status")
+	}
+	return false
+}
+
+// run executes req (or joins an identical read-only run in flight) and
+// returns its reply; ok is false when the request was cancelled, in which
+// case nothing is answered.
+func (r *remoteAgentRequests) run(ctx context.Context, req remoteAgentRequest) (remoteAgentReply, bool) {
+	r.mu.Lock()
+	key := ""
+	if remoteAgentReadOnly(req.Args) {
+		key = strings.Join(req.Args, "\x00")
+	}
+	f := r.byKey[key]
+	if key == "" || f == nil {
+		fctx, fcancel := context.WithTimeout(ctx, remoteAgentRequestTimeout)
+		f = &remoteAgentFlight{key: key, cancel: fcancel, done: make(chan struct{})}
+		if key != "" {
+			r.byKey[key] = f
+		}
+		go r.execute(fctx, f, req.Args)
+	}
+	f.waiters++
+	r.byID[req.ID] = f
+	r.mu.Unlock()
+
+	<-f.done
+	r.mu.Lock()
+	cancelled := r.byID[req.ID] != f
+	delete(r.byID, req.ID)
+	r.mu.Unlock()
+	if cancelled {
+		return remoteAgentReply{}, false
+	}
+	return remoteAgentReply{ID: req.ID, Stdout: f.stdout, Stderr: f.stderr, Code: f.code, Stamp: f.stamp}, true
+}
+
+func (r *remoteAgentRequests) execute(ctx context.Context, f *remoteAgentFlight, args []string) {
+	defer close(f.done)
+	defer f.cancel()
+	defer func() {
+		r.mu.Lock()
+		if f.key != "" && r.byKey[f.key] == f {
+			delete(r.byKey, f.key)
+		}
+		r.mu.Unlock()
+	}()
+	select {
+	case r.sem <- struct{}{}:
+	case <-ctx.Done():
+		f.stderr, f.code = "cancelled while queued", 1
+		return
+	}
+	defer func() { <-r.sem }()
+	f.stdout, f.stderr, f.code = r.exec(ctx, args)
+	f.stamp = remoteAgentStampNanos(r.stampPath)
+}
+
+// cancel drops request id: its subprocess is killed once no other request
+// shares the run, and no reply is written for it.
+func (r *remoteAgentRequests) cancel(id int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	f, ok := r.byID[id]
+	if !ok {
+		return
+	}
+	delete(r.byID, id)
+	f.waiters--
+	if f.waiters <= 0 {
+		if f.key != "" && r.byKey[f.key] == f {
+			delete(r.byKey, f.key)
+		}
+		f.cancel()
+	}
 }
 
 // watchRemotePane captures sessionID's pane every paneEvery until ctx ends
@@ -452,4 +875,20 @@ func remoteAgentStamp(dbPath string) string {
 		}
 	}
 	return b.String()
+}
+
+// remoteAgentStampNanos is the newest mtime among the state DB, its WAL and
+// SHM in unix nanoseconds: an ordering key on the remote's clock for when a
+// listing was taken or a command finished. 0 when nothing can be stat'ed.
+func remoteAgentStampNanos(dbPath string) int64 {
+	var newest int64
+	if dbPath == "" {
+		return 0
+	}
+	for _, p := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+		if st, err := os.Stat(p); err == nil && st.ModTime().UnixNano() > newest {
+			newest = st.ModTime().UnixNano()
+		}
+	}
+	return newest
 }

--- a/cmd/agent-deck/remote_agent_cmd_test.go
+++ b/cmd/agent-deck/remote_agent_cmd_test.go
@@ -41,15 +41,19 @@ func TestRemoteAgent_RequestsEventsAndDenyList(t *testing.T) {
 		return "ran:" + strings.Join(args, " "), "", 0
 	}
 	// The probe is what the change feed compares; here it is the same
-	// listing the request path returns, so the two stay in step.
+	// listing the request path returns, so the two stay in step. It is
+	// wrapped in the shapes a real listing has (an array, an object) since
+	// anything else counts as a failed probe and is pushed bare.
 	probe := func() (string, string, error) {
 		l, _, _ := run(context.Background(), []string{"list", "--json"})
 		g, _, _ := run(context.Background(), []string{"group", "list", "--json"})
-		return l, g, nil
+		lb, _ := json.Marshal([]string{l})
+		gb, _ := json.Marshal(map[string]string{"groups": g})
+		return string(lb), string(gb), nil
 	}
 	done := make(chan struct{})
 	go func() {
-		serveRemoteAgent(context.Background(), inR, outW, run, probe, db, 20*time.Millisecond, nil, 0)
+		serveRemoteAgent(context.Background(), inR, outW, remoteAgentConfig{Run: run, Probe: probe, WatchPath: db, WatchEvery: 20 * time.Millisecond, ProbeQuiet: 30 * time.Millisecond})
 		_ = outW.Close()
 		close(done)
 	}()
@@ -138,11 +142,11 @@ func TestRemoteAgent_ProbeTimingAndFailureFallback(t *testing.T) {
 			return "", "", errors.New("storage gone")
 		}
 		time.Sleep(5 * time.Millisecond)
-		return "[" + string(content) + "]", "{}", nil
+		return "[\"" + string(content) + "\"]", "{}", nil
 	}
 	done := make(chan struct{})
 	go func() {
-		serveRemoteAgent(context.Background(), inR, outW, run, probe, db, 20*time.Millisecond, nil, 0)
+		serveRemoteAgent(context.Background(), inR, outW, remoteAgentConfig{Run: run, Probe: probe, WatchPath: db, WatchEvery: 20 * time.Millisecond, ProbeQuiet: 30 * time.Millisecond})
 		_ = outW.Close()
 		close(done)
 	}()
@@ -179,7 +183,7 @@ func TestRemoteAgent_ProbeTimingAndFailureFallback(t *testing.T) {
 		t.Fatal(err)
 	}
 	r := next()
-	if r.Event != "changed" || r.Sessions != "[v2-longer]" || r.Groups != "{}" {
+	if r.Event != "changed" || r.Sessions != `["v2-longer"]` || r.Groups != "{}" {
 		t.Fatalf("expected a changed event with listings, got %+v", r)
 	}
 	if r.ProbeMS < 5 {
@@ -232,7 +236,7 @@ func TestRemoteAgent_WatchPushesPaneOnChange(t *testing.T) {
 	run := func(ctx context.Context, args []string) (string, string, int) { return "", "", 0 }
 	done := make(chan struct{})
 	go func() {
-		serveRemoteAgent(context.Background(), inR, outW, run, nil, "", 0, capture, 10*time.Millisecond)
+		serveRemoteAgent(context.Background(), inR, outW, remoteAgentConfig{Run: run, Capture: capture, PaneEvery: 10 * time.Millisecond})
 		_ = outW.Close()
 		close(done)
 	}()
@@ -361,7 +365,7 @@ func TestRemoteAgent_WatchRefusedWithoutCapture(t *testing.T) {
 	inR, inW := io.Pipe()
 	outR, outW := io.Pipe()
 	go func() {
-		serveRemoteAgent(context.Background(), inR, outW, func(context.Context, []string) (string, string, int) { return "", "", 0 }, nil, "", 0, nil, 0)
+		serveRemoteAgent(context.Background(), inR, outW, remoteAgentConfig{Run: func(context.Context, []string) (string, string, int) { return "", "", 0 }})
 		_ = outW.Close()
 	}()
 	sc := bufio.NewScanner(outR)

--- a/cmd/agent-deck/remote_agent_harden_test.go
+++ b/cmd/agent-deck/remote_agent_harden_test.go
@@ -1,0 +1,561 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// agentHarness drives serveRemoteAgent over pipes: send writes one request
+// line, replies delivers every decoded line, closeIn ends stdin, done closes
+// when the agent loop returned.
+type agentHarness struct {
+	t       *testing.T
+	inW     *io.PipeWriter
+	replies chan remoteAgentReply
+	done    chan struct{}
+}
+
+func startAgent(t *testing.T, cfg remoteAgentConfig) *agentHarness {
+	t.Helper()
+	return startAgentOn(t, cfg, nil)
+}
+
+// startAgentOn lets a test replace the agent's stdout (wrap wraps the pipe
+// writer the harness reads from).
+func startAgentOn(t *testing.T, cfg remoteAgentConfig, wrap func(io.Writer) io.Writer) *agentHarness {
+	t.Helper()
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+	var out io.Writer = outW
+	if wrap != nil {
+		out = wrap(outW)
+	}
+	h := &agentHarness{t: t, inW: inW, replies: make(chan remoteAgentReply, 256), done: make(chan struct{})}
+	go func() {
+		serveRemoteAgent(context.Background(), inR, out, cfg)
+		_ = outW.Close()
+		close(h.done)
+	}()
+	go func() {
+		sc := bufio.NewScanner(outR)
+		sc.Buffer(make([]byte, 0, 64*1024), 64*1024*1024)
+		for sc.Scan() {
+			var r remoteAgentReply
+			if json.Unmarshal(sc.Bytes(), &r) == nil {
+				h.replies <- r
+			}
+		}
+		close(h.replies)
+	}()
+	if r := h.next("ready"); r.Event != "ready" {
+		t.Fatalf("first line must announce ready, got %+v", r)
+	}
+	t.Cleanup(func() { _ = inW.Close() })
+	return h
+}
+
+func (h *agentHarness) send(req remoteAgentRequest) {
+	h.t.Helper()
+	b, _ := json.Marshal(req)
+	if _, err := h.inW.Write(append(b, '\n')); err != nil {
+		h.t.Fatal(err)
+	}
+}
+
+// next returns the next reply that is not a liveness ping.
+func (h *agentHarness) next(what string) remoteAgentReply {
+	h.t.Helper()
+	for {
+		select {
+		case r, ok := <-h.replies:
+			if !ok {
+				h.t.Fatalf("agent closed while waiting for %s", what)
+			}
+			if r.Event == "ping" {
+				continue
+			}
+			return r
+		case <-time.After(3 * time.Second):
+			h.t.Fatalf("timeout waiting for %s", what)
+		}
+	}
+}
+
+func (h *agentHarness) noneWithin(d time.Duration, what string) {
+	h.t.Helper()
+	deadline := time.After(d)
+	for {
+		select {
+		case r, ok := <-h.replies:
+			if !ok {
+				h.t.Fatalf("agent closed while expecting %s", what)
+			}
+			if r.Event == "ping" {
+				continue
+			}
+			h.t.Fatalf("unexpected %+v while expecting %s", r, what)
+		case <-deadline:
+			return
+		}
+	}
+}
+
+func (h *agentHarness) closeAndWait() {
+	h.t.Helper()
+	_ = h.inW.Close()
+	select {
+	case <-h.done:
+	case <-time.After(3 * time.Second):
+		h.t.Fatal("agent did not exit when stdin closed")
+	}
+}
+
+// Finding 2: a probe runs no sooner than the quiet interval after the last
+// one ended, so a burst of state writes costs one probe (with the final
+// listing) instead of one per tick; a write that lands while a probe runs
+// is probed again rather than taken as seen.
+func TestRemoteAgent_ProbeDebounceAndReprobe(t *testing.T) {
+	dir := t.TempDir()
+	db := filepath.Join(dir, "state.db")
+	if err := writeFileAtomic(db, `["v0"]`); err != nil {
+		t.Fatal(err)
+	}
+	var probes atomic.Int32
+	var touchDuringProbe atomic.Bool
+	probe := func() (string, string, error) {
+		probes.Add(1)
+		content, _ := os.ReadFile(db)
+		if touchDuringProbe.CompareAndSwap(true, false) {
+			// A write landing mid-probe: same content, new stamp.
+			time.Sleep(2 * time.Millisecond)
+			_ = writeFileAtomic(db, string(content)+" ")
+		}
+		return strings.TrimSpace(string(content)), "{}", nil
+	}
+	const quiet = 150 * time.Millisecond
+	h := startAgent(t, remoteAgentConfig{
+		Run:        func(context.Context, []string) (string, string, int) { return "", "", 0 },
+		Probe:      probe,
+		WatchPath:  db,
+		WatchEvery: 5 * time.Millisecond,
+		ProbeQuiet: quiet,
+	})
+	// Let the seed probe and the quiet interval after it pass.
+	time.Sleep(quiet + 50*time.Millisecond)
+	if seed := probes.Load(); seed != 1 {
+		t.Fatalf("expected exactly the seed probe before any change, got %d", seed)
+	}
+
+	// One write after a quiet interval is probed at once (no added lag).
+	if err := writeFileAtomic(db, `["v1"]`); err != nil {
+		t.Fatal(err)
+	}
+	if r := h.next("changed for v1"); r.Event != "changed" || r.Sessions != `["v1"]` {
+		t.Fatalf("expected the v1 listing, got %+v", r)
+	}
+	if got := probes.Load(); got != 2 {
+		t.Fatalf("a lone write costs one probe, got %d in total", got)
+	}
+
+	// Ten writes inside the quiet interval: one probe, one changed event
+	// carrying the final listing.
+	for i := 0; i < 10; i++ {
+		if err := writeFileAtomic(db, `["v1","`+strings.Repeat("x", i)+`"]`); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(6 * time.Millisecond)
+	}
+	if r := h.next("changed after burst"); r.Event != "changed" || r.Sessions != `["v1","xxxxxxxxx"]` {
+		t.Fatalf("expected one changed event with the final listing, got %+v", r)
+	}
+	h.noneWithin(quiet+100*time.Millisecond, "silence after one probe for the burst")
+	if got := probes.Load(); got != 3 {
+		t.Fatalf("a burst of writes must cost one probe, got %d in total", got)
+	}
+
+	// A stamp that moves during the probe: exactly one more probe (the
+	// reprobe finds nothing new and pushes nothing).
+	touchDuringProbe.Store(true)
+	if err := writeFileAtomic(db, `["v2"]`); err != nil {
+		t.Fatal(err)
+	}
+	if r := h.next("changed for v2"); r.Event != "changed" || r.Sessions != `["v2"]` {
+		t.Fatalf("expected the v2 listing, got %+v", r)
+	}
+	h.noneWithin(2*quiet+100*time.Millisecond, "no push for a reprobe that finds the same listing")
+	if got := probes.Load(); got != 5 {
+		t.Fatalf("a stamp moved during the probe must be probed once more (v2 probe + reprobe), got %d in total", got)
+	}
+	h.closeAndWait()
+}
+
+// Finding 9 and 13: a probe whose listing is not a JSON array (an error
+// message on stdout) or whose groups are not an object pushes a bare
+// "changed"; a valid listing is pushed compacted, with the stamp it was
+// taken at; a listing over the push cap goes bare too.
+func TestRemoteAgent_PushShapeCompactionAndCap(t *testing.T) {
+	dir := t.TempDir()
+	db := filepath.Join(dir, "state.db")
+	if err := writeFileAtomic(db, "start"); err != nil {
+		t.Fatal(err)
+	}
+	var mu sync.Mutex
+	list, groups := "[]", "{}"
+	setListing := func(l, g string) {
+		mu.Lock()
+		list, groups = l, g
+		mu.Unlock()
+		// Any write moves the stamp; the content is irrelevant to the probe.
+		if err := writeFileAtomic(db, l+g); err != nil {
+			t.Fatal(err)
+		}
+	}
+	probe := func() (string, string, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		return list, groups, nil
+	}
+	h := startAgent(t, remoteAgentConfig{
+		Run:          func(context.Context, []string) (string, string, int) { return "", "", 0 },
+		Probe:        probe,
+		WatchPath:    db,
+		WatchEvery:   5 * time.Millisecond,
+		ProbeQuiet:   10 * time.Millisecond,
+		MaxPushBytes: 200,
+	})
+	time.Sleep(30 * time.Millisecond)
+
+	setListing("Error: database is locked\n", "{}")
+	if r := h.next("bare changed for an error listing"); r.Event != "changed" || r.Sessions != "" || r.Groups != "" {
+		t.Fatalf("an error listing must push a bare changed event, got %+v", r)
+	}
+	setListing("[]\n", "Error: database is locked\n")
+	if r := h.next("bare changed for error groups"); r.Event != "changed" || r.Sessions != "" || r.Groups != "" {
+		t.Fatalf("an error group listing must push a bare changed event, got %+v", r)
+	}
+
+	before := time.Now().Add(-time.Second).UnixNano()
+	setListing("[\n  {\n    \"id\": \"a\",\n    \"title\": \"x y\"\n  }\n]\n", "{\n  \"groups\": [],\n  \"total_groups\": 0\n}\n")
+	r := h.next("compact listing")
+	if r.Event != "changed" || r.Sessions != `[{"id":"a","title":"x y"}]` || r.Groups != `{"groups":[],"total_groups":0}` {
+		t.Fatalf("listings must be pushed compacted, got %+v", r)
+	}
+	if r.Stamp < before {
+		t.Fatalf("a changed event must carry the DB stamp it was taken at, got %d", r.Stamp)
+	}
+
+	setListing("["+strings.Repeat(`{"id":"b"},`, 30)+`{"id":"c"}]`, "{}")
+	if r := h.next("bare changed for an oversize listing"); r.Event != "changed" || r.Sessions != "" || r.Stamp == 0 {
+		t.Fatalf("a listing over the cap must push a bare changed event with a stamp, got %+v", r)
+	}
+	h.closeAndWait()
+}
+
+// Finding 4: identical read-only requests in flight share one subprocess
+// and each get the answer under their own id; distinct requests do not.
+func TestRemoteAgent_SingleFlightReadOnlyRequests(t *testing.T) {
+	var runs atomic.Int32
+	release := make(chan struct{})
+	run := func(ctx context.Context, args []string) (string, string, int) {
+		runs.Add(1)
+		select {
+		case <-release:
+		case <-ctx.Done():
+		}
+		return "out:" + strings.Join(args, " "), "", 0
+	}
+	h := startAgent(t, remoteAgentConfig{Run: run})
+	h.send(remoteAgentRequest{ID: 1, Args: []string{"list", "--json"}})
+	h.send(remoteAgentRequest{ID: 2, Args: []string{"list", "--json"}})
+	h.send(remoteAgentRequest{ID: 3, Args: []string{"group", "list", "--json"}})
+	h.send(remoteAgentRequest{ID: 4, Args: []string{"rename", "s1", "t"}})
+	h.send(remoteAgentRequest{ID: 5, Args: []string{"rename", "s1", "t"}})
+	time.Sleep(50 * time.Millisecond)
+	if got := runs.Load(); got != 4 {
+		t.Fatalf("two identical list requests must share one run (list, group list, rename x2 = 4), got %d", got)
+	}
+	close(release)
+	seen := map[int64]string{}
+	for i := 0; i < 5; i++ {
+		r := h.next("reply")
+		seen[r.ID] = r.Stdout
+	}
+	if seen[1] != "out:list --json" || seen[2] != "out:list --json" || seen[3] != "out:group list --json" || seen[4] != "out:rename s1 t" || seen[5] != "out:rename s1 t" {
+		t.Fatalf("every request must be answered under its own id, got %v", seen)
+	}
+	// The shared run is over: a new identical request runs afresh.
+	h.send(remoteAgentRequest{ID: 6, Args: []string{"list", "--json"}})
+	if r := h.next("fresh list"); r.ID != 6 || r.Stdout != "out:list --json" {
+		t.Fatalf("fresh list reply = %+v", r)
+	}
+	if got := runs.Load(); got != 5 {
+		t.Fatalf("a request after the shared run finished must run again, got %d runs", got)
+	}
+	h.closeAndWait()
+}
+
+// Finding 4: {"id":N,"cancel":true} ends request N's subprocess and no
+// reply follows; a shared run survives until its last sharer cancels.
+func TestRemoteAgent_CancelKillsRequest(t *testing.T) {
+	var cancelled atomic.Int32
+	run := func(ctx context.Context, args []string) (string, string, int) {
+		select {
+		case <-ctx.Done():
+			cancelled.Add(1)
+			return "", "killed", 137
+		case <-time.After(2 * time.Second):
+			return "finished", "", 0
+		}
+	}
+	h := startAgent(t, remoteAgentConfig{Run: run})
+	h.send(remoteAgentRequest{ID: 1, Args: []string{"rename", "s1", "t"}})
+	h.send(remoteAgentRequest{ID: 2, Args: []string{"list", "--json"}})
+	h.send(remoteAgentRequest{ID: 3, Args: []string{"list", "--json"}})
+	time.Sleep(30 * time.Millisecond)
+	h.send(remoteAgentRequest{ID: 1, Cancel: true})
+	h.send(remoteAgentRequest{ID: 2, Cancel: true})
+	time.Sleep(50 * time.Millisecond)
+	if got := cancelled.Load(); got != 1 {
+		t.Fatalf("cancelling a lone request kills it, cancelling one sharer of a run does not: want 1 kill, got %d", got)
+	}
+	h.noneWithin(50*time.Millisecond, "silence for cancelled requests")
+	h.send(remoteAgentRequest{ID: 3, Cancel: true})
+	time.Sleep(50 * time.Millisecond)
+	if got := cancelled.Load(); got != 2 {
+		t.Fatalf("the last sharer's cancel must kill the shared run, got %d kills", got)
+	}
+	h.noneWithin(50*time.Millisecond, "no reply for any cancelled request")
+	// Cancelling an unknown id is harmless.
+	h.send(remoteAgentRequest{ID: 99, Cancel: true})
+	h.send(remoteAgentRequest{ID: 4, Args: []string{"status"}})
+	// status is not run in this test's runner; it just needs to answer.
+	if r := h.next("status reply"); r.ID != 4 {
+		t.Fatalf("reply after cancels = %+v", r)
+	}
+	h.closeAndWait()
+}
+
+// Finding 4: at most MaxConcurrent subprocesses run at once; the rest wait
+// their turn, and a queued request that is cancelled never runs.
+func TestRemoteAgent_ConcurrencyCap(t *testing.T) {
+	var running, peak atomic.Int32
+	var started atomic.Int32
+	release := make(chan struct{})
+	run := func(ctx context.Context, args []string) (string, string, int) {
+		started.Add(1)
+		n := running.Add(1)
+		for {
+			p := peak.Load()
+			if n <= p || peak.CompareAndSwap(p, n) {
+				break
+			}
+		}
+		select {
+		case <-release:
+		case <-ctx.Done():
+		}
+		running.Add(-1)
+		return strings.Join(args, " "), "", 0
+	}
+	h := startAgent(t, remoteAgentConfig{Run: run, MaxConcurrent: 2})
+	for i := int64(1); i <= 5; i++ {
+		h.send(remoteAgentRequest{ID: i, Args: []string{"rename", "s", strings.Repeat("x", int(i))}})
+	}
+	time.Sleep(50 * time.Millisecond)
+	if got := started.Load(); got != 2 {
+		t.Fatalf("only MaxConcurrent requests may run at once, got %d started", got)
+	}
+	h.send(remoteAgentRequest{ID: 5, Cancel: true})
+	close(release)
+	ids := map[int64]bool{}
+	for i := 0; i < 4; i++ {
+		ids[h.next("reply").ID] = true
+	}
+	if ids[5] || len(ids) != 4 {
+		t.Fatalf("four queued requests must answer and the cancelled one must not, got %v", ids)
+	}
+	if peak.Load() > 2 {
+		t.Fatalf("peak concurrency %d exceeds the cap of 2", peak.Load())
+	}
+	if started.Load() != 4 {
+		t.Fatalf("a request cancelled while queued must never start, got %d starts", started.Load())
+	}
+	h.closeAndWait()
+}
+
+// Finding 6: the agent pushes ping events, answers the peer's pings under
+// their id, and exits once stdin stays silent past the idle deadline.
+func TestRemoteAgent_PingAndIdleExit(t *testing.T) {
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+	done := make(chan struct{})
+	go func() {
+		serveRemoteAgent(context.Background(), inR, outW, remoteAgentConfig{
+			Run:       func(context.Context, []string) (string, string, int) { return "", "", 0 },
+			PingEvery: 20 * time.Millisecond,
+			IdleAfter: 300 * time.Millisecond,
+		})
+		_ = outW.Close()
+		close(done)
+	}()
+	sc := bufio.NewScanner(outR)
+	lines := make(chan remoteAgentReply, 64)
+	go func() {
+		for sc.Scan() {
+			var r remoteAgentReply
+			_ = json.Unmarshal(sc.Bytes(), &r)
+			lines <- r
+		}
+		close(lines)
+	}()
+	if r := <-lines; r.Event != "ready" {
+		t.Fatalf("ready first, got %+v", r)
+	}
+	if r := <-lines; r.Event != "ping" {
+		t.Fatalf("expected a ping event, got %+v", r)
+	}
+	// The peer's pings reset the idle deadline: keep it alive for longer
+	// than IdleAfter, then let it lapse.
+	for i := 0; i < 4; i++ {
+		time.Sleep(150 * time.Millisecond)
+		b, _ := json.Marshal(remoteAgentRequest{ID: int64(10 + i), Ping: true})
+		if _, err := inW.Write(append(b, '\n')); err != nil {
+			t.Fatal(err)
+		}
+		for {
+			r := <-lines
+			if r.Event == "ping" {
+				continue
+			}
+			if r.ID != int64(10+i) || r.Code != 0 || r.Error != "" {
+				t.Fatalf("ping with an id must be acknowledged under it, got %+v", r)
+			}
+			break
+		}
+	}
+	select {
+	case <-done:
+		t.Fatal("agent exited although the peer kept pinging")
+	default:
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("agent did not exit after the idle deadline")
+	}
+	_ = inW.Close()
+}
+
+// Finding 6: a stdout that stops taking lines ends the agent even while
+// stdin stays open, and never blocks a reply or the watcher on the way.
+func TestRemoteAgent_ExitsWhenStdoutDies(t *testing.T) {
+	inR, inW := io.Pipe()
+	defer func() { _ = inW.Close() }()
+	var writes atomic.Int32
+	out := writerFunc(func(b []byte) (int, error) {
+		if writes.Add(1) > 1 {
+			return 0, errors.New("broken pipe")
+		}
+		return len(b), nil
+	})
+	done := make(chan struct{})
+	go func() {
+		serveRemoteAgent(context.Background(), inR, out, remoteAgentConfig{
+			Run:       func(context.Context, []string) (string, string, int) { return "", "", 0 },
+			PingEvery: 10 * time.Millisecond,
+		})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("agent did not exit after stdout failed")
+	}
+}
+
+// Finding 6: the outbound queue is bounded and a peer that never reads
+// cannot wedge the agent: the writer gives up and the agent exits.
+func TestRemoteAgent_ExitsWhenPeerStopsReading(t *testing.T) {
+	inR, inW := io.Pipe()
+	defer func() { _ = inW.Close() }()
+	blocked := make(chan struct{})
+	out := writerFunc(func(b []byte) (int, error) {
+		<-blocked // never drained
+		return 0, errors.New("closed")
+	})
+	done := make(chan struct{})
+	go func() {
+		serveRemoteAgent(context.Background(), inR, out, remoteAgentConfig{
+			Run:       func(context.Context, []string) (string, string, int) { return "", "", 0 },
+			PingEvery: time.Millisecond,
+		})
+		close(done)
+	}()
+	// The loop must keep taking requests while the queue fills, and end
+	// once it is full.
+	b, _ := json.Marshal(remoteAgentRequest{ID: 1, Args: []string{"status"}})
+	_, _ = inW.Write(append(b, '\n'))
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("agent did not exit after its outbound queue filled")
+	}
+	close(blocked)
+}
+
+type writerFunc func([]byte) (int, error)
+
+func (f writerFunc) Write(b []byte) (int, error) { return f(b) }
+
+// Finding 10: a command reply carries the DB stamp after the command ran,
+// so the local side can tell a listing older than its last action.
+func TestRemoteAgent_ReplyCarriesStamp(t *testing.T) {
+	dir := t.TempDir()
+	db := filepath.Join(dir, "state.db")
+	if err := writeFileAtomic(db, "v1"); err != nil {
+		t.Fatal(err)
+	}
+	run := func(ctx context.Context, args []string) (string, string, int) {
+		_ = writeFileAtomic(db, "v2")
+		return "ok", "", 0
+	}
+	h := startAgent(t, remoteAgentConfig{Run: run, WatchPath: db})
+	before := time.Now().Add(-time.Second).UnixNano()
+	h.send(remoteAgentRequest{ID: 1, Args: []string{"rename", "s", "t"}})
+	r := h.next("reply")
+	if r.ID != 1 || r.Stdout != "ok" || r.Stamp < before {
+		t.Fatalf("reply must carry the DB stamp after the command, got %+v", r)
+	}
+	st, _ := os.Stat(db)
+	if r.Stamp != st.ModTime().UnixNano() {
+		t.Fatalf("stamp %d must be the state file's mtime %d", r.Stamp, st.ModTime().UnixNano())
+	}
+	h.closeAndWait()
+}
+
+func TestRemoteAgentReadOnly(t *testing.T) {
+	for args, want := range map[string]bool{
+		"list --json":             true,
+		"group list --json":       true,
+		"costs summary --json":    true,
+		"group create x":          false,
+		"rename s t":              false,
+		"remove s":                false,
+		"session output s --pane": true,
+		"session restart s":       false,
+	} {
+		if got := remoteAgentReadOnly(strings.Fields(args)); got != want {
+			t.Errorf("remoteAgentReadOnly(%q) = %v, want %v", args, got, want)
+		}
+	}
+}

--- a/cmd/agent-deck/remote_agent_harden_test.go
+++ b/cmd/agent-deck/remote_agent_harden_test.go
@@ -496,8 +496,9 @@ func TestRemoteAgent_ExitsWhenPeerStopsReading(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		serveRemoteAgent(context.Background(), inR, out, remoteAgentConfig{
-			Run:       func(context.Context, []string) (string, string, int) { return "", "", 0 },
-			PingEvery: time.Millisecond,
+			Run:        func(context.Context, []string) (string, string, int) { return "", "", 0 },
+			PingEvery:  time.Millisecond,
+			WriteStall: 50 * time.Millisecond,
 		})
 		close(done)
 	}()
@@ -511,6 +512,73 @@ func TestRemoteAgent_ExitsWhenPeerStopsReading(t *testing.T) {
 		t.Fatal("agent did not exit after its outbound queue filled")
 	}
 	close(blocked)
+}
+
+// Finding 6, the other way round: a pipe that is slow but alive (a thin
+// link swallowing a large listing while pane pushes keep coming) must only
+// backpressure the producers, not end the agent; every line still arrives.
+func TestRemoteAgent_SlowPipeBackpressuresWithoutExit(t *testing.T) {
+	var got atomic.Int32
+	out := writerFunc(func(b []byte) (int, error) {
+		// Far slower than the 1ms ping cadence: the 64-line queue fills
+		// within the stall window many times over.
+		time.Sleep(5 * time.Millisecond)
+		got.Add(1)
+		return len(b), nil
+	})
+	inR, inW := io.Pipe()
+	done := make(chan struct{})
+	go func() {
+		serveRemoteAgent(context.Background(), inR, out, remoteAgentConfig{
+			Run:        func(context.Context, []string) (string, string, int) { return "ok", "", 0 },
+			PingEvery:  time.Millisecond,
+			WriteStall: 2 * time.Second,
+		})
+		close(done)
+	}()
+	time.Sleep(600 * time.Millisecond)
+	select {
+	case <-done:
+		t.Fatal("a slow but live pipe must not end the agent")
+	default:
+	}
+	_ = inW.Close()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("agent did not exit when stdin closed")
+	}
+	if n := got.Load(); n < 64 {
+		t.Fatalf("expected the queue to have been drained past its size, got %d writes", n)
+	}
+}
+
+// Finding 4: a cancel that follows its request on the very next line must
+// still find it (the request is registered before its goroutine starts).
+func TestRemoteAgent_CancelRightAfterRequest(t *testing.T) {
+	var cancelled atomic.Int32
+	run := func(ctx context.Context, args []string) (string, string, int) {
+		select {
+		case <-ctx.Done():
+			cancelled.Add(1)
+			return "", "killed", 137
+		case <-time.After(2 * time.Second):
+			return "finished", "", 0
+		}
+	}
+	h := startAgent(t, remoteAgentConfig{Run: run})
+	h.send(remoteAgentRequest{ID: 1, Args: []string{"rename", "s1", "t"}})
+	h.send(remoteAgentRequest{ID: 1, Cancel: true})
+	h.send(remoteAgentRequest{ID: 2, Ping: true})
+	if r := h.next("ping ack"); r.ID != 2 {
+		t.Fatalf("expected the ping ack, got %+v", r)
+	}
+	time.Sleep(30 * time.Millisecond)
+	if got := cancelled.Load(); got != 1 {
+		t.Fatalf("the cancel right after the request must kill it, got %d kills", got)
+	}
+	h.noneWithin(50*time.Millisecond, "no reply for the cancelled request")
+	h.closeAndWait()
 }
 
 type writerFunc func([]byte) (int, error)

--- a/cmd/agent-deck/remote_agent_harden_test.go
+++ b/cmd/agent-deck/remote_agent_harden_test.go
@@ -307,8 +307,9 @@ func TestRemoteAgent_SingleFlightReadOnlyRequests(t *testing.T) {
 // Finding 4: {"id":N,"cancel":true} ends request N's subprocess and no
 // reply follows; a shared run survives until its last sharer cancels.
 func TestRemoteAgent_CancelKillsRequest(t *testing.T) {
-	var cancelled atomic.Int32
+	var started, cancelled atomic.Int32
 	run := func(ctx context.Context, args []string) (string, string, int) {
+		started.Add(1)
 		select {
 		case <-ctx.Done():
 			cancelled.Add(1)
@@ -556,8 +557,9 @@ func TestRemoteAgent_SlowPipeBackpressuresWithoutExit(t *testing.T) {
 // Finding 4: a cancel that follows its request on the very next line must
 // still find it (the request is registered before its goroutine starts).
 func TestRemoteAgent_CancelRightAfterRequest(t *testing.T) {
-	var cancelled atomic.Int32
+	var started, cancelled atomic.Int32
 	run := func(ctx context.Context, args []string) (string, string, int) {
+		started.Add(1)
 		select {
 		case <-ctx.Done():
 			cancelled.Add(1)
@@ -574,8 +576,11 @@ func TestRemoteAgent_CancelRightAfterRequest(t *testing.T) {
 		t.Fatalf("expected the ping ack, got %+v", r)
 	}
 	time.Sleep(30 * time.Millisecond)
-	if got := cancelled.Load(); got != 1 {
-		t.Fatalf("the cancel right after the request must kill it, got %d kills", got)
+	// Either the cancel arrived before the subprocess started (it never
+	// runs) or after (it is killed); both are correct, and in neither case
+	// may the request run to completion or produce a reply.
+	if s, c := started.Load(), cancelled.Load(); s != c {
+		t.Fatalf("a started request must be killed by its cancel: started=%d killed=%d", s, c)
 	}
 	h.noneWithin(50*time.Millisecond, "no reply for the cancelled request")
 	h.closeAndWait()

--- a/cmd/agent-deck/remote_agent_probe_test.go
+++ b/cmd/agent-deck/remote_agent_probe_test.go
@@ -4,6 +4,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
 )
 
 // The in-process probe must produce exactly what `list --json` and `group
@@ -48,9 +51,27 @@ func TestRemoteAgent_InProcessProbeMatchesCLI(t *testing.T) {
 		t.Fatalf("newRemoteAgentProbe: %v", err)
 	}
 	defer closeProbe()
+	// The probe is read-only: it relies on no global state DB being
+	// registered in the agent process, and it must leave the stamp the
+	// watcher compares untouched (finding 2: a probe that moved the stamp
+	// would trigger itself).
+	if statedb.GetGlobal() != nil {
+		t.Fatal("the agent process must not register a global state DB")
+	}
+	dbPath, err := session.GetDBPathForProfile("ch_support_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stampBefore := remoteAgentStamp(dbPath)
 	gotList, gotGroups, err := probe()
 	if err != nil {
 		t.Fatalf("probe: %v", err)
+	}
+	if _, _, err := probe(); err != nil {
+		t.Fatalf("second probe: %v", err)
+	}
+	if got := remoteAgentStamp(dbPath); got != stampBefore {
+		t.Fatalf("a probe must not write to the state DB: stamp %q -> %q", stampBefore, got)
 	}
 	if gotList != wantList {
 		t.Errorf("probe list differs from `list --json`:\n--- probe\n%s\n--- cli\n%s", gotList, wantList)

--- a/internal/session/remote_channel.go
+++ b/internal/session/remote_channel.go
@@ -23,21 +23,31 @@ import (
 // refetch. When the channel is down (remote too old, ssh dropped), callers
 // fall back to one ssh exec per command exactly as before.
 type RemoteChannel struct {
-	name    string
-	dial    func(ctx context.Context) (io.WriteCloser, io.Reader, func(), error)
-	events  chan<- RemoteChange
-	mu      sync.Mutex
-	stdin   io.WriteCloser
-	closeFn func()
-	pending map[int64]chan remoteChannelReply
-	nextID  atomic.Int64
-	up      atomic.Bool
+	name string
+	// identity is host, profile and binary path of the remote this channel
+	// was dialled for. A config edit that re-points the name at another host
+	// gets a fresh channel instead of requests to the old one.
+	identity string
+	dial     func(ctx context.Context) (io.WriteCloser, io.Reader, func(), error)
+	events   *remoteChangeMailbox
+	mu       sync.Mutex
+	stdin    io.WriteCloser
+	closeFn  func()
+	pending  map[int64]chan remoteChannelReply
+	nextID   atomic.Int64
+	up       atomic.Bool
+	// gen counts transports. markDown only tears down the transport it was
+	// called for, so a reader or ping loop of an old transport can never
+	// kill the one dialled after it.
+	gen uint64
 	// unsupportedUntil is set when the remote does not know remote-agent
 	// (old build): no reconnect attempts until then.
 	unsupportedUntil time.Time
 	lastAttempt      time.Time
 	backoff          time.Duration
 	dialing          bool
+	// closed is set by Close: no redial, no more pushes.
+	closed bool
 	// watching is the session whose pane the remote agent is pushing for
 	// this channel ("" for none); reset when the transport drops, because
 	// the agent's watch dies with it. watchUnsupported is set when the
@@ -45,7 +55,38 @@ type RemoteChannel struct {
 	// pane watching): the caller then polls the preview as before.
 	watching         string
 	watchUnsupported bool
+	// timeouts counts requests in a row that got no reply before their
+	// deadline; lastRead is when the agent last said anything. Together
+	// they detect a half-open link (#5): writes into a dead ssh session
+	// still succeed, so only silence gives it away.
+	timeouts int
+	lastRead time.Time
+	// Tunables, zero for the defaults below (tests shrink them).
+	pingEvery    time.Duration
+	pingTimeout  time.Duration
+	helloTimeout time.Duration
+	maxFrame     int
 }
+
+const (
+	// remoteChannelPingEvery is how often the client pings an idle channel;
+	// remoteChannelPingTimeout is how long it waits for the answer before
+	// declaring the link half-open.
+	remoteChannelPingEvery   = 20 * time.Second
+	remoteChannelPingTimeout = 20 * time.Second
+	// remoteChannelHelloTimeout bounds the wait for the agent's ready line.
+	remoteChannelHelloTimeout = 15 * time.Second
+	// remoteChannelMaxFrame caps one line from the agent (#13). A 2000
+	// session listing is about 2 MB; anything near this limit is a verb
+	// gone wrong, and it costs a reconnect rather than the TUI's memory.
+	remoteChannelMaxFrame = 32 << 20
+	// remoteChannelTimeoutsToDrop is how many consecutive request timeouts
+	// mark the transport down.
+	remoteChannelTimeoutsToDrop = 2
+	// remoteChannelUnsupportedFor is how long an old remote (no
+	// remote-agent verb) is left alone before the channel is tried again.
+	remoteChannelUnsupportedFor = 10 * time.Minute
+)
 
 type remoteChannelRequest struct {
 	ID      int64    `json:"id"`
@@ -53,6 +94,10 @@ type remoteChannelRequest struct {
 	Watch   string   `json:"watch,omitempty"`
 	Lines   int      `json:"lines,omitempty"`
 	Unwatch bool     `json:"unwatch,omitempty"`
+	// Ping asks for any reply at all. An agent that predates pings answers
+	// it with a "verb not allowed" error, which proves the link just as
+	// well.
+	Ping bool `json:"ping,omitempty"`
 }
 
 type remoteChannelReply struct {
@@ -89,17 +134,124 @@ type RemotePaneEvent struct {
 	Err     string
 }
 
-// errChannelDown means the transport failed, not the remote command; callers
-// fall back to a plain ssh exec.
+// errChannelDown means the transport failed before the request reached the
+// agent; callers fall back to a plain ssh exec.
 var errChannelDown = errors.New("remote channel down")
 
-// remoteChangeEvents fans in "changed" pushes from every remote for the TUI.
-// Buffered and non-blocking on the sending side: a burst collapses into a few
-// pending refreshes, never a stall on the reader goroutine.
-var remoteChangeEvents = make(chan RemoteChange, 32)
+// errChannelInterrupted means the request was written to the agent and the
+// transport failed before its reply arrived. The remote may have executed
+// the command (#3), so callers must not run it again blindly: read-only
+// verbs may be retried, anything else is reported so the caller refetches.
+var errChannelInterrupted = errors.New("remote channel interrupted before the reply")
 
-// RemoteChangeEvents delivers pushed changes, one per remote change.
-func RemoteChangeEvents() <-chan RemoteChange { return remoteChangeEvents }
+// errChannelFrameTooLarge is the reader's verdict on a line longer than
+// maxFrame; it takes the transport down instead of the process (#13).
+var errChannelFrameTooLarge = errors.New("remote channel frame too large")
+
+// isChannelTransportErr reports whether err is one of the channel's own
+// transport failures rather than a verdict from the remote command.
+func isChannelTransportErr(err error) bool {
+	return errors.Is(err, errChannelDown) || errors.Is(err, errChannelInterrupted)
+}
+
+// remoteChangeMailbox is the fan-in for pushed events (#14). It keeps the
+// newest "changed" snapshot per remote and the newest pane capture per
+// watched session; a burst from one remote collapses into one delivery of
+// its latest state, and one remote's burst never delays another's.
+//
+// Ordering guarantee: per slot (a remote's listing, or one session's pane)
+// deliveries are in arrival order and never go backwards; intermediate
+// snapshots may be skipped. A "changed" push for one remote is delivered
+// independently of its pane pushes.
+type remoteChangeMailbox struct {
+	mu     sync.Mutex
+	slots  map[string]RemoteChange
+	queue  []string
+	notify chan struct{}
+	out    chan RemoteChange
+	once   sync.Once
+}
+
+func newRemoteChangeMailbox() *remoteChangeMailbox {
+	return &remoteChangeMailbox{
+		slots:  map[string]RemoteChange{},
+		notify: make(chan struct{}, 1),
+		out:    make(chan RemoteChange),
+	}
+}
+
+func mailboxKey(ch RemoteChange) string {
+	if ch.Pane != nil {
+		return "pane\x00" + ch.Remote + "\x00" + ch.Pane.Session
+	}
+	return "changed\x00" + ch.Remote
+}
+
+// put stores ch as the newest state of its slot. A slot already waiting
+// keeps its place in the queue and only its content is replaced.
+func (m *remoteChangeMailbox) put(ch RemoteChange) {
+	key := mailboxKey(ch)
+	m.mu.Lock()
+	if _, waiting := m.slots[key]; !waiting {
+		m.queue = append(m.queue, key)
+	}
+	m.slots[key] = ch
+	m.mu.Unlock()
+	select {
+	case m.notify <- struct{}{}:
+	default:
+	}
+}
+
+// drop discards everything waiting for one remote (its channel closed).
+func (m *remoteChangeMailbox) drop(remote string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	kept := m.queue[:0]
+	for _, key := range m.queue {
+		if m.slots[key].Remote == remote {
+			delete(m.slots, key)
+			continue
+		}
+		kept = append(kept, key)
+	}
+	m.queue = kept
+}
+
+// Events returns the delivery channel, starting the pump on first use.
+func (m *remoteChangeMailbox) Events() <-chan RemoteChange {
+	m.once.Do(func() { go m.pump() })
+	return m.out
+}
+
+// pump hands the oldest waiting slot to the receiver. Nothing is taken out
+// of the mailbox until the receiver is about to get it, so a newer push
+// during a slow receive is still what arrives next.
+func (m *remoteChangeMailbox) pump() {
+	for range m.notify {
+		for {
+			m.mu.Lock()
+			if len(m.queue) == 0 {
+				m.mu.Unlock()
+				break
+			}
+			key := m.queue[0]
+			m.queue = m.queue[1:]
+			ch := m.slots[key]
+			delete(m.slots, key)
+			m.mu.Unlock()
+			m.out <- ch
+		}
+	}
+}
+
+// remoteChangeInbox fans in pushes from every remote for the TUI.
+var remoteChangeInbox = newRemoteChangeMailbox()
+
+// RemoteChangeEvents delivers pushed changes: the latest listing per remote
+// and the latest pane capture per watched session, in arrival order per
+// slot (see remoteChangeMailbox for the guarantee).
+func RemoteChangeEvents() <-chan RemoteChange { return remoteChangeInbox.Events() }
 
 var (
 	remoteChannelsMu sync.Mutex
@@ -122,30 +274,86 @@ func remoteChannelsEnabled() bool {
 	return v == "" || v == "1" || strings.EqualFold(v, "true")
 }
 
+// remoteIdentity is the part of a remote's config a channel is bound to.
+func remoteIdentity(host, profile, path string) string {
+	return host + "\x00" + profile + "\x00" + path
+}
+
 // channelFor returns the shared channel for a runner's remote, starting it
-// on first use. nil when channels are disabled or the runner is unnamed.
+// on first use. nil when channels are disabled or the runner is unnamed. A
+// channel dialled for another host, profile or binary under the same name
+// is closed and replaced (#8).
 func channelFor(r *SSHRunner) *RemoteChannel {
 	if r == nil || r.name == "" || r.runFn != nil || !remoteChannelsEnabled() {
 		return nil
 	}
+	identity := remoteIdentity(r.Host, r.Profile, r.AgentDeckPath)
 	remoteChannelsMu.Lock()
 	defer remoteChannelsMu.Unlock()
 	if ch, ok := remoteChannels[r.name]; ok {
-		return ch
+		if ch.identity == identity {
+			if !ch.up.Load() {
+				// A dropped transport is redialled by the next request to
+				// that remote (ensureConnected is a no-op while a dial is
+				// running, during backoff or after Close).
+				go ch.ensureConnected()
+			}
+			return ch
+		}
+		ch.Close()
+		delete(remoteChannels, r.name)
 	}
 	rc := *r
-	ch := &RemoteChannel{
-		name:    r.name,
-		events:  remoteChangeEvents,
-		pending: map[int64]chan remoteChannelReply{},
-		backoff: 2 * time.Second,
-		dial: func(ctx context.Context) (io.WriteCloser, io.Reader, func(), error) {
+	dial := rc.dialChannelFn
+	if dial == nil {
+		dial = func(ctx context.Context) (io.WriteCloser, io.Reader, func(), error) {
 			return rc.dialRemoteAgent(ctx)
-		},
+		}
 	}
+	ch := newRemoteChannel(r.name, identity, dial)
 	remoteChannels[r.name] = ch
 	go ch.ensureConnected()
 	return ch
+}
+
+func newRemoteChannel(name, identity string, dial func(ctx context.Context) (io.WriteCloser, io.Reader, func(), error)) *RemoteChannel {
+	return &RemoteChannel{
+		name:     name,
+		identity: identity,
+		events:   remoteChangeInbox,
+		pending:  map[int64]chan remoteChannelReply{},
+		backoff:  2 * time.Second,
+		dial:     dial,
+	}
+}
+
+// ReconcileRemoteChannels closes the channels of remotes that are no longer
+// configured, or whose host, profile or binary path changed, so a removed
+// remote stops pushing rows into the tree and a re-pointed name redials
+// (#8). Call it whenever the remote config is (re)loaded, before the fetch
+// round that uses it.
+func ReconcileRemoteChannels(config map[string]RemoteConfig) {
+	remoteChannelsMu.Lock()
+	defer remoteChannelsMu.Unlock()
+	for name, ch := range remoteChannels {
+		rc, ok := config[name]
+		if ok && ch.identity == remoteIdentity(rc.Host, rc.GetProfile(), rc.GetAgentDeckPath()) {
+			continue
+		}
+		ch.Close()
+		delete(remoteChannels, name)
+	}
+}
+
+// CloseRemoteChannels closes every channel (TUI shutdown), which ends each
+// remote's agent process instead of leaving it to sshd's keepalive.
+func CloseRemoteChannels() {
+	remoteChannelsMu.Lock()
+	defer remoteChannelsMu.Unlock()
+	for name, ch := range remoteChannels {
+		ch.Close()
+		delete(remoteChannels, name)
+	}
 }
 
 // dialRemoteAgent starts `ssh host agent-deck -p profile remote-agent` with
@@ -156,9 +364,12 @@ func (r *SSHRunner) dialRemoteAgent(ctx context.Context) (io.WriteCloser, io.Rea
 		return nil, nil, nil, err
 	}
 	_ = os.MkdirAll(sshControlDir, 0700)
+	// A stale ControlMaster socket would hang this dial forever (#1421),
+	// which the hello timeout would then read as a slow remote.
+	CleanStaleSSHSockets()
 	// Same argv construction as every other ssh exec in this file (host
 	// validated above, options fixed, remote command shell-quoted).
-	cmd := exec.CommandContext(ctx, "ssh", r.sshBaseArgs(r.buildRemoteCommand("remote-agent"))...) //nolint:gosec // see comment above
+	cmd := exec.CommandContext(ctx, "ssh", r.sshChannelArgs(r.buildRemoteCommand("remote-agent"))...) //nolint:gosec // see comment above
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return nil, nil, nil, err
@@ -184,12 +395,41 @@ func (r *SSHRunner) dialRemoteAgent(ctx context.Context) (io.WriteCloser, io.Rea
 // Connected reports whether requests can go over the channel right now.
 func (c *RemoteChannel) Connected() bool { return c.up.Load() }
 
+// Close takes the channel down for good: the transport is torn down, requests
+// in flight fail, nothing waiting in the mailbox for this remote is
+// delivered, and there is no redial.
+func (c *RemoteChannel) Close() {
+	c.mu.Lock()
+	c.closed = true
+	gen := c.gen
+	c.mu.Unlock()
+	c.markDownGen(gen)
+	c.events.drop(c.name)
+}
+
+func (c *RemoteChannel) tunables() (pingEvery, pingTimeout, helloTimeout time.Duration, maxFrame int) {
+	pingEvery, pingTimeout, helloTimeout, maxFrame = c.pingEvery, c.pingTimeout, c.helloTimeout, c.maxFrame
+	if pingEvery <= 0 {
+		pingEvery = remoteChannelPingEvery
+	}
+	if pingTimeout <= 0 {
+		pingTimeout = remoteChannelPingTimeout
+	}
+	if helloTimeout <= 0 {
+		helloTimeout = remoteChannelHelloTimeout
+	}
+	if maxFrame <= 0 {
+		maxFrame = remoteChannelMaxFrame
+	}
+	return pingEvery, pingTimeout, helloTimeout, maxFrame
+}
+
 // ensureConnected dials if the channel is down and a retry is due. It never
 // blocks a caller: connecting happens on its own goroutine and requests made
 // meanwhile fall back to ssh exec.
 func (c *RemoteChannel) ensureConnected() {
 	c.mu.Lock()
-	if c.up.Load() || c.dialing || time.Now().Before(c.unsupportedUntil) || time.Since(c.lastAttempt) < c.backoff {
+	if c.closed || c.up.Load() || c.dialing || time.Now().Before(c.unsupportedUntil) || time.Since(c.lastAttempt) < c.backoff {
 		c.mu.Unlock()
 		return
 	}
@@ -197,49 +437,91 @@ func (c *RemoteChannel) ensureConnected() {
 	c.lastAttempt = time.Now()
 	c.mu.Unlock()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	stdin, stdout, closeFn, err := c.dial(ctx)
-	if err != nil {
-		cancel()
+	retryLater := func() {
 		c.mu.Lock()
 		c.dialing = false
 		c.backoff = minDuration(c.backoff*2, 30*time.Second)
 		c.mu.Unlock()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	stdin, stdout, closeFn, err := c.dial(ctx)
+	if err != nil {
+		cancel()
+		retryLater()
 		return
 	}
-	// The agent announces itself; anything else (an old build printing
-	// "Unknown command") means no channel on this remote for a while.
+	// The agent announces itself. Only readable text that is not JSON (an
+	// old build's usage or unknown-command output) means the remote has no
+	// remote-agent and is left alone for a while (#7); EOF, a timeout or a
+	// stale socket are link trouble and get the short backoff.
+	_, _, helloTimeout, maxFrame := c.tunables()
 	reader := bufio.NewReader(stdout)
-	firstLine, rerr := readLineWithin(reader, 15*time.Second)
+	firstLine, rerr := readLineWithin(reader, helloTimeout, maxFrame)
 	var hello remoteChannelReply
-	if rerr != nil || json.Unmarshal([]byte(firstLine), &hello) != nil || hello.Event != "ready" {
+	switch {
+	case rerr != nil:
+		closeFn()
+		cancel()
+		retryLater()
+		return
+	case json.Unmarshal([]byte(firstLine), &hello) != nil || hello.Event != "ready":
 		closeFn()
 		cancel()
 		c.mu.Lock()
 		c.dialing = false
-		c.unsupportedUntil = time.Now().Add(10 * time.Minute)
+		c.unsupportedUntil = time.Now().Add(remoteChannelUnsupportedFor)
 		c.mu.Unlock()
 		return
 	}
 	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		closeFn()
+		cancel()
+		return
+	}
+	c.gen++
+	gen := c.gen
 	c.stdin = stdin
 	c.closeFn = func() { closeFn(); cancel() }
 	c.dialing = false
 	c.backoff = 2 * time.Second
+	c.timeouts = 0
+	c.lastRead = time.Now()
 	c.up.Store(true)
 	c.mu.Unlock()
-	go c.readLoop(reader)
+	go c.readLoop(reader, gen, maxFrame)
+	go c.pingLoop(ctx, gen)
 }
 
-func readLineWithin(r *bufio.Reader, d time.Duration) (string, error) {
+// readFrame reads one newline-terminated line, refusing to buffer more than
+// max bytes of it.
+func readFrame(r *bufio.Reader, max int) ([]byte, error) {
+	var line []byte
+	for {
+		chunk, err := r.ReadSlice('\n')
+		if len(line)+len(chunk) > max {
+			return nil, errChannelFrameTooLarge
+		}
+		line = append(line, chunk...)
+		if err == nil {
+			return line, nil
+		}
+		if !errors.Is(err, bufio.ErrBufferFull) {
+			return line, err
+		}
+	}
+}
+
+func readLineWithin(r *bufio.Reader, d time.Duration, maxFrame int) (string, error) {
 	type res struct {
 		s   string
 		err error
 	}
 	ch := make(chan res, 1)
 	go func() {
-		s, err := r.ReadString('\n')
-		ch <- res{s, err}
+		s, err := readFrame(r, maxFrame)
+		ch <- res{string(s), err}
 	}()
 	select {
 	case v := <-ch:
@@ -249,15 +531,57 @@ func readLineWithin(r *bufio.Reader, d time.Duration) (string, error) {
 	}
 }
 
-func (c *RemoteChannel) readLoop(r *bufio.Reader) {
+// pingLoop keeps a quiet channel honest (#5): after pingEvery of silence it
+// sends a ping and takes the transport down when no reply comes within
+// pingTimeout. Any traffic from the agent, including its own ping events,
+// counts as life and postpones the next ping.
+func (c *RemoteChannel) pingLoop(ctx context.Context, gen uint64) {
+	pingEvery, pingTimeout, _, _ := c.tunables()
+	t := time.NewTicker(pingEvery)
+	defer t.Stop()
 	for {
-		line, err := r.ReadString('\n')
-		if err != nil {
-			c.markDown()
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+		}
+		c.mu.Lock()
+		quiet := time.Since(c.lastRead) >= pingEvery
+		live := c.gen == gen && !c.closed
+		c.mu.Unlock()
+		if !live {
 			return
 		}
+		if !quiet {
+			continue
+		}
+		pctx, cancel := context.WithTimeout(ctx, pingTimeout)
+		_, err := c.roundTrip(pctx, remoteChannelRequest{Ping: true})
+		cancel()
+		if errors.Is(err, context.DeadlineExceeded) {
+			sessionLog.Debug("remote_channel_ping_lost", slog.String("remote", c.name))
+			c.markDownGen(gen)
+			return
+		}
+	}
+}
+
+func (c *RemoteChannel) readLoop(r *bufio.Reader, gen uint64, maxFrame int) {
+	for {
+		line, err := readFrame(r, maxFrame)
+		if err != nil {
+			if errors.Is(err, errChannelFrameTooLarge) {
+				sessionLog.Warn("remote_channel_frame_too_large", slog.String("remote", c.name), slog.Int("limit", maxFrame))
+			}
+			c.markDownGen(gen)
+			return
+		}
+		c.mu.Lock()
+		c.lastRead = time.Now()
+		c.timeouts = 0
+		c.mu.Unlock()
 		var reply remoteChannelReply
-		if json.Unmarshal([]byte(strings.TrimSpace(line)), &reply) != nil {
+		if json.Unmarshal([]byte(strings.TrimSpace(string(line))), &reply) != nil {
 			continue
 		}
 		if reply.Event == "changed" {
@@ -273,6 +597,7 @@ func (c *RemoteChannel) readLoop(r *bufio.Reader) {
 			continue
 		}
 		if reply.ID == 0 {
+			// Other events (an agent's own ping) only count as life.
 			continue
 		}
 		c.mu.Lock()
@@ -285,14 +610,15 @@ func (c *RemoteChannel) readLoop(r *bufio.Reader) {
 	}
 }
 
-// publish hands an event to the fan-in without ever blocking the reader: a
-// full buffer drops the event (a "changed" push is followed by a poll, a
-// "pane" push by the next change of that pane).
+// publish hands an event to the mailbox without ever blocking the reader.
+// A closed channel publishes nothing: its remote is gone from the config.
 func (c *RemoteChannel) publish(ch RemoteChange) {
-	select {
-	case c.events <- ch:
-	default:
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return
 	}
+	c.events.put(ch)
 }
 
 // changeFromReply parses the listings a "changed" event carries; a payload
@@ -321,10 +647,24 @@ func (c *RemoteChannel) changeFromReply(r remoteChannelReply) RemoteChange {
 	return ch
 }
 
-// markDown closes the transport and fails every request in flight so the
-// caller falls back to exec; the next ensureConnected redials.
+// markDown closes the current transport and fails every request in flight
+// (never written: errChannelDown, the caller execs; written: the caller
+// gets errChannelInterrupted); the next ensureConnected redials.
 func (c *RemoteChannel) markDown() {
 	c.mu.Lock()
+	gen := c.gen
+	c.mu.Unlock()
+	c.markDownGen(gen)
+}
+
+// markDownGen is markDown for one specific transport: a no-op when a newer
+// one has been dialled since.
+func (c *RemoteChannel) markDownGen(gen uint64) {
+	c.mu.Lock()
+	if c.gen != gen {
+		c.mu.Unlock()
+		return
+	}
 	c.up.Store(false)
 	if c.closeFn != nil {
 		c.closeFn()
@@ -332,17 +672,19 @@ func (c *RemoteChannel) markDown() {
 	}
 	c.stdin = nil
 	c.watching = ""
+	c.timeouts = 0
 	pending := c.pending
 	c.pending = map[int64]chan remoteChannelReply{}
 	c.mu.Unlock()
 	for _, ch := range pending {
-		ch <- remoteChannelReply{Code: -1, Error: errChannelDown.Error()}
+		ch <- remoteChannelReply{Code: -1, Error: errChannelInterrupted.Error()}
 	}
 }
 
 // Request runs args on the remote over the channel. It returns the command's
 // stdout, or an error that names the exit status and stderr (the same shape
-// SSHRunner.run produces), or errChannelDown when the transport failed.
+// SSHRunner.run produces), errChannelDown when the transport failed before
+// the request went out, or errChannelInterrupted when it failed afterwards.
 func (c *RemoteChannel) Request(ctx context.Context, args []string) ([]byte, error) {
 	r, err := c.roundTrip(ctx, remoteChannelRequest{Args: args})
 	if err != nil {
@@ -396,7 +738,7 @@ func (c *RemoteChannel) Watch(ctx context.Context, sessionID string, lines int) 
 		if c.watching == sessionID {
 			c.watching = ""
 		}
-		if !errors.Is(err, errChannelDown) && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		if !isChannelTransportErr(err) && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 			c.watchUnsupported = true
 		}
 		c.mu.Unlock()
@@ -418,8 +760,10 @@ func (c *RemoteChannel) Unwatch(ctx context.Context) error {
 }
 
 // roundTrip sends one request and waits for its reply, mapping a failed
-// command to the same error shape SSHRunner.run produces and a dead
-// transport to errChannelDown.
+// command to the same error shape SSHRunner.run produces, a transport that
+// failed before the write to errChannelDown and one that failed after it to
+// errChannelInterrupted. Consecutive deadline misses take the transport
+// down (#5): a half-open ssh link accepts writes forever and answers none.
 func (c *RemoteChannel) roundTrip(ctx context.Context, req remoteChannelRequest) (remoteChannelReply, error) {
 	if !c.up.Load() {
 		// The channel outlives this request, so its dial is not bound to
@@ -430,7 +774,7 @@ func (c *RemoteChannel) roundTrip(ctx context.Context, req remoteChannelRequest)
 	id := c.nextID.Add(1)
 	reply := make(chan remoteChannelReply, 1)
 	c.mu.Lock()
-	stdin := c.stdin
+	stdin, gen := c.stdin, c.gen
 	if stdin == nil {
 		c.mu.Unlock()
 		return remoteChannelReply{}, errChannelDown
@@ -440,14 +784,23 @@ func (c *RemoteChannel) roundTrip(ctx context.Context, req remoteChannelRequest)
 
 	req.ID = id
 	line, _ := json.Marshal(req)
-	if _, err := stdin.Write(append(line, '\n')); err != nil {
-		c.markDown()
+	if n, err := stdin.Write(append(line, '\n')); err != nil {
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+		c.markDownGen(gen)
+		if n > 0 {
+			// Part of the line may have reached the agent; it cannot have
+			// been executed without the newline, but be conservative.
+			return remoteChannelReply{}, errChannelInterrupted
+		}
 		return remoteChannelReply{}, errChannelDown
 	}
 	select {
 	case r := <-reply:
-		if r.Code == -1 && r.Error == errChannelDown.Error() {
-			return r, errChannelDown
+		if r.Code == -1 && r.Error == errChannelInterrupted.Error() {
+			// markDownGen's verdict for a request that was on the wire.
+			return r, errChannelInterrupted
 		}
 		if r.Error != "" {
 			return r, fmt.Errorf("ssh command failed: %s", r.Error)
@@ -463,7 +816,16 @@ func (c *RemoteChannel) roundTrip(ctx context.Context, req remoteChannelRequest)
 	case <-ctx.Done():
 		c.mu.Lock()
 		delete(c.pending, id)
+		drop := false
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) && c.gen == gen {
+			c.timeouts++
+			drop = c.timeouts >= remoteChannelTimeoutsToDrop
+		}
 		c.mu.Unlock()
+		if drop {
+			sessionLog.Debug("remote_channel_timeouts", slog.String("remote", c.name))
+			c.markDownGen(gen)
+		}
 		return remoteChannelReply{}, ctx.Err()
 	}
 }

--- a/internal/session/remote_channel.go
+++ b/internal/session/remote_channel.go
@@ -61,6 +61,13 @@ type RemoteChannel struct {
 	// still succeed, so only silence gives it away.
 	timeouts int
 	lastRead time.Time
+	// lastMutation is the stamp (remote state DB mtime, unix ns) the agent
+	// reported with its reply to the most recent mutating verb. A pushed
+	// listing stamped before it was taken before that command ran, so its
+	// data is dropped and only the bare "changed" goes out (finding 10).
+	// Stamps come from the remote's clock and outlive a transport, so a
+	// redial keeps it.
+	lastMutation int64
 	// Tunables, zero for the defaults below (tests shrink them).
 	pingEvery    time.Duration
 	pingTimeout  time.Duration
@@ -98,6 +105,9 @@ type remoteChannelRequest struct {
 	// it with a "verb not allowed" error, which proves the link just as
 	// well.
 	Ping bool `json:"ping,omitempty"`
+	// Cancel tells the agent to kill request ID's subprocess (no reply
+	// follows); sent when a request's context ends before its reply.
+	Cancel bool `json:"cancel,omitempty"`
 }
 
 type remoteChannelReply struct {
@@ -111,6 +121,10 @@ type remoteChannelReply struct {
 	Groups   string `json:"groups,omitempty"`
 	ProbeMS  int64  `json:"probe_ms,omitempty"`
 	Session  string `json:"session,omitempty"`
+	// Stamp is the remote state DB's mtime (unix ns) when the listing of a
+	// "changed" event was taken, or after a command finished (0 from an
+	// agent that predates stamps).
+	Stamp int64 `json:"stamp,omitempty"`
 }
 
 // RemoteChange is one pushed event from a remote. For a "changed" event,
@@ -123,6 +137,10 @@ type RemoteChange struct {
 	Groups   []string
 	HasData  bool
 	Pane     *RemotePaneEvent
+	// Stamp is the remote state DB's mtime (unix ns) the listing was taken
+	// at, 0 when the agent did not say. A receiver that knows the stamp of
+	// its own last mutating command can tell a stale listing by it.
+	Stamp int64
 }
 
 // RemotePaneEvent is one pushed pane capture for the watched session: the
@@ -152,6 +170,19 @@ var errChannelFrameTooLarge = errors.New("remote channel frame too large")
 // transport failures rather than a verdict from the remote command.
 func isChannelTransportErr(err error) bool {
 	return errors.Is(err, errChannelDown) || errors.Is(err, errChannelInterrupted)
+}
+
+// ErrRemoteInterrupted is errChannelInterrupted for callers outside the
+// package (tests that stage the outcome, mainly); IsRemoteInterrupted is
+// the check to use.
+var ErrRemoteInterrupted = errChannelInterrupted
+
+// IsRemoteInterrupted reports whether err (possibly wrapped) says the
+// channel dropped after a command was written to the remote and before its
+// reply came back. The command may or may not have run: callers treat the
+// outcome as unknown and refetch rather than retry or revert.
+func IsRemoteInterrupted(err error) bool {
+	return errors.Is(err, errChannelInterrupted)
 }
 
 // remoteChangeMailbox is the fan-in for pushed events (#14). It keeps the
@@ -585,11 +616,21 @@ func (c *RemoteChannel) readLoop(r *bufio.Reader, gen uint64, maxFrame int) {
 			continue
 		}
 		if reply.Event == "changed" {
+			change := c.changeFromReply(reply)
+			stale := c.staleListing(change)
+			if stale {
+				// The listing predates the last mutating command's
+				// completion: drop its data so the receiver fetches (the
+				// bare event still says something changed).
+				change = RemoteChange{Remote: c.name, Stamp: change.Stamp}
+			}
 			sessionLog.Debug("remote_channel_changed",
 				slog.String("remote", c.name),
-				slog.Bool("pushed_data", strings.TrimSpace(reply.Sessions) != ""),
+				slog.Bool("pushed_data", change.HasData),
+				slog.Bool("stale_dropped", stale),
+				slog.Int64("stamp", reply.Stamp),
 				slog.Int64("probe_ms", reply.ProbeMS))
-			c.publish(c.changeFromReply(reply))
+			c.publish(change)
 			continue
 		}
 		if reply.Event == "pane" {
@@ -621,15 +662,52 @@ func (c *RemoteChannel) publish(ch RemoteChange) {
 	c.events.put(ch)
 }
 
+// staleListing reports whether a pushed listing carries a stamp older than
+// the reply to this channel's last mutating command, i.e. it was taken
+// before that command ran. A listing without a stamp, or without data, is
+// never stale here.
+func (c *RemoteChannel) staleListing(ch RemoteChange) bool {
+	if !ch.HasData || ch.Stamp == 0 {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.lastMutation > 0 && ch.Stamp < c.lastMutation
+}
+
+// LastMutationStamp is the stamp the agent reported with its reply to the
+// most recent mutating command over this channel (0 when none, or when the
+// agent predates stamps). A pushed listing stamped before it is stale.
+func (c *RemoteChannel) LastMutationStamp() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.lastMutation
+}
+
+// noteReplyStamp records the stamp of a reply to a mutating verb. Any reply
+// counts, a refused command included: the stamp only says "listings taken
+// before this are older than the command", which is true either way.
+func (c *RemoteChannel) noteReplyStamp(args []string, stamp int64) {
+	if stamp == 0 || len(args) == 0 || remoteVerbReadOnly(args) {
+		return
+	}
+	c.mu.Lock()
+	if stamp > c.lastMutation {
+		c.lastMutation = stamp
+	}
+	c.mu.Unlock()
+}
+
 // changeFromReply parses the listings a "changed" event carries; a payload
-// that does not parse is dropped so the receiver fetches instead.
+// that does not parse is dropped so the receiver fetches instead. HasData
+// is set only when the sessions payload parsed to a listing.
 func (c *RemoteChannel) changeFromReply(r remoteChannelReply) RemoteChange {
-	ch := RemoteChange{Remote: c.name}
+	ch := RemoteChange{Remote: c.name, Stamp: r.Stamp}
 	if strings.TrimSpace(r.Sessions) == "" {
 		return ch
 	}
 	sessions, err := parseRemoteSessions([]byte(r.Sessions))
-	if err != nil {
+	if err != nil || sessions == nil {
 		return ch
 	}
 	for i := range sessions {
@@ -802,6 +880,7 @@ func (c *RemoteChannel) roundTrip(ctx context.Context, req remoteChannelRequest)
 			// markDownGen's verdict for a request that was on the wire.
 			return r, errChannelInterrupted
 		}
+		c.noteReplyStamp(req.Args, r.Stamp)
 		if r.Error != "" {
 			return r, fmt.Errorf("ssh command failed: %s", r.Error)
 		}
@@ -814,6 +893,12 @@ func (c *RemoteChannel) roundTrip(ctx context.Context, req remoteChannelRequest)
 		}
 		return r, nil
 	case <-ctx.Done():
+		// Tell the agent to kill the request's subprocess before forgetting
+		// it, so a slow verb does not keep running (and keep holding a
+		// request slot) on the remote after its caller gave up. Best
+		// effort: a failed write means the transport is going anyway.
+		cancelLine, _ := json.Marshal(remoteChannelRequest{ID: id, Cancel: true})
+		_, _ = stdin.Write(append(cancelLine, '\n'))
 		c.mu.Lock()
 		delete(c.pending, id)
 		drop := false

--- a/internal/session/remote_channel.go
+++ b/internal/session/remote_channel.go
@@ -201,11 +201,16 @@ type remoteChangeMailbox struct {
 	notify chan struct{}
 	out    chan RemoteChange
 	once   sync.Once
+	// seq numbers every put so the pump can tell whether the slot it is
+	// about to hand over was replaced or dropped while it waited.
+	seq  uint64
+	seqs map[string]uint64
 }
 
 func newRemoteChangeMailbox() *remoteChangeMailbox {
 	return &remoteChangeMailbox{
 		slots:  map[string]RemoteChange{},
+		seqs:   map[string]uint64{},
 		notify: make(chan struct{}, 1),
 		out:    make(chan RemoteChange),
 	}
@@ -227,7 +232,15 @@ func (m *remoteChangeMailbox) put(ch RemoteChange) {
 		m.queue = append(m.queue, key)
 	}
 	m.slots[key] = ch
+	m.seq++
+	m.seqs[key] = m.seq
 	m.mu.Unlock()
+	m.wake()
+}
+
+// wake nudges the pump without blocking: a put has new content, or a drop
+// has removed what the pump may be waiting to deliver.
+func (m *remoteChangeMailbox) wake() {
 	select {
 	case m.notify <- struct{}{}:
 	default:
@@ -242,11 +255,17 @@ func (m *remoteChangeMailbox) drop(remote string) {
 	for _, key := range m.queue {
 		if m.slots[key].Remote == remote {
 			delete(m.slots, key)
+			delete(m.seqs, key)
 			continue
 		}
 		kept = append(kept, key)
 	}
 	m.queue = kept
+	m.mu.Unlock()
+	// The pump may be parked offering a slot of this remote; make it look
+	// again so a dropped remote's push is never delivered.
+	m.wake()
+	m.mu.Lock()
 }
 
 // Events returns the delivery channel, starting the pump on first use.
@@ -261,17 +280,31 @@ func (m *remoteChangeMailbox) Events() <-chan RemoteChange {
 func (m *remoteChangeMailbox) pump() {
 	for range m.notify {
 		for {
+			// Peek, do not take: the slot stays in the mailbox while the
+			// receiver is busy, so a newer put replaces it in place and a
+			// drop removes it, and either makes the pump look again.
 			m.mu.Lock()
 			if len(m.queue) == 0 {
 				m.mu.Unlock()
 				break
 			}
 			key := m.queue[0]
-			m.queue = m.queue[1:]
-			ch := m.slots[key]
-			delete(m.slots, key)
+			ch, seq := m.slots[key], m.seqs[key]
 			m.mu.Unlock()
-			m.out <- ch
+			select {
+			case m.out <- ch:
+				m.mu.Lock()
+				if cur, ok := m.seqs[key]; ok && cur == seq {
+					delete(m.slots, key)
+					delete(m.seqs, key)
+					if len(m.queue) > 0 && m.queue[0] == key {
+						m.queue = m.queue[1:]
+					}
+				}
+				m.mu.Unlock()
+			case <-m.notify:
+				// Replaced or dropped meanwhile: look again.
+			}
 		}
 	}
 }

--- a/internal/session/remote_channel_test.go
+++ b/internal/session/remote_channel_test.go
@@ -37,6 +37,12 @@ type fakeAgentT struct {
 	// closeOut ends the agent's output (the transport dies from the far
 	// side).
 	closeOut func()
+	// stamp is what every reply carries as its "stamp" (0 for an agent
+	// that predates stamps); pushDataStamped pushes a listing with one.
+	stamp           atomic.Int64
+	pushDataStamped func(sessions, groups string, stamp int64)
+	// cancelled receives the id of every cancel line.
+	cancelled chan int64
 }
 
 // fakeAgent answers requests like the remote agent would, over pipes.
@@ -51,7 +57,7 @@ func newFakeAgent(t *testing.T, ready, refuseWatch bool) *fakeAgentT {
 	inR, inW := io.Pipe()
 	outR, outW := io.Pipe()
 	var wmu sync.Mutex
-	a := &fakeAgentT{watched: make(chan string, 16), refuseWatch: refuseWatch, hung: make(chan int64, 16)}
+	a := &fakeAgentT{watched: make(chan string, 16), refuseWatch: refuseWatch, hung: make(chan int64, 16), cancelled: make(chan int64, 16)}
 	write := func(v any) {
 		if a.mute.Load() {
 			return
@@ -73,6 +79,10 @@ func newFakeAgent(t *testing.T, ready, refuseWatch bool) *fakeAgentT {
 		for sc.Scan() {
 			var req remoteChannelRequest
 			if json.Unmarshal(sc.Bytes(), &req) != nil {
+				continue
+			}
+			if req.Cancel {
+				a.cancelled <- req.ID
 				continue
 			}
 			if req.Ping {
@@ -100,9 +110,9 @@ func newFakeAgent(t *testing.T, ready, refuseWatch bool) *fakeAgentT {
 			case req.Args[0] == "hang" || (hangOn != "" && req.Args[0] == hangOn):
 				a.hung <- req.ID
 			case req.Args[0] == "fail":
-				write(remoteChannelReply{ID: req.ID, Code: 1, Stderr: "no such session"})
+				write(remoteChannelReply{ID: req.ID, Code: 1, Stderr: "no such session", Stamp: a.stamp.Load()})
 			default:
-				write(remoteChannelReply{ID: req.ID, Stdout: "out:" + strings.Join(req.Args, " ")})
+				write(remoteChannelReply{ID: req.ID, Stdout: "out:" + strings.Join(req.Args, " "), Stamp: a.stamp.Load()})
 			}
 		}
 	}()
@@ -112,6 +122,9 @@ func newFakeAgent(t *testing.T, ready, refuseWatch bool) *fakeAgentT {
 	a.push = func(event string) { write(remoteChannelReply{Event: event}) }
 	a.pushData = func(sessions, groups string) {
 		write(remoteChannelReply{Event: "changed", Sessions: sessions, Groups: groups})
+	}
+	a.pushDataStamped = func(sessions, groups string, stamp int64) {
+		write(remoteChannelReply{Event: "changed", Sessions: sessions, Groups: groups, Stamp: stamp})
 	}
 	a.pushPane = func(session, content, errText string) {
 		write(remoteChannelReply{Event: "pane", Session: session, Stdout: content, Error: errText})
@@ -802,5 +815,140 @@ func TestRemoteChannel_ClosedDropsPushes(t *testing.T) {
 	case ev := <-events:
 		t.Fatalf("closed channel must publish nothing, got %+v", ev)
 	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+// Finding 10: a pushed listing stamped before the reply to the last
+// mutating command was taken before that command ran. Its data is dropped
+// (the bare "changed" still goes out so the receiver fetches); a listing
+// stamped at or after it applies, and read-only verbs never move the bar.
+func TestRemoteChannel_StampGateDropsListingOlderThanMutation(t *testing.T) {
+	agent := newFakeAgent(t, true, false)
+	ch, events := newTestChannel(agent.dial)
+	ch.ensureConnected()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	next := func() RemoteChange {
+		t.Helper()
+		select {
+		case c := <-events:
+			return c
+		case <-time.After(2 * time.Second):
+			t.Fatal("no event")
+			return RemoteChange{}
+		}
+	}
+	listing := `[{"id":"s1","title":"one","tool":"claude","status":"running"}]`
+
+	// A read-only verb's stamp is not a mutation.
+	agent.stamp.Store(500)
+	if _, err := ch.Request(ctx, []string{"list", "--json"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := ch.LastMutationStamp(); got != 0 {
+		t.Fatalf("a listing must not record a mutation stamp, got %d", got)
+	}
+	agent.pushDataStamped(listing, "", 100)
+	if c := next(); !c.HasData || c.Stamp != 100 {
+		t.Fatalf("with no mutation yet every listing applies; got %+v", c)
+	}
+
+	// A mutating verb records its reply's stamp, a refused one too.
+	agent.stamp.Store(1000)
+	if _, err := ch.Request(ctx, []string{"remove", "s1"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := ch.LastMutationStamp(); got != 1000 {
+		t.Fatalf("LastMutationStamp = %d, want 1000", got)
+	}
+	agent.stamp.Store(1200)
+	_, _ = ch.Request(ctx, []string{"fail"})
+	if got := ch.LastMutationStamp(); got != 1200 {
+		t.Fatalf("a refused mutating verb still moves the bar: got %d, want 1200", got)
+	}
+	agent.stamp.Store(900)
+	_, _ = ch.Request(ctx, []string{"rename", "s1", "x"})
+	if got := ch.LastMutationStamp(); got != 1200 {
+		t.Fatalf("the bar never goes backwards: got %d, want 1200", got)
+	}
+
+	// Older listing: data dropped, event kept.
+	agent.pushDataStamped(listing, "", 1100)
+	if c := next(); c.HasData || c.Sessions != nil || c.Remote != "box" || c.Stamp != 1100 {
+		t.Fatalf("a listing older than the last mutation must arrive bare; got %+v", c)
+	}
+	// Same stamp (the probe listed right after the command): applies.
+	agent.pushDataStamped(listing, "", 1200)
+	if c := next(); !c.HasData || len(c.Sessions) != 1 {
+		t.Fatalf("a listing stamped at the mutation applies; got %+v", c)
+	}
+	// Newer: applies. Unstamped (old agent): applies, the receiver decides.
+	agent.pushDataStamped(listing, "", 1300)
+	if c := next(); !c.HasData || c.Stamp != 1300 {
+		t.Fatalf("a newer listing applies; got %+v", c)
+	}
+	agent.pushData(listing, "")
+	if c := next(); !c.HasData || c.Stamp != 0 {
+		t.Fatalf("an unstamped listing is left to the receiver; got %+v", c)
+	}
+}
+
+// A request whose context ends before its reply tells the agent to cancel
+// it, so the remote does not keep running a verb nobody waits for.
+func TestRemoteChannel_CancelSentWhenContextEnds(t *testing.T) {
+	agent := newFakeAgent(t, true, false)
+	ch, _ := newTestChannel(agent.dial)
+	ch.pingEvery = time.Hour
+	ch.ensureConnected()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	_, err := ch.Request(ctx, []string{"hang"})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("want deadline exceeded, got %v", err)
+	}
+	var hungID int64
+	select {
+	case hungID = <-agent.hung:
+	case <-time.After(time.Second):
+		t.Fatal("agent never received the request")
+	}
+	select {
+	case id := <-agent.cancelled:
+		if id != hungID {
+			t.Fatalf("cancel names request %d, want %d", id, hungID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no cancel line reached the agent")
+	}
+	if !ch.Connected() {
+		t.Fatal("one cancelled request must not take the channel down")
+	}
+	// A late reply for the cancelled id is ignored, not delivered to the
+	// next request.
+	if out, err := ch.Request(context.Background(), []string{"list"}); err != nil || string(out) != "out:list" {
+		t.Fatalf("list after a cancel = %q, %v", out, err)
+	}
+}
+
+// HasData is set only when the payload parsed to a listing: a JSON null,
+// garbage or an absent payload leave it unset so the receiver fetches; an
+// empty listing is data (the remote has no sessions).
+func TestRemoteChannel_ChangeFromReplyHasDataOnlyForListings(t *testing.T) {
+	ch, _ := newTestChannel(nil)
+	cases := map[string]bool{
+		"":                          false,
+		"null":                      false,
+		"{not a list}":              false,
+		`[{"id":"s1","title":"x"}]`: true,
+		"[]":                        true,
+	}
+	for payload, want := range cases {
+		got := ch.changeFromReply(remoteChannelReply{Event: "changed", Sessions: payload, Stamp: 7})
+		if got.HasData != want {
+			t.Errorf("payload %q: HasData = %v, want %v", payload, got.HasData, want)
+		}
+		if got.Stamp != 7 {
+			t.Errorf("payload %q: stamp not carried", payload)
+		}
 	}
 }

--- a/internal/session/remote_channel_test.go
+++ b/internal/session/remote_channel_test.go
@@ -705,15 +705,19 @@ func TestRemoteChangeMailbox_LatestWinsPerSlot(t *testing.T) {
 	case <-time.After(50 * time.Millisecond):
 	}
 
-	// A push during a slow receive still arrives after the one in flight.
+	// A push during a slow receive replaces the snapshot still waiting to
+	// be handed over: the receiver gets the newest state once, and the
+	// superseded one is never delivered.
 	m.put(RemoteChange{Remote: "a", HasData: true, Sessions: one("a4")})
 	time.Sleep(20 * time.Millisecond)
 	m.put(RemoteChange{Remote: "a", HasData: true, Sessions: one("a5")})
-	if ev := next(); ev.Sessions[0].ID != "a4" {
-		t.Fatalf("in-flight delivery = %+v, want a4", ev)
-	}
 	if ev := next(); ev.Sessions[0].ID != "a5" {
-		t.Fatalf("follow-up delivery = %+v, want a5", ev)
+		t.Fatalf("delivery after a slow receive = %+v, want the newest a5", ev)
+	}
+	select {
+	case ev := <-m.Events():
+		t.Fatalf("the superseded a4 must not be delivered, got %+v", ev)
+	case <-time.After(50 * time.Millisecond):
 	}
 
 	// drop discards a remote's waiting slots and nothing else.

--- a/internal/session/remote_channel_test.go
+++ b/internal/session/remote_channel_test.go
@@ -25,6 +25,18 @@ type fakeAgentT struct {
 	lines   atomic.Int64
 	// refuseWatch makes the agent answer watch requests like an old build.
 	refuseWatch bool
+	// mute drops every reply and push once set: the link looks half-open.
+	mute atomic.Bool
+	// pings counts ping requests received.
+	pings atomic.Int64
+	// hung receives the id of every "hang" request, which never gets a
+	// reply; hangOn names one more verb that hangs the same way ("" for
+	// none), so a real read-only or mutating verb can be left unanswered.
+	hung   chan int64
+	hangOn atomic.Value
+	// closeOut ends the agent's output (the transport dies from the far
+	// side).
+	closeOut func()
 }
 
 // fakeAgent answers requests like the remote agent would, over pipes.
@@ -39,13 +51,17 @@ func newFakeAgent(t *testing.T, ready, refuseWatch bool) *fakeAgentT {
 	inR, inW := io.Pipe()
 	outR, outW := io.Pipe()
 	var wmu sync.Mutex
+	a := &fakeAgentT{watched: make(chan string, 16), refuseWatch: refuseWatch, hung: make(chan int64, 16)}
 	write := func(v any) {
+		if a.mute.Load() {
+			return
+		}
 		b, _ := json.Marshal(v)
 		wmu.Lock()
 		_, _ = outW.Write(append(b, '\n'))
 		wmu.Unlock()
 	}
-	a := &fakeAgentT{watched: make(chan string, 16), refuseWatch: refuseWatch}
+	a.closeOut = func() { _ = outW.Close() }
 	go func() {
 		if ready {
 			write(remoteChannelReply{Event: "ready"})
@@ -59,6 +75,12 @@ func newFakeAgent(t *testing.T, ready, refuseWatch bool) *fakeAgentT {
 			if json.Unmarshal(sc.Bytes(), &req) != nil {
 				continue
 			}
+			if req.Ping {
+				// Like an agent that predates pings: any reply proves life.
+				a.pings.Add(1)
+				write(remoteChannelReply{ID: req.ID, Code: 2, Error: "verb not allowed over the channel"})
+				continue
+			}
 			if req.Watch != "" || req.Unwatch {
 				if a.refuseWatch {
 					write(remoteChannelReply{ID: req.ID, Code: 2, Error: "verb not allowed over the channel"})
@@ -69,8 +91,15 @@ func newFakeAgent(t *testing.T, ready, refuseWatch bool) *fakeAgentT {
 				write(remoteChannelReply{ID: req.ID})
 				continue
 			}
-			switch req.Args[0] {
-			case "fail":
+			if len(req.Args) == 0 {
+				write(remoteChannelReply{ID: req.ID, Code: 2, Error: "verb not allowed over the channel"})
+				continue
+			}
+			hangOn, _ := a.hangOn.Load().(string)
+			switch {
+			case req.Args[0] == "hang" || (hangOn != "" && req.Args[0] == hangOn):
+				a.hung <- req.ID
+			case req.Args[0] == "fail":
 				write(remoteChannelReply{ID: req.ID, Code: 1, Stderr: "no such session"})
 			default:
 				write(remoteChannelReply{ID: req.ID, Stdout: "out:" + strings.Join(req.Args, " ")})
@@ -90,10 +119,47 @@ func newFakeAgent(t *testing.T, ready, refuseWatch bool) *fakeAgentT {
 	return a
 }
 
-func newTestChannel(dial func(context.Context) (io.WriteCloser, io.Reader, func(), error)) (*RemoteChannel, chan RemoteChange) {
-	events := make(chan RemoteChange, 8)
-	ch := &RemoteChannel{name: "box", dial: dial, events: events, pending: map[int64]chan remoteChannelReply{}, backoff: time.Millisecond}
-	return ch, events
+// redialingAgent returns a dial that starts a fresh fake agent on every
+// call (a real redial gets a new ssh process, not the pipes closeFn shut)
+// and a getter for the agent currently serving.
+func redialingAgent(t *testing.T) (dial func(context.Context) (io.WriteCloser, io.Reader, func(), error), current func() *fakeAgentT) {
+	t.Helper()
+	var mu sync.Mutex
+	var cur *fakeAgentT
+	dial = func(ctx context.Context) (io.WriteCloser, io.Reader, func(), error) {
+		a := newFakeAgent(t, true, false)
+		mu.Lock()
+		cur = a
+		mu.Unlock()
+		return a.dial(ctx)
+	}
+	current = func() *fakeAgentT {
+		mu.Lock()
+		defer mu.Unlock()
+		return cur
+	}
+	return dial, current
+}
+
+func newTestChannel(dial func(context.Context) (io.WriteCloser, io.Reader, func(), error)) (*RemoteChannel, <-chan RemoteChange) {
+	inbox := newRemoteChangeMailbox()
+	ch := newRemoteChannel("box", "h\x00p\x00agent-deck", dial)
+	ch.events = inbox
+	ch.backoff = time.Millisecond
+	return ch, inbox.Events()
+}
+
+// waitUntil polls cond for up to d.
+func waitUntil(t *testing.T, d time.Duration, cond func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return cond()
 }
 
 func TestRemoteChannel_RequestReplyAndEvents(t *testing.T) {
@@ -289,5 +355,452 @@ func TestRemoteChannel_WatchRefusedMarksUnsupported(t *testing.T) {
 		if err != nil || string(out) != "out:list" {
 			t.Fatalf("ordinary requests must keep working after a refused watch, got %q, %v", out, err)
 		}
+	}
+}
+
+// A reply lost after the request went out is not the same as a request that
+// never went out: the remote may have run the command (#3).
+func TestRemoteChannel_LostReplyIsInterruptedNotDown(t *testing.T) {
+	agent := newFakeAgent(t, true, false)
+	ch, _ := newTestChannel(agent.dial)
+	ch.ensureConnected()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := ch.Request(ctx, []string{"hang"})
+		done <- err
+	}()
+	select {
+	case <-agent.hung:
+	case <-time.After(2 * time.Second):
+		t.Fatal("agent never received the request")
+	}
+	agent.closeOut()
+	select {
+	case err := <-done:
+		if !errors.Is(err, errChannelInterrupted) {
+			t.Fatalf("a request the agent received must fail as interrupted, got %v", err)
+		}
+		if errors.Is(err, errChannelDown) {
+			t.Fatal("interrupted must not read as down, or the caller would re-run the command")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("request did not fail when the transport dropped")
+	}
+	if ch.Connected() {
+		t.Fatal("channel must be down after the agent's output ended")
+	}
+	if _, err := ch.Request(ctx, []string{"list"}); !errors.Is(err, errChannelDown) {
+		t.Fatalf("a request on the down channel was never written, want errChannelDown, got %v", err)
+	}
+}
+
+// SSHRunner.run re-runs only read-only verbs after an interrupted request;
+// a mutating verb's interruption reaches the caller (#3). The next request
+// after a drop redials.
+func TestSSHRunnerRun_InterruptedMutatingVerbIsNotReexecuted(t *testing.T) {
+	t.Setenv("AGENT_DECK_REMOTE_CHANNEL", "1")
+	t.Cleanup(CloseRemoteChannels)
+	dial, agent := redialingAgent(t)
+	// Host "" makes the exec fallback fail on validation, which is how the
+	// test sees whether a fallback was attempted at all.
+	r := &SSHRunner{name: "interrupt-test", Profile: "default", AgentDeckPath: "agent-deck", dialChannelFn: dial}
+	ch := channelFor(r)
+	if ch == nil {
+		t.Fatal("channelFor returned nil")
+	}
+	if !waitUntil(t, 2*time.Second, ch.Connected) {
+		t.Fatal("channel never connected")
+	}
+	// interrupted runs args, waits until the agent has the request, then
+	// drops the transport under it.
+	interrupted := func(args ...string) error {
+		a := agent()
+		a.hangOn.Store(args[0])
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		done := make(chan error, 1)
+		go func() {
+			_, err := r.run(ctx, args...)
+			done <- err
+		}()
+		select {
+		case <-a.hung:
+		case <-time.After(2 * time.Second):
+			t.Fatal("agent never received the request")
+		}
+		ch.markDown()
+		select {
+		case err := <-done:
+			return err
+		case <-time.After(2 * time.Second):
+			t.Fatal("run did not return after the transport dropped")
+		}
+		return nil
+	}
+	err := interrupted("remove", "s1")
+	if !errors.Is(err, errChannelInterrupted) {
+		t.Fatalf("a mutating verb interrupted after the write must surface errChannelInterrupted, got %v", err)
+	}
+	if strings.Contains(err.Error(), "ssh host") {
+		t.Fatalf("a mutating verb must not be re-run over exec, got %v", err)
+	}
+	// The next request finds the channel down, kicks a redial and execs.
+	// (A redial waits out the backoff; the test does not.)
+	ch.mu.Lock()
+	ch.lastAttempt = time.Time{}
+	ch.mu.Unlock()
+	if _, err := r.run(context.Background(), "list", "--json"); err == nil || !strings.Contains(err.Error(), "ssh host is empty") {
+		t.Fatalf("a request on the dropped channel must fall back to exec, got %v", err)
+	}
+	if !waitUntil(t, 2*time.Second, ch.Connected) {
+		t.Fatal("the request after a drop did not redial")
+	}
+	err = interrupted("list", "--json")
+	if errors.Is(err, errChannelInterrupted) {
+		t.Fatalf("an interrupted listing must be re-run over exec, got %v", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "ssh host is empty") {
+		t.Fatalf("the exec fallback must have been attempted, got %v", err)
+	}
+}
+
+func TestRemoteVerbReadOnly(t *testing.T) {
+	readOnly := [][]string{
+		{"list", "--json"}, {"ls"}, {"accounts", "--json"}, {"group", "list", "--json"},
+		{"costs", "summary", "--json"}, {"mcp", "list", "--quiet"}, {"skill", "list"},
+		{"session", "output", "s1", "--json"}, {"session", "pane", "s1"}, {"session", "show", "s1"}, {"version"},
+		{"inbox", "export", "--json"}, {"inbox", "writer-status", "--json"},
+	}
+	for _, args := range readOnly {
+		if !remoteVerbReadOnly(args) {
+			t.Errorf("%v must be read-only", args)
+		}
+	}
+	mutating := [][]string{
+		nil, {"add", "/p"}, {"remove", "s1"}, {"session", "restart", "s1"}, {"session", "fork", "--json", "s1"},
+		{"session", "stop", "s1"}, {"group", "move", "g", "--position", "1"}, {"mcp", "attach", "s1", "x"}, {"costs"},
+		{"session", "archive", "s1"}, {"session", "unarchive", "s1"}, {"inbox", "clear"},
+	}
+	for _, args := range mutating {
+		if remoteVerbReadOnly(args) {
+			t.Errorf("%v must count as mutating", args)
+		}
+	}
+}
+
+// Two requests in a row that get no reply before their deadline take the
+// transport down, so the caller execs and the next request redials (#5).
+func TestRemoteChannel_ConsecutiveTimeoutsMarkDown(t *testing.T) {
+	dial, _ := redialingAgent(t)
+	ch, _ := newTestChannel(dial)
+	ch.pingEvery = time.Hour
+	ch.ensureConnected()
+	for i := 0; i < remoteChannelTimeoutsToDrop; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+		_, err := ch.Request(ctx, []string{"hang"})
+		cancel()
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("request %d: want deadline exceeded, got %v", i, err)
+		}
+		if i < remoteChannelTimeoutsToDrop-1 && !ch.Connected() {
+			t.Fatalf("one timeout alone must not take the channel down")
+		}
+	}
+	if ch.Connected() {
+		t.Fatal("channel must be down after consecutive timeouts")
+	}
+	// A reply in between resets the count.
+	ch.lastAttempt = time.Time{}
+	ch.ensureConnected()
+	if !ch.Connected() {
+		t.Fatal("redial failed")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	_, _ = ch.Request(ctx, []string{"hang"})
+	cancel()
+	if _, err := ch.Request(context.Background(), []string{"list"}); err != nil {
+		t.Fatalf("list after one timeout: %v", err)
+	}
+	ctx, cancel = context.WithTimeout(context.Background(), 30*time.Millisecond)
+	_, _ = ch.Request(ctx, []string{"hang"})
+	cancel()
+	if !ch.Connected() {
+		t.Fatal("a reply between two timeouts must reset the count")
+	}
+}
+
+// A silent agent (half-open link) is found by the client's ping; an agent
+// that answers pings, even with an error like an old build, keeps the
+// channel up.
+func TestRemoteChannel_PingDetectsSilentLink(t *testing.T) {
+	agent := newFakeAgent(t, true, false)
+	ch, _ := newTestChannel(agent.dial)
+	ch.pingEvery = 20 * time.Millisecond
+	ch.pingTimeout = 40 * time.Millisecond
+	ch.ensureConnected()
+	if !waitUntil(t, 2*time.Second, func() bool { return agent.pings.Load() >= 2 }) {
+		t.Fatal("client never pinged the idle agent")
+	}
+	if !ch.Connected() {
+		t.Fatal("an agent that answers pings must keep the channel up")
+	}
+	agent.mute.Store(true)
+	if !waitUntil(t, 2*time.Second, func() bool { return !ch.Connected() }) {
+		t.Fatal("a missed ping window must take the channel down")
+	}
+	if _, err := ch.Request(context.Background(), []string{"list"}); !errors.Is(err, errChannelDown) {
+		t.Fatalf("after the ping failure requests must fall back, got %v", err)
+	}
+}
+
+// Only readable non-JSON output from the remote (an old build) marks it
+// unsupported for a long time; link trouble gets the short backoff (#7).
+func TestRemoteChannel_DialFailuresBackOffInsteadOfDisabling(t *testing.T) {
+	cases := []struct {
+		name string
+		dial func(context.Context) (io.WriteCloser, io.Reader, func(), error)
+	}{
+		{"dial error", func(context.Context) (io.WriteCloser, io.Reader, func(), error) {
+			return nil, nil, nil, errors.New("ssh: connect: connection refused")
+		}},
+		{"eof before hello", func(context.Context) (io.WriteCloser, io.Reader, func(), error) {
+			inR, inW := io.Pipe()
+			outR, outW := io.Pipe()
+			_ = outW.Close()
+			return inW, outR, func() { _ = inR.Close() }, nil
+		}},
+		{"slow hello", func(context.Context) (io.WriteCloser, io.Reader, func(), error) {
+			inR, inW := io.Pipe()
+			outR, outW := io.Pipe()
+			return inW, outR, func() { _ = inR.Close(); _ = outW.Close() }, nil
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ch, _ := newTestChannel(tc.dial)
+			ch.helloTimeout = 30 * time.Millisecond
+			ch.ensureConnected()
+			if ch.Connected() {
+				t.Fatal("must not be connected")
+			}
+			if !ch.unsupportedUntil.IsZero() {
+				t.Fatalf("%s must not mark the remote unsupported", tc.name)
+			}
+			if ch.backoff <= time.Millisecond || ch.backoff > 30*time.Second {
+				t.Fatalf("backoff = %v, want doubled within the 30s cap", ch.backoff)
+			}
+			if ch.dialing {
+				t.Fatal("dialing flag left set")
+			}
+		})
+	}
+	dial, _, _ := fakeAgent(t, false)
+	ch, _ := newTestChannel(dial)
+	ch.ensureConnected()
+	if time.Until(ch.unsupportedUntil) < time.Minute {
+		t.Fatal("non-JSON hello must still mark the remote unsupported")
+	}
+}
+
+// A line longer than the cap costs the transport, not the process (#13).
+func TestRemoteChannel_OversizeFrameDropsTransport(t *testing.T) {
+	agent := newFakeAgent(t, true, false)
+	ch, events := newTestChannel(agent.dial)
+	ch.maxFrame = 4096
+	ch.ensureConnected()
+	agent.pushData(`[{"id":"s1","title":"one"}]`, "")
+	select {
+	case ev := <-events:
+		if !ev.HasData {
+			t.Fatalf("small frame must still arrive parsed, got %+v", ev)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("small push did not arrive")
+	}
+	agent.pushData(`[{"id":"s1","title":"`+strings.Repeat("x", 8192)+`"}]`, "")
+	if !waitUntil(t, 2*time.Second, func() bool { return !ch.Connected() }) {
+		t.Fatal("an oversize frame must take the channel down")
+	}
+	select {
+	case ev := <-events:
+		t.Fatalf("the oversize frame must not be delivered, got %+v", ev)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestReadFrame(t *testing.T) {
+	r := bufio.NewReaderSize(strings.NewReader(strings.Repeat("a", 100)+"\nshort\n"+strings.Repeat("b", 50)), 16)
+	line, err := readFrame(r, 200)
+	if err != nil || len(line) != 101 {
+		t.Fatalf("long line across buffer refills: len %d, %v", len(line), err)
+	}
+	line, err = readFrame(r, 200)
+	if err != nil || string(line) != "short\n" {
+		t.Fatalf("second line = %q, %v", line, err)
+	}
+	line, err = readFrame(r, 200)
+	if !errors.Is(err, io.EOF) || len(line) != 50 {
+		t.Fatalf("unterminated tail: %q, %v", line, err)
+	}
+	r = bufio.NewReaderSize(strings.NewReader(strings.Repeat("a", 100)+"\n"), 16)
+	if _, err := readFrame(r, 64); !errors.Is(err, errChannelFrameTooLarge) {
+		t.Fatalf("over the cap: %v", err)
+	}
+}
+
+// The mailbox keeps only the newest snapshot per remote and the newest pane
+// per session, and delivers slots in first-arrival order (#14).
+func TestRemoteChangeMailbox_LatestWinsPerSlot(t *testing.T) {
+	m := newRemoteChangeMailbox()
+	one := func(id string) []RemoteSessionInfo { return []RemoteSessionInfo{{ID: id}} }
+	m.put(RemoteChange{Remote: "a", HasData: true, Sessions: one("a1")})
+	m.put(RemoteChange{Remote: "b", HasData: true, Sessions: one("b1")})
+	m.put(RemoteChange{Remote: "a", Pane: &RemotePaneEvent{Session: "s1", Content: "old"}})
+	m.put(RemoteChange{Remote: "a", HasData: true, Sessions: one("a2")})
+	m.put(RemoteChange{Remote: "a", HasData: true, Sessions: one("a3")})
+	m.put(RemoteChange{Remote: "a", Pane: &RemotePaneEvent{Session: "s1", Content: "new"}})
+	m.put(RemoteChange{Remote: "a", Pane: &RemotePaneEvent{Session: "s2", Content: "other"}})
+
+	next := func() RemoteChange {
+		t.Helper()
+		select {
+		case ev := <-m.Events():
+			return ev
+		case <-time.After(2 * time.Second):
+			t.Fatal("mailbox delivered nothing")
+			return RemoteChange{}
+		}
+	}
+	if ev := next(); ev.Remote != "a" || ev.Pane != nil || ev.Sessions[0].ID != "a3" {
+		t.Fatalf("first delivery = %+v, want a's newest listing a3", ev)
+	}
+	if ev := next(); ev.Remote != "b" || ev.Sessions[0].ID != "b1" {
+		t.Fatalf("second delivery = %+v, want b1", ev)
+	}
+	if ev := next(); ev.Pane == nil || ev.Pane.Session != "s1" || ev.Pane.Content != "new" {
+		t.Fatalf("third delivery = %+v, want s1's newest pane", ev)
+	}
+	if ev := next(); ev.Pane == nil || ev.Pane.Session != "s2" {
+		t.Fatalf("fourth delivery = %+v, want s2's pane", ev)
+	}
+	select {
+	case ev := <-m.Events():
+		t.Fatalf("superseded snapshots must not be delivered, got %+v", ev)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// A push during a slow receive still arrives after the one in flight.
+	m.put(RemoteChange{Remote: "a", HasData: true, Sessions: one("a4")})
+	time.Sleep(20 * time.Millisecond)
+	m.put(RemoteChange{Remote: "a", HasData: true, Sessions: one("a5")})
+	if ev := next(); ev.Sessions[0].ID != "a4" {
+		t.Fatalf("in-flight delivery = %+v, want a4", ev)
+	}
+	if ev := next(); ev.Sessions[0].ID != "a5" {
+		t.Fatalf("follow-up delivery = %+v, want a5", ev)
+	}
+
+	// drop discards a remote's waiting slots and nothing else.
+	m.put(RemoteChange{Remote: "gone", HasData: true})
+	m.put(RemoteChange{Remote: "gone", Pane: &RemotePaneEvent{Session: "x"}})
+	m.put(RemoteChange{Remote: "kept", HasData: true})
+	m.drop("gone")
+	if ev := next(); ev.Remote != "kept" {
+		t.Fatalf("after drop got %+v, want kept", ev)
+	}
+	select {
+	case ev := <-m.Events():
+		t.Fatalf("dropped remote must not be delivered, got %+v", ev)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+// Channels follow the config: a name re-pointed at another host gets a new
+// channel, a removed name loses its channel, and shutdown closes all (#8).
+func TestRemoteChannels_FollowConfig(t *testing.T) {
+	t.Setenv("AGENT_DECK_REMOTE_CHANNEL", "1")
+	t.Cleanup(CloseRemoteChannels)
+	agent1 := newFakeAgent(t, true, false)
+	r1 := &SSHRunner{name: "box", Host: "h1", Profile: "default", AgentDeckPath: "agent-deck", dialChannelFn: agent1.dial}
+	ch1 := channelFor(r1)
+	if ch1 == nil || channelFor(r1) != ch1 {
+		t.Fatal("same identity must share one channel")
+	}
+	if !waitUntil(t, 2*time.Second, ch1.Connected) {
+		t.Fatal("ch1 never connected")
+	}
+	// Same config again keeps it.
+	ReconcileRemoteChannels(map[string]RemoteConfig{"box": {Host: "h1"}})
+	if RemoteChannelFor("box") != ch1 || !ch1.Connected() {
+		t.Fatal("reconcile with an unchanged config must keep the channel")
+	}
+
+	dial2, _ := redialingAgent(t)
+	r2 := &SSHRunner{name: "box", Host: "h2", Profile: "default", AgentDeckPath: "agent-deck", dialChannelFn: dial2}
+	ch2 := channelFor(r2)
+	if ch2 == ch1 {
+		t.Fatal("a re-pointed name must get a fresh channel")
+	}
+	if ch1.Connected() || !ch1.closed {
+		t.Fatal("the old host's channel must be closed")
+	}
+	agent1.push("changed")
+	if !waitUntil(t, 2*time.Second, ch2.Connected) {
+		t.Fatal("ch2 never connected")
+	}
+	if RemoteChannelFor("box") != ch2 {
+		t.Fatal("registry must point at the new channel")
+	}
+	ch1.lastAttempt = time.Time{}
+	ch1.ensureConnected()
+	if ch1.Connected() {
+		t.Fatal("a closed channel must never redial")
+	}
+
+	// Profile change through reconcile.
+	ReconcileRemoteChannels(map[string]RemoteConfig{"box": {Host: "h2", Profile: "work"}})
+	if RemoteChannelFor("box") != nil || ch2.Connected() {
+		t.Fatal("a profile change must close the channel so the next command redials")
+	}
+	ch3 := channelFor(r2)
+	if !waitUntil(t, 2*time.Second, ch3.Connected) {
+		t.Fatal("ch3 never connected")
+	}
+	ReconcileRemoteChannels(map[string]RemoteConfig{})
+	if RemoteChannelFor("box") != nil || ch3.Connected() {
+		t.Fatal("a removed remote must lose its channel")
+	}
+	ch4 := channelFor(r2)
+	if !waitUntil(t, 2*time.Second, ch4.Connected) {
+		t.Fatal("ch4 never connected")
+	}
+	CloseRemoteChannels()
+	if RemoteChannelFor("box") != nil || ch4.Connected() {
+		t.Fatal("shutdown must close every channel")
+	}
+}
+
+// A closed channel publishes nothing: the removed remote's rows cannot come
+// back through a late push.
+func TestRemoteChannel_ClosedDropsPushes(t *testing.T) {
+	agent := newFakeAgent(t, true, false)
+	ch, events := newTestChannel(agent.dial)
+	ch.ensureConnected()
+	agent.pushData(`[{"id":"s1"}]`, "")
+	select {
+	case <-events:
+	case <-time.After(2 * time.Second):
+		t.Fatal("push before close did not arrive")
+	}
+	ch.publish(RemoteChange{Remote: "box", HasData: true})
+	ch.Close()
+	ch.publish(RemoteChange{Remote: "box", HasData: true, Sessions: []RemoteSessionInfo{{ID: "late"}}})
+	select {
+	case ev := <-events:
+		t.Fatalf("closed channel must publish nothing, got %+v", ev)
+	case <-time.After(50 * time.Millisecond):
 	}
 }

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -164,6 +164,10 @@ type SSHRunner struct {
 	// channel (#2174). Empty for runners built without a name.
 	name string
 
+	// dialChannelFn lets tests stub the persistent channel's ssh subprocess
+	// (channelFor). nil = real SSH.
+	dialChannelFn func(ctx context.Context) (io.WriteCloser, io.Reader, func(), error)
+
 	// openStreamFn lets tests stub out the persistent-stream subprocess
 	// without spawning real ssh. nil = real SSH (#1112 bug 2).
 	openStreamFn func(ctx context.Context, args ...string) (io.WriteCloser, func() error, error)
@@ -254,7 +258,16 @@ func (r *SSHRunner) run(ctx context.Context, args ...string) ([]byte, error) {
 	// the channel can only make things faster, never break them.
 	if ch := channelFor(r); ch != nil && ch.Connected() {
 		out, err := ch.Request(ctx, args)
-		if !errors.Is(err, errChannelDown) {
+		switch {
+		case err == nil:
+			return out, nil
+		case errors.Is(err, errChannelDown):
+			// Never reached the agent: an exec is the same request.
+		case errors.Is(err, errChannelInterrupted) && remoteVerbReadOnly(args):
+			// Written, reply lost. Re-running a listing is harmless; a
+			// mutating verb may already have run on the remote (#3), so
+			// its error goes to the caller, who refetches.
+		default:
 			return out, err
 		}
 	}
@@ -1175,6 +1188,44 @@ func ValidateSSHHost(host string) error {
 // sshBaseArgs returns common SSH args for running a raw command on the remote.
 func (r *SSHRunner) sshBaseArgs(remoteCmd string) []string {
 	return append(r.sshConnOpts(), r.Host, remoteCmd)
+}
+
+// sshChannelArgs is sshBaseArgs for the persistent channel (#2174). It adds
+// ServerAlive probes so a link that died under the session (laptop sleep,
+// VPN flap, NAT expiry) is torn down by ssh within about 45 s instead of
+// the OS keepalive's hours (#5). One-shot execs do not need them: their
+// command timeout already bounds them.
+func (r *SSHRunner) sshChannelArgs(remoteCmd string) []string {
+	args := append(r.sshConnOpts(), "-o", "ServerAliveInterval=15", "-o", "ServerAliveCountMax=3")
+	return append(args, r.Host, remoteCmd)
+}
+
+// remoteVerbReadOnly reports whether args is a verb that only reads remote
+// state, so running it twice is harmless. Anything not listed here counts
+// as mutating.
+func remoteVerbReadOnly(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	second := ""
+	if len(args) > 1 {
+		second = args[1]
+	}
+	switch args[0] {
+	case "list", "ls", "accounts", "version", "status":
+		return true
+	case "group":
+		return second == "list"
+	case "costs":
+		return second == "summary"
+	case "mcp", "skill":
+		return second == "list"
+	case "inbox":
+		return second == "export" || second == "writer-status"
+	case "session":
+		return second == "show" || second == "output" || second == "pane"
+	}
+	return false
 }
 
 // buildAttachArgs builds the ssh argv for an interactive attach. It shares

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -869,3 +869,22 @@ func TestRemoteStartArgs_NoWaitAndFallback(t *testing.T) {
 		t.Fatal("an ordinary failure must not be mistaken for an unknown flag")
 	}
 }
+
+// The channel dial carries ServerAlive probes so a dead link is noticed in
+// under a minute (#5); one-shot execs keep the shared options only.
+func TestSSHRunnerChannelArgs_AddServerAlive(t *testing.T) {
+	r := &SSHRunner{Host: "user@host"}
+	args := strings.Join(r.sshChannelArgs("cmd"), " ")
+	if !strings.Contains(args, "-o ServerAliveInterval=15 -o ServerAliveCountMax=3 user@host cmd") {
+		t.Fatalf("channel args = %q", args)
+	}
+	base := strings.Join(r.sshBaseArgs("cmd"), " ")
+	if strings.Contains(base, "ServerAlive") {
+		t.Fatalf("exec args must stay unchanged, got %q", base)
+	}
+	for _, opt := range []string{"ControlMaster=auto", "BatchMode=yes", "ConnectTimeout=10"} {
+		if !strings.Contains(args, opt) {
+			t.Fatalf("channel args must keep %s, got %q", opt, args)
+		}
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -698,6 +698,16 @@ type Home struct {
 	// fetch was already in flight: that fetch may predate the change, so
 	// another one starts as soon as it lands.
 	remoteRefetchWanted bool
+	// remoteConfigured is the set of remote names the last successfully
+	// read config listed (nil before the first read). A push from a name
+	// outside it is from a remote that was removed from the config and is
+	// dropped; every name in it other than the pusher is kept as is when a
+	// push is applied. Guarded by remoteSessionsMu.
+	remoteConfigured map[string]struct{}
+	// remoteMutationStamp returns the stamp (remote DB mtime, unix ns) of
+	// the last mutating command confirmed over a remote's channel, 0 when
+	// unknown. nil means ask the channel; tests inject a stub.
+	remoteMutationStamp func(remoteName string) int64
 	// remotePending marks remote session rows with an action underway
 	// (sessionID -> "deleting…"), drawn on the row so the screen says what
 	// is happening while the remote answers instead of freezing.
@@ -2337,7 +2347,7 @@ func (h *Home) moveRemoteSessionToGroup(title, remoteName, sessionID, targetGrou
 		defer cancel()
 		if _, err := runner.RunCommand(ctx, "group", "move", sessionID, targetGroupPath); err != nil {
 			return remoteMoveResultMsg{remoteName: remoteName, sessionID: sessionID, groupPath: targetGroupPath,
-				err: fmt.Errorf("failed to move '%s' on %s: %v", title, remoteName, err)}
+				err: fmt.Errorf("failed to move '%s' on %s: %w", title, remoteName, err)}
 		}
 		return remoteMoveResultMsg{remoteName: remoteName, sessionID: sessionID, groupPath: targetGroupPath}
 	}
@@ -2384,7 +2394,7 @@ func (h *Home) createRemoteGroup(name, remoteName, parentPath, defaultPath strin
 		args := remoteGroupCreateArgs(name, parentPath, defaultPath)
 		if _, err := runner.RunCommand(ctx, args...); err != nil {
 			return remoteGroupResultMsg{remoteName: remoteName,
-				err: fmt.Errorf("failed to create group '%s' on %s: %v", name, remoteName, err)}
+				err: fmt.Errorf("failed to create group '%s' on %s: %w", name, remoteName, err)}
 		}
 		full := name
 		if parentPath != "" {
@@ -2411,7 +2421,7 @@ func (h *Home) deleteRemoteGroup(groupPath, remoteName string) tea.Cmd {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		if _, err := runner.RunCommand(ctx, "group", "delete", groupPath); err != nil {
-			return result(fmt.Errorf("failed to delete group '%s' on %s: %v", groupPath, remoteName, err))
+			return result(fmt.Errorf("failed to delete group '%s' on %s: %w", groupPath, remoteName, err))
 		}
 		return result(nil)
 	}
@@ -4140,10 +4150,24 @@ func (h *Home) waitRemoteChange() tea.Msg {
 	return remoteChangedMsg{remoteName: change.Remote, change: change}
 }
 
+// remoteIsConfigured reports whether remoteName is in the last config read.
+// Before the first read every name passes: the startup cache may hold rows
+// for remotes the config has not been consulted about yet.
+func (h *Home) remoteIsConfigured(remoteName string) bool {
+	h.remoteSessionsMu.RLock()
+	defer h.remoteSessionsMu.RUnlock()
+	if h.remoteConfigured == nil {
+		return true
+	}
+	_, ok := h.remoteConfigured[remoteName]
+	return ok
+}
+
 // pushedRemoteFetch shapes a pushed change as a fetch result for that one
 // remote: every other remote is marked failed (the merge keeps its rows),
 // costs are absent (left untouched), and the sequence number advances so an
-// older poll cannot overwrite this newer state.
+// older poll cannot overwrite this newer state. The caller has checked that
+// the pusher is still configured (remoteIsConfigured).
 func (h *Home) pushedRemoteFetch(ch session.RemoteChange) remoteSessionsFetchedMsg {
 	msg := remoteSessionsFetchedMsg{
 		gen:          atomic.AddUint64(&h.remoteFetchSeq, 1),
@@ -4158,14 +4182,18 @@ func (h *Home) pushedRemoteFetch(ch session.RemoteChange) remoteSessionsFetchedM
 	} else {
 		msg.groupsFailed[ch.Remote] = true
 	}
-	// Every other remote the TUI knows is marked failed: the ones with rows,
-	// and the ones known only by a group list or a cost figure (a remote
-	// with zero sessions still has a host header and folders to keep,
-	// finding 12). A remote the config lists but nothing has fetched yet
-	// has nothing to lose.
-	// TODO(#2181 follow-up): once session.ReconcileRemoteChannels(config)
-	// exists, take the configured names from it here instead.
+	// Every other remote is marked failed: the ones the config lists, and
+	// the ones the TUI still knows by rows, a group list or a cost figure
+	// (a remote with zero sessions still has a host header and folders to
+	// keep, finding 12; the startup cache may know remotes the config has
+	// not been read for yet).
 	h.remoteSessionsMu.RLock()
+	for name := range h.remoteConfigured {
+		if name != ch.Remote {
+			msg.failed[name] = true
+			msg.groupsFailed[name] = true
+		}
+	}
 	for name := range h.remoteSessions {
 		if name != ch.Remote {
 			msg.failed[name] = true
@@ -4195,6 +4223,16 @@ func (h *Home) pushedRemoteFetch(ch session.RemoteChange) remoteSessionsFetchedM
 // probe lists the state DB on a timer, so a listing snapshotted just before
 // the action ran can arrive just after its confirmation.
 const remoteActionGrace = 3 * time.Second
+
+// remoteOutcomeUnknown is the handler's answer when the channel dropped
+// after a mutating command was written to remoteName and before its reply
+// (session.IsRemoteInterrupted): the remote may or may not have run it, so
+// nothing is confirmed or reverted on faith, the footer says so, and a
+// fetch settles the tree.
+func (h *Home) remoteOutcomeUnknown(remoteName string) tea.Cmd {
+	h.setError(fmt.Errorf("on %s: connection dropped before the reply, refreshing", remoteName))
+	return h.fetchRemoteSessions
+}
 
 // noteRemoteActionSettled records that remote just confirmed a user action.
 func (h *Home) noteRemoteActionSettled(remoteName string) {
@@ -4257,41 +4295,68 @@ func (h *Home) remoteActionInProgress(remoteName string) bool {
 	return false
 }
 
+// lastRemoteMutationStamp is the stamp of the last mutating command the
+// remote confirmed over its channel, 0 when there is no channel or it does
+// not know.
+func (h *Home) lastRemoteMutationStamp(remoteName string) int64 {
+	if h.remoteMutationStamp != nil {
+		return h.remoteMutationStamp(remoteName)
+	}
+	if ch := session.RemoteChannelFor(remoteName); ch != nil {
+		return ch.LastMutationStamp()
+	}
+	return 0
+}
+
 // stalePushedChange reports whether a pushed listing for ch.Remote predates
-// a user action and must not be applied (finding 10). While an action on
-// that remote is in flight, or within remoteActionGrace of its confirmation,
-// a listing that still contains a session the action removed, or shows one
-// it archived as active (or the reverse), is stale: the probe read the DB
-// before the action ran. Outside that window, or when the listing agrees
-// with the action, the push applies as usual. Entries older than the grace
-// are dropped as they are met.
+// a user action and must not be applied (finding 10).
 //
-// TODO(channel owner): when RemoteChange carries the DB stamp the listing was
-// taken at, compare stamps here instead of session membership.
+// When the listing carries the DB stamp it was taken at and the remote's
+// channel knows the stamp of the last mutating command it confirmed, the
+// two decide it: a listing stamped before the command is stale, one stamped
+// at or after it is the truth (the channel already drops the former before
+// it gets here; the check is repeated so the verdict does not depend on
+// which side saw the stamps).
+//
+// Without stamps (an agent that predates them, a command that ran as a
+// plain ssh exec while the channel was down), session membership decides:
+// while an action on that remote is in flight, or within remoteActionGrace
+// of its confirmation, a listing that still contains a session the action
+// removed, or shows one it archived as active (or the reverse), is stale:
+// the probe read the DB before the action ran. Outside that window, or
+// when the listing agrees with the action, the push applies as usual.
+// Entries older than the grace are dropped as they are met.
 func (h *Home) stalePushedChange(ch session.RemoteChange, now time.Time) bool {
 	removed := h.remoteActionRemoved[ch.Remote]
 	if len(removed) == 0 {
 		return false
 	}
-	inGrace := h.remoteActionInProgress(ch.Remote) || now.Sub(h.remoteActionSettled[ch.Remote]) < remoteActionGrace
-	stale := false
 	for id, rec := range removed {
 		if now.Sub(rec.at) >= remoteActionGrace {
 			delete(removed, id)
-			continue
 		}
-		if !inGrace {
-			continue
+	}
+	if len(removed) == 0 {
+		delete(h.remoteActionRemoved, ch.Remote)
+		return false
+	}
+	if ch.Stamp > 0 {
+		if last := h.lastRemoteMutationStamp(ch.Remote); last > 0 {
+			return ch.Stamp < last
 		}
+	}
+	inGrace := h.remoteActionInProgress(ch.Remote) || now.Sub(h.remoteActionSettled[ch.Remote]) < remoteActionGrace
+	if !inGrace {
+		return false
+	}
+	stale := false
+	for id, rec := range removed {
 		for i := range ch.Sessions {
 			if ch.Sessions[i].ID == id && rec.contradicts(&ch.Sessions[i]) {
 				stale = true
 				break
 			}
 		}
-	}
-	if len(removed) == 0 {
-		delete(h.remoteActionRemoved, ch.Remote)
 	}
 	return stale
 }
@@ -4309,7 +4374,23 @@ func (h *Home) fetchRemoteSessions() tea.Msg {
 		// deconfigured; keep everything and say why.
 		return remoteSessionsFetchedMsg{gen: gen, configErr: err}
 	}
-	if config == nil || len(config.Remotes) == 0 {
+	// The config is the truth about which remotes exist: close the channel
+	// of any remote that was removed or re-pointed at another host, so it
+	// stops pushing rows into the tree, and remember the names so a push
+	// can be checked against them (#8).
+	var remotes map[string]session.RemoteConfig
+	if config != nil {
+		remotes = config.Remotes
+	}
+	session.ReconcileRemoteChannels(remotes)
+	configured := make(map[string]struct{}, len(remotes))
+	for name := range remotes {
+		configured[name] = struct{}{}
+	}
+	h.remoteSessionsMu.Lock()
+	h.remoteConfigured = configured
+	h.remoteSessionsMu.Unlock()
+	if len(remotes) == 0 {
 		return remoteSessionsFetchedMsg{gen: gen, sessions: nil}
 	}
 
@@ -7580,6 +7661,13 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return h, h.waitRemoteChange
 		}
+		if !h.remoteIsConfigured(msg.remoteName) {
+			// The remote was removed from the config (its channel is being
+			// closed by the next fetch round): nothing it says belongs in
+			// the tree any more.
+			uiLog.Debug("remote_changed", slog.String("remote", msg.remoteName), slog.Bool("deconfigured_dropped", true))
+			return h, h.waitRemoteChange
+		}
 		if msg.change.HasData && !h.stalePushedChange(msg.change, time.Now()) {
 			// The event brought the listings: apply them now, no round trip.
 			uiLog.Debug("remote_changed", slog.String("remote", msg.remoteName), slog.Bool("pushed_data", true))
@@ -7633,6 +7721,11 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case remoteSessionDeletedMsg:
 		h.setRemotePending(msg.sessionID, "")
 		h.noteRemoteActionSettled(msg.remoteName)
+		if session.IsRemoteInterrupted(msg.err) {
+			// The remote may have deleted it: the row stays until the
+			// fetch says.
+			return h, h.remoteOutcomeUnknown(msg.remoteName)
+		}
 		if msg.err != nil {
 			h.setError(fmt.Errorf("failed to delete '%s' on %s: %w", msg.title, msg.remoteName, msg.err))
 			return h, nil
@@ -7644,6 +7737,9 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case remoteSessionClosedMsg:
 		h.setRemotePending(msg.sessionID, "")
 		h.noteRemoteActionSettled(msg.remoteName)
+		if session.IsRemoteInterrupted(msg.err) {
+			return h, h.remoteOutcomeUnknown(msg.remoteName)
+		}
 		if msg.err != nil {
 			h.setError(fmt.Errorf("failed to close '%s' on %s: %w", msg.title, msg.remoteName, msg.err))
 			return h, nil
@@ -7658,6 +7754,9 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		h.setRemotePending(msg.sessionID, "")
 		h.noteRemoteActionSettled(msg.remoteName)
+		if session.IsRemoteInterrupted(msg.err) {
+			return h, h.remoteOutcomeUnknown(msg.remoteName)
+		}
 		if msg.err != nil {
 			h.setError(fmt.Errorf("failed to %s '%s' on %s: %w", verb, msg.title, msg.remoteName, msg.err))
 			return h, nil
@@ -7678,6 +7777,9 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		delete(h.resumingSessions, remoteRestartAnimationID(msg.remoteName, msg.sessionID))
 		h.setRemotePending(msg.sessionID, "")
 		h.noteRemoteActionSettled(msg.remoteName)
+		if session.IsRemoteInterrupted(msg.err) {
+			return h, h.remoteOutcomeUnknown(msg.remoteName)
+		}
 		if msg.err != nil {
 			h.setError(fmt.Errorf("failed to restart '%s' on %s: %w", msg.title, msg.remoteName, msg.err))
 			return h, nil
@@ -7691,6 +7793,9 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		delete(h.forkingSessions, remoteRestartAnimationID(msg.remoteName, msg.sessionID))
 		h.setRemotePending(msg.sessionID, "")
 		h.noteRemoteActionSettled(msg.remoteName)
+		if session.IsRemoteInterrupted(msg.err) {
+			return h, h.remoteOutcomeUnknown(msg.remoteName)
+		}
 		if msg.err != nil {
 			h.setError(fmt.Errorf("failed to fork '%s' on %s: %w", msg.title, msg.remoteName, msg.err))
 			return h, nil
@@ -7772,6 +7877,12 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 	case remoteRenameResultMsg:
+		if session.IsRemoteInterrupted(msg.err) {
+			// Reverting is safe: the fetch brings the title the remote
+			// actually has.
+			h.setRemoteSessionTitle(msg.remoteName, msg.sessionID, msg.oldTitle)
+			return h, h.remoteOutcomeUnknown(msg.remoteName)
+		}
 		if msg.err != nil {
 			h.setRemoteSessionTitle(msg.remoteName, msg.sessionID, msg.oldTitle)
 			h.setError(fmt.Errorf("failed to rename '%s' on %s: %v", msg.oldTitle, msg.remoteName, msg.err))
@@ -7781,6 +7892,9 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 	case remoteMoveResultMsg:
+		if session.IsRemoteInterrupted(msg.err) {
+			return h, h.remoteOutcomeUnknown(msg.remoteName)
+		}
 		if msg.err != nil {
 			h.setError(msg.err)
 			return h, nil
@@ -7805,6 +7919,9 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 	case remoteGroupResultMsg:
+		if session.IsRemoteInterrupted(msg.err) {
+			return h, h.remoteOutcomeUnknown(msg.remoteName)
+		}
 		if msg.err != nil {
 			h.setError(msg.err)
 			return h, nil
@@ -7837,6 +7954,9 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 	case remoteGroupDeleteResultMsg:
+		if session.IsRemoteInterrupted(msg.err) {
+			return h, h.remoteOutcomeUnknown(msg.remoteName)
+		}
 		if msg.err != nil {
 			h.setError(msg.err)
 			return h, nil
@@ -7859,6 +7979,9 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return h, h.fetchRemoteSessions
 
 	case remoteGroupReorderResultMsg:
+		if session.IsRemoteInterrupted(msg.err) {
+			return h, h.remoteOutcomeUnknown(msg.remoteName)
+		}
 		if msg.err != nil {
 			h.setError(msg.err)
 			return h, nil
@@ -12178,8 +12301,9 @@ func (h *Home) performFinalShutdown(shutdownPool bool) tea.Cmd {
 		// The remote snapshot is written on a 30 s debounce; quit writes
 		// whatever is pending so the next start renders the fleet as last seen.
 		h.flushRemoteSessionsCache(true)
-		// TODO(channel owner): call session.CloseRemoteChannels() here once
-		// it exists, so no ssh child or remote agent outlives the TUI.
+		// End every remote agent now rather than leaving it to sshd's
+		// keepalive: no ssh child outlives the TUI.
+		session.CloseRemoteChannels()
 		// Save both instances AND groups on quit (critical fix: was losing groups!)
 		h.saveInstances()
 
@@ -16283,7 +16407,7 @@ func (h *Home) reorderRemoteGroup(item session.Item, delta int) tea.Cmd {
 		moved, err := runner.ReorderGroup(ctx, groupPath, delta)
 		if err != nil {
 			return remoteGroupReorderResultMsg{remoteName: remoteName, groupPath: groupPath, delta: delta,
-				err: fmt.Errorf("failed to move '%s' %s on %s: %v", groupPath, direction, remoteName, err)}
+				err: fmt.Errorf("failed to move '%s' %s on %s: %w", groupPath, direction, remoteName, err)}
 		}
 		return remoteGroupReorderResultMsg{remoteName: remoteName, groupPath: groupPath, delta: delta, moved: moved}
 	}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -12178,6 +12178,8 @@ func (h *Home) performFinalShutdown(shutdownPool bool) tea.Cmd {
 		// The remote snapshot is written on a 30 s debounce; quit writes
 		// whatever is pending so the next start renders the fleet as last seen.
 		h.flushRemoteSessionsCache(true)
+		// TODO(channel owner): call session.CloseRemoteChannels() here once
+		// it exists, so no ssh child or remote agent outlives the TUI.
 		// Save both instances AND groups on quit (critical fix: was losing groups!)
 		h.saveInstances()
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -662,6 +662,29 @@ type Home struct {
 	// fast host must not make a slower host's still-valid answer look stale.
 	remoteFetchSeq     uint64
 	remoteFetchApplied map[string]uint64 // remoteName -> last applied generation
+	// remoteGroupsGen records which generation each remote's held group
+	// list came from. A poll result superseded by a push still carries the
+	// remote's cost summary and group list, which the push may not have;
+	// costs always apply, and the group list applies unless a newer message
+	// already brought one.
+	remoteGroupsGen map[string]uint64
+	// remoteActionSettled is when each remote last confirmed a user action
+	// (delete, close, archive, restart, fork) and remoteActionRemoved lists
+	// the sessions those actions removed and when. For a short grace after
+	// a confirmation a push from that remote is treated as suspect: the
+	// agent's probe may have listed before the action ran, and applying it
+	// would resurrect the row the user just watched disappear (finding 10).
+	remoteActionSettled map[string]time.Time
+	remoteActionRemoved map[string]map[string]remoteActionRecord
+	// remoteHeaderCounts holds the session and status counts of every remote
+	// header row, keyed by Item.Path and rebuilt with the rows, so a frame
+	// does not rescan every remote session for every visible header.
+	remoteHeaderCounts map[string]remoteHeaderCount
+	// Remote snapshot save debounce (see flushRemoteSessionsCache). Guarded
+	// by remoteSessionsMu.
+	remoteCacheDirty    bool
+	remoteCacheLastSave time.Time
+	remoteCacheLastHash uint64
 	// newRemoteFetchRunner builds the runner one per-remote fetch talks to.
 	// nil means a real SSHRunner; tests inject stubs to prove delivery
 	// timing without ssh.
@@ -2477,6 +2500,7 @@ func (h *Home) dropRemoteSession(remoteName, sessionID string) {
 		h.remoteSessions[remoteName] = kept
 	}
 	h.remoteSessionsMu.Unlock()
+	h.noteRemoteSessionRemoved(remoteName, sessionID)
 	h.cachedStatusCounts.valid.Store(false)
 	h.rebuildFlatItems()
 }
@@ -3199,9 +3223,15 @@ func (h *Home) rebuildFlatItemsAt(now time.Time) {
 		h.flatItems = expanded
 	}
 
+	// Header counts are taken once here from the same in-view slices the
+	// renderer used to rescan per header per frame (finding 11).
+	h.remoteHeaderCounts = make(map[string]remoteHeaderCount)
 	if len(remotes) > 0 {
 		for _, remoteName := range remoteNames {
 			sessions := remotes[remoteName]
+			for path, counts := range remoteHeaderCounts(remoteName, sessions) {
+				h.remoteHeaderCounts[path] = counts
+			}
 			if h.timeFilter != session.TimeFilterAll {
 				filtered := make([]session.RemoteSessionInfo, 0, len(sessions))
 				for _, remote := range sessions {
@@ -3223,7 +3253,17 @@ func (h *Home) rebuildFlatItemsAt(now time.Time) {
 			// active view, empty remote groups get a header row too, like an
 			// empty local group; any filter or the archived view hides them.
 			showEmptyGroups := !viewArchived && h.timeFilter == session.TimeFilterAll && h.statusFilter == ""
-			h.flatItems = append(h.flatItems, buildRemoteFlatItemsWithEmptyGroups(remoteName, sessions, h.remoteGroupsCollapsed, h.remoteSessionOrder.forRemote(remoteName), remoteGroupLists[remoteName], showEmptyGroups)...)
+			rows := buildRemoteFlatItemsWithEmptyGroups(remoteName, sessions, h.remoteGroupsCollapsed, h.remoteSessionOrder.forRemote(remoteName), remoteGroupLists[remoteName], showEmptyGroups)
+			for _, row := range rows {
+				// An empty group's header has no session to count; give it
+				// a zero entry so the renderer never falls back to a scan.
+				if row.Type == session.ItemTypeRemoteGroup {
+					if _, ok := h.remoteHeaderCounts[row.Path]; !ok {
+						h.remoteHeaderCounts[row.Path] = remoteHeaderCount{}
+					}
+				}
+			}
+			h.flatItems = append(h.flatItems, rows...)
 		}
 	}
 
@@ -3898,13 +3938,31 @@ func (h *Home) propagateThemeToSessions() {
 func (h *Home) applyRemoteFetch(msg remoteSessionsFetchedMsg) (tea.Model, tea.Cmd) {
 	if msg.configErr != nil || h.remoteFetchIsStale(msg) {
 		// Config unreadable, or a fetch that started before one already
-		// applied for the same remote: keep the current tree. Only account
-		// for the landed fetch so the round can finish and the next poll
-		// runs.
+		// applied for the same remote: keep the current rows. Account for
+		// the landed fetch so the round can finish, and advance the poll
+		// clock for a poll result, or the next tick would start another
+		// round at once and a remote whose pushes keep outrunning the poll
+		// would be listed every two seconds for nothing (finding 1).
 		h.remoteSessionsMu.Lock()
 		h.remoteFetchLanded(msg)
+		if !msg.pushed {
+			h.lastRemoteFetch = time.Now()
+		}
+		// A superseded poll result still carries what the push did not:
+		// the cost summary always, the group list when nothing newer
+		// brought one. Without this a remote whose pushes always beat the
+		// poll never shows a cost figure.
+		staleGroups := make(map[string][]string, len(msg.groups))
+		for name, paths := range msg.groups {
+			if msg.gen >= h.remoteGroupsGen[name] {
+				staleGroups[name] = paths
+			}
+		}
+		h.applyRemoteGroupLists(msg.gen, staleGroups, nil, false)
 		h.remoteSessionsMu.Unlock()
-		if msg.configErr != nil {
+		if msg.configErr == nil {
+			h.applyRemoteCosts(msg)
+		} else {
 			h.setError(fmt.Errorf("remote refresh skipped, config could not be read: %v", msg.configErr))
 		}
 		return h, nil
@@ -3929,42 +3987,22 @@ func (h *Home) applyRemoteFetch(msg remoteSessionsFetchedMsg) (tea.Model, tea.Cm
 			}
 		}
 	}
-	// Remote group lists: replace wholesale for remotes that reported a
-	// fresh list; failed remotes keep their last-good cached paths so the
-	// move dialog doesn't lose empty-group targets on a transient SSH
-	// hiccup. Remotes absent from BOTH lists are dropped (deconfigured).
-	if h.remoteGroups == nil {
-		h.remoteGroups = make(map[string][]string)
-	}
-	keepGroups := make(map[string]bool, len(msg.groups)+len(msg.groupsFailed))
-	for name, paths := range msg.groups {
-		h.remoteGroups[name] = paths
-		keepGroups[name] = true
-	}
-	for name := range msg.groupsFailed {
-		keepGroups[name] = true
-	}
-	for name := range h.remoteGroups {
-		if !keepGroups[name] {
-			delete(h.remoteGroups, name)
-		}
-	}
+	h.applyRemoteGroupLists(msg.gen, msg.groups, msg.groupsFailed, true)
 	for name := range msg.sessions {
 		if !msg.failed[name] {
 			delete(h.remoteFromCache, name)
 		}
 	}
-	h.lastRemoteFetch = time.Now()
+	// Only a poll advances the poll clock: a push says nothing about the
+	// other remotes, and a chatty remote must not keep the fleet poll from
+	// ever running for the quiet ones (finding 1).
+	if !msg.pushed {
+		h.lastRemoteFetch = time.Now()
+	}
 	roundDone := h.remoteFetchLanded(msg)
 	h.remoteSessionsMu.Unlock()
 	h.saveRemoteSessionsCache(msg.sessions)
-	// #1101: store remote cost summaries so renderCostLine can fold them
-	// into the displayed totals on the next paint.
-	if msg.costs != nil {
-		h.remoteCostsMu.Lock()
-		h.remoteCosts = mergeRemoteCosts(h.remoteCosts, msg)
-		h.remoteCostsMu.Unlock()
-	}
+	h.applyRemoteCosts(msg)
 	// #1112 bug 1: a remote running→waiting transition wouldn't update
 	// the header pill ("[◐ Waiting N]") because countSessionStatuses
 	// caches for 500ms. The row icon updated (read from the map
@@ -4001,6 +4039,47 @@ func (h *Home) remoteFetchIsStale(msg remoteSessionsFetchedMsg) bool {
 		}
 	}
 	return false
+}
+
+// applyRemoteGroupLists stores the group lists a message brought. Remotes
+// with a fresh list are replaced wholesale; failed remotes keep their
+// last-good cached paths so the move dialog doesn't lose empty-group targets
+// on a transient SSH hiccup. With prune set, remotes absent from BOTH lists
+// are dropped (deconfigured); a superseded result passes false because it
+// knows nothing about who is still configured. Called with remoteSessionsMu
+// held.
+func (h *Home) applyRemoteGroupLists(gen uint64, groups map[string][]string, groupsFailed map[string]bool, prune bool) {
+	if h.remoteGroups == nil {
+		h.remoteGroups = make(map[string][]string)
+	}
+	if h.remoteGroupsGen == nil {
+		h.remoteGroupsGen = make(map[string]uint64)
+	}
+	for name, paths := range groups {
+		h.remoteGroups[name] = paths
+		h.remoteGroupsGen[name] = gen
+	}
+	if !prune {
+		return
+	}
+	for name := range h.remoteGroups {
+		if _, fresh := groups[name]; fresh || groupsFailed[name] {
+			continue
+		}
+		delete(h.remoteGroups, name)
+		delete(h.remoteGroupsGen, name)
+	}
+}
+
+// applyRemoteCosts folds a message's cost summaries into the per-remote map
+// (#1101) so renderCostLine can show them on the next paint.
+func (h *Home) applyRemoteCosts(msg remoteSessionsFetchedMsg) {
+	if msg.costs == nil {
+		return
+	}
+	h.remoteCostsMu.Lock()
+	h.remoteCosts = mergeRemoteCosts(h.remoteCosts, msg)
+	h.remoteCostsMu.Unlock()
 }
 
 // remoteFetchLanded accounts for one fetch result and reports whether that
@@ -4079,6 +4158,13 @@ func (h *Home) pushedRemoteFetch(ch session.RemoteChange) remoteSessionsFetchedM
 	} else {
 		msg.groupsFailed[ch.Remote] = true
 	}
+	// Every other remote the TUI knows is marked failed: the ones with rows,
+	// and the ones known only by a group list or a cost figure (a remote
+	// with zero sessions still has a host header and folders to keep,
+	// finding 12). A remote the config lists but nothing has fetched yet
+	// has nothing to lose.
+	// TODO(#2181 follow-up): once session.ReconcileRemoteChannels(config)
+	// exists, take the configured names from it here instead.
 	h.remoteSessionsMu.RLock()
 	for name := range h.remoteSessions {
 		if name != ch.Remote {
@@ -4086,8 +4172,128 @@ func (h *Home) pushedRemoteFetch(ch session.RemoteChange) remoteSessionsFetchedM
 			msg.groupsFailed[name] = true
 		}
 	}
+	for name := range h.remoteGroups {
+		if name != ch.Remote {
+			msg.failed[name] = true
+			msg.groupsFailed[name] = true
+		}
+	}
 	h.remoteSessionsMu.RUnlock()
+	h.remoteCostsMu.RLock()
+	for name := range h.remoteCosts {
+		if name != ch.Remote {
+			msg.failed[name] = true
+			msg.groupsFailed[name] = true
+		}
+	}
+	h.remoteCostsMu.RUnlock()
 	return msg
+}
+
+// remoteActionGrace is how long after a remote confirms a user action its
+// pushes are checked against the sessions that action removed. The agent's
+// probe lists the state DB on a timer, so a listing snapshotted just before
+// the action ran can arrive just after its confirmation.
+const remoteActionGrace = 3 * time.Second
+
+// noteRemoteActionSettled records that remote just confirmed a user action.
+func (h *Home) noteRemoteActionSettled(remoteName string) {
+	if h.remoteActionSettled == nil {
+		h.remoteActionSettled = make(map[string]time.Time)
+	}
+	h.remoteActionSettled[remoteName] = time.Now()
+}
+
+// remoteActionRecord is what a confirmed action did to one session: took
+// it off the remote's rows (delete), or moved it between the active and the
+// archived view (archive, unarchive: archived says which way).
+type remoteActionRecord struct {
+	at       time.Time
+	archived *bool
+}
+
+// contradicts reports whether a pushed listing still shows the session as
+// it was before the action: a removed session listed at all, an archived
+// one listed active or the reverse.
+func (r remoteActionRecord) contradicts(s *session.RemoteSessionInfo) bool {
+	return r.archived == nil || s.Archived != *r.archived
+}
+
+// noteRemoteSessionRemoved records that a confirmed action removed sessionID
+// from remoteName's rows, so a push still listing it is known to be stale.
+func (h *Home) noteRemoteSessionRemoved(remoteName, sessionID string) {
+	h.noteRemoteAction(remoteName, sessionID, remoteActionRecord{at: time.Now()})
+}
+
+// noteRemoteSessionArchived records that a confirmed action archived (or
+// unarchived) sessionID, so a push still listing it the old way is stale.
+func (h *Home) noteRemoteSessionArchived(remoteName, sessionID string, archived bool) {
+	h.noteRemoteAction(remoteName, sessionID, remoteActionRecord{at: time.Now(), archived: &archived})
+}
+
+func (h *Home) noteRemoteAction(remoteName, sessionID string, rec remoteActionRecord) {
+	if h.remoteActionRemoved == nil {
+		h.remoteActionRemoved = make(map[string]map[string]remoteActionRecord)
+	}
+	if h.remoteActionRemoved[remoteName] == nil {
+		h.remoteActionRemoved[remoteName] = make(map[string]remoteActionRecord)
+	}
+	h.remoteActionRemoved[remoteName][sessionID] = rec
+}
+
+// remoteActionInProgress reports whether a user action on remoteName is
+// still waiting for the remote's answer.
+func (h *Home) remoteActionInProgress(remoteName string) bool {
+	if len(h.remotePending) == 0 {
+		return false
+	}
+	h.remoteSessionsMu.RLock()
+	defer h.remoteSessionsMu.RUnlock()
+	for _, s := range h.remoteSessions[remoteName] {
+		if _, pending := h.remotePending[s.ID]; pending {
+			return true
+		}
+	}
+	return false
+}
+
+// stalePushedChange reports whether a pushed listing for ch.Remote predates
+// a user action and must not be applied (finding 10). While an action on
+// that remote is in flight, or within remoteActionGrace of its confirmation,
+// a listing that still contains a session the action removed, or shows one
+// it archived as active (or the reverse), is stale: the probe read the DB
+// before the action ran. Outside that window, or when the listing agrees
+// with the action, the push applies as usual. Entries older than the grace
+// are dropped as they are met.
+//
+// TODO(channel owner): when RemoteChange carries the DB stamp the listing was
+// taken at, compare stamps here instead of session membership.
+func (h *Home) stalePushedChange(ch session.RemoteChange, now time.Time) bool {
+	removed := h.remoteActionRemoved[ch.Remote]
+	if len(removed) == 0 {
+		return false
+	}
+	inGrace := h.remoteActionInProgress(ch.Remote) || now.Sub(h.remoteActionSettled[ch.Remote]) < remoteActionGrace
+	stale := false
+	for id, rec := range removed {
+		if now.Sub(rec.at) >= remoteActionGrace {
+			delete(removed, id)
+			continue
+		}
+		if !inGrace {
+			continue
+		}
+		for i := range ch.Sessions {
+			if ch.Sessions[i].ID == id && rec.contradicts(&ch.Sessions[i]) {
+				stale = true
+				break
+			}
+		}
+	}
+	if len(removed) == 0 {
+		delete(h.remoteActionRemoved, ch.Remote)
+	}
+	return stale
 }
 
 // fetchRemoteSessions starts a fleet poll. It reads the config, sweeps stale
@@ -4226,7 +4432,10 @@ func (h *Home) fetchOneRemote(gen uint64, name string, rc session.RemoteConfig, 
 //   - remotes present in fetched → replaced wholesale (new sessions appear,
 //     removed sessions drop);
 //   - remotes in failed (errored this round) → keep their last-good sessions
-//     from prev, so a transient SSH hiccup never wipes a remote;
+//     from prev, so a transient SSH hiccup never wipes a remote; a remote
+//     known with ZERO sessions (fresh, or fully archived) is kept too, so its
+//     host header and folders survive a result that did not cover it
+//     (finding 12);
 //   - remotes absent from both fetched and failed → dropped (deconfigured).
 //
 // It is a pure function so the reconciliation logic is unit-testable without
@@ -4241,7 +4450,7 @@ func mergeRemoteSessions(prev, fetched map[string][]session.RemoteSessionInfo, f
 			// A successful result for this remote (if any) always wins.
 			continue
 		}
-		if prevSess, ok := prev[name]; ok && len(prevSess) > 0 {
+		if prevSess, ok := prev[name]; ok {
 			merged[name] = prevSess
 		}
 	}
@@ -7371,11 +7580,17 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return h, h.waitRemoteChange
 		}
-		if msg.change.HasData {
+		if msg.change.HasData && !h.stalePushedChange(msg.change, time.Now()) {
 			// The event brought the listings: apply them now, no round trip.
 			uiLog.Debug("remote_changed", slog.String("remote", msg.remoteName), slog.Bool("pushed_data", true))
 			_, cmd := h.applyRemoteFetch(h.pushedRemoteFetch(msg.change))
 			return h, tea.Batch(cmd, h.waitRemoteChange)
+		}
+		if msg.change.HasData {
+			// The listing predates an action the user just completed on
+			// this remote: applying it would bring the removed row back.
+			// Drop it and let a fetch settle the truth instead.
+			uiLog.Debug("remote_changed", slog.String("remote", msg.remoteName), slog.Bool("stale_push_dropped", true))
 		}
 		// A pushed change without data: refetch at once unless a fetch is
 		// already in flight (then one more runs after it).
@@ -7417,6 +7632,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case remoteSessionDeletedMsg:
 		h.setRemotePending(msg.sessionID, "")
+		h.noteRemoteActionSettled(msg.remoteName)
 		if msg.err != nil {
 			h.setError(fmt.Errorf("failed to delete '%s' on %s: %w", msg.title, msg.remoteName, msg.err))
 			return h, nil
@@ -7427,6 +7643,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case remoteSessionClosedMsg:
 		h.setRemotePending(msg.sessionID, "")
+		h.noteRemoteActionSettled(msg.remoteName)
 		if msg.err != nil {
 			h.setError(fmt.Errorf("failed to close '%s' on %s: %w", msg.title, msg.remoteName, msg.err))
 			return h, nil
@@ -7440,6 +7657,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			verb = "unarchive"
 		}
 		h.setRemotePending(msg.sessionID, "")
+		h.noteRemoteActionSettled(msg.remoteName)
 		if msg.err != nil {
 			h.setError(fmt.Errorf("failed to %s '%s' on %s: %w", verb, msg.title, msg.remoteName, msg.err))
 			return h, nil
@@ -7451,6 +7669,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 				s.Status = string(session.StatusStopped)
 			}
 		})
+		h.noteRemoteSessionArchived(msg.remoteName, msg.sessionID, archived)
 		h.setError(fmt.Errorf("%sd '%s' on %s%s", verb, msg.title, msg.remoteName, h.remoteActionTook(msg.remoteName, "archive", msg.sessionID)))
 		return h, h.fetchRemoteSessions
 
@@ -7458,6 +7677,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		delete(h.remoteRestarting, remoteRestartAnimationID(msg.remoteName, msg.sessionID))
 		delete(h.resumingSessions, remoteRestartAnimationID(msg.remoteName, msg.sessionID))
 		h.setRemotePending(msg.sessionID, "")
+		h.noteRemoteActionSettled(msg.remoteName)
 		if msg.err != nil {
 			h.setError(fmt.Errorf("failed to restart '%s' on %s: %w", msg.title, msg.remoteName, msg.err))
 			return h, nil
@@ -7470,6 +7690,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		delete(h.remoteForking, remoteRestartAnimationID(msg.remoteName, msg.sessionID))
 		delete(h.forkingSessions, remoteRestartAnimationID(msg.remoteName, msg.sessionID))
 		h.setRemotePending(msg.sessionID, "")
+		h.noteRemoteActionSettled(msg.remoteName)
 		if msg.err != nil {
 			h.setError(fmt.Errorf("failed to fork '%s' on %s: %w", msg.title, msg.remoteName, msg.err))
 			return h, nil
@@ -8406,6 +8627,9 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			h.uiStateSaveTicks = 0
 			h.saveUIState()
 		}
+		// A remote snapshot held back by the save debounce lands here once
+		// its interval has passed.
+		h.flushRemoteSessionsCache(false)
 
 		// Periodic remote session fetch (issue #1170). Cadence is configurable
 		// via [ui] remote_session_refresh_secs (default 15s); see
@@ -11951,6 +12175,9 @@ func (h *Home) performFinalShutdown(shutdownPool bool) tea.Cmd {
 		h.cleanupNotifications()
 		// Save UI state (cursor, preview mode, filter) before saving instances
 		h.saveUIState()
+		// The remote snapshot is written on a 30 s debounce; quit writes
+		// whatever is pending so the next start renders the fleet as last seen.
+		h.flushRemoteSessionsCache(true)
 		// Save both instances AND groups on quit (critical fix: was losing groups!)
 		h.saveInstances()
 
@@ -19501,12 +19728,8 @@ func (h *Home) renderRemoteGroupItem(b *strings.Builder, item session.Item, sele
 	// Render the last path segment with a subtree count, indented by level, and
 	// no host-latency marker (latency is a host-level metric shown on Level 0).
 	if item.Level > 0 {
-		h.remoteSessionsMu.RLock()
-		sessions := h.remoteSessionsInView(item.RemoteName)
 		groupPath := strings.TrimPrefix(item.Path, "remotes/"+item.RemoteName+"/")
-		count := remoteSubGroupCount(sessions, groupPath)
-		running, waiting := remoteStatusCounts(sessions, groupPath)
-		h.remoteSessionsMu.RUnlock()
+		counts := h.remoteHeaderCount(item)
 
 		segName := groupPath
 		if idx := strings.LastIndex(groupPath, "/"); idx >= 0 {
@@ -19518,17 +19741,15 @@ func (h *Home) renderRemoteGroupItem(b *strings.Builder, item session.Item, sele
 			strings.Repeat("  ", item.Level), // nest under the remote header
 			expandIcon,
 			nameStyle.Render(segName),
-			countStyle.Render(fmt.Sprintf(" (%d)", count)),
-			remoteStatusSuffix(running, waiting),
+			countStyle.Render(fmt.Sprintf(" (%d)", counts.total)),
+			remoteStatusSuffix(counts.running, counts.waiting),
 		))
 		return
 	}
 
 	// Level 0: the remote host header. Count the sessions this view shows.
+	counts := h.remoteHeaderCount(item)
 	h.remoteSessionsMu.RLock()
-	sessions := h.remoteSessionsInView(item.RemoteName)
-	count := len(sessions)
-	running, waiting := remoteStatusCounts(sessions, "")
 	fromCache := h.remoteFromCache[item.RemoteName]
 	fetching := h.remotesFetchActive
 	h.remoteSessionsMu.RUnlock()
@@ -19547,10 +19768,33 @@ func (h *Home) renderRemoteGroupItem(b *strings.Builder, item session.Item, sele
 		remoteRowGutter(selected), // align with group hotkey gutter (flush with local root groups)
 		expandIcon,
 		nameStyle.Render("remotes/"+item.RemoteName),
-		countStyle.Render(fmt.Sprintf(" (%d)", count)),
-		remoteStatusSuffix(running, waiting),
+		countStyle.Render(fmt.Sprintf(" (%d)", counts.total)),
+		remoteStatusSuffix(counts.running, counts.waiting),
 		trailer,
 	))
+}
+
+// remoteHeaderCount returns the counts for a remote header row: the ones
+// rebuildFlatItems computed with the rows when it has them, otherwise (rows
+// built by hand, as tests do) the same numbers scanned from the in-view
+// sessions the way the renderer always did.
+func (h *Home) remoteHeaderCount(item session.Item) remoteHeaderCount {
+	if counts, ok := h.remoteHeaderCounts[item.Path]; ok {
+		return counts
+	}
+	h.remoteSessionsMu.RLock()
+	defer h.remoteSessionsMu.RUnlock()
+	sessions := h.remoteSessionsInView(item.RemoteName)
+	groupPath := ""
+	if item.Level > 0 {
+		groupPath = strings.TrimPrefix(item.Path, "remotes/"+item.RemoteName+"/")
+	}
+	counts := remoteHeaderCount{total: len(sessions)}
+	if groupPath != "" {
+		counts.total = remoteSubGroupCount(sessions, groupPath)
+	}
+	counts.running, counts.waiting = remoteStatusCounts(sessions, groupPath)
+	return counts
 }
 
 // remoteStatusSuffix renders the same running/waiting glyph counts local

--- a/internal/ui/remote_cache.go
+++ b/internal/ui/remote_cache.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"encoding/json"
+	"hash/fnv"
 	"log/slog"
 	"time"
 
@@ -41,12 +42,52 @@ type remoteSessionsCache struct {
 	FetchedAt map[string]time.Time `json:"fetched_at,omitempty"`
 }
 
-// saveRemoteSessionsCache persists the current remote session map. Called from
-// the fetch-completion path; a dropped save is recoverable on the next fetch.
-// liveFetched names the remotes whose data came from a successful fetch THIS
-// cycle — only their freshness stamps advance. Failed or merely-carried-over
-// remotes keep their previous stamp so stale data still ages out.
+// remoteSessionsCacheSaveInterval is the shortest gap between two writes of
+// the snapshot. A pushing remote can deliver several listings a second and
+// each used to JSON-encode the whole fleet and rewrite it into state.db on
+// the UI goroutine; the on-disk copy only has to be right at the next start.
+const remoteSessionsCacheSaveInterval = 30 * time.Second
+
+// remoteSessionsCacheRefreshAge bounds how long an unchanged fleet goes
+// without a rewrite, so the on-disk stamps keep ahead of the load-time
+// expiry (remoteSessionsCacheMaxAge) on a quiet fleet.
+const remoteSessionsCacheRefreshAge = time.Hour
+
+// remoteSessionsCacheDoc is the snapshot as written: the sessions are
+// encoded once and hashed, so an unchanged fleet is not rewritten.
+type remoteSessionsCacheDoc struct {
+	SavedAt   time.Time            `json:"saved_at"`
+	Sessions  json.RawMessage      `json:"sessions"`
+	FetchedAt map[string]time.Time `json:"fetched_at,omitempty"`
+}
+
+// saveRemoteSessionsCache records that the remote session map changed and
+// writes it when the debounce allows (see flushRemoteSessionsCache; a dropped
+// save is recoverable on the next fetch). liveFetched names the remotes whose
+// data came from a successful fetch THIS cycle — only their freshness stamps
+// advance. Failed or merely-carried-over remotes keep their previous stamp so
+// stale data still ages out.
 func (h *Home) saveRemoteSessionsCache(liveFetched map[string][]session.RemoteSessionInfo) {
+	if !remoteSessionsCacheEnabled || h.storage == nil {
+		return
+	}
+	h.remoteSessionsMu.Lock()
+	if h.remoteFetchedAt == nil {
+		h.remoteFetchedAt = make(map[string]time.Time)
+	}
+	for name := range liveFetched {
+		h.remoteFetchedAt[name] = time.Now()
+	}
+	h.remoteCacheDirty = true
+	h.remoteSessionsMu.Unlock()
+	h.flushRemoteSessionsCache(false)
+}
+
+// flushRemoteSessionsCache writes the pending snapshot if there is one and
+// the last write is at least remoteSessionsCacheSaveInterval old (force skips
+// the wait: quit). The sessions are hashed so a fleet that has not changed
+// since the last write is not rewritten until remoteSessionsCacheRefreshAge.
+func (h *Home) flushRemoteSessionsCache(force bool) {
 	if !remoteSessionsCacheEnabled || h.storage == nil {
 		return
 	}
@@ -54,20 +95,36 @@ func (h *Home) saveRemoteSessionsCache(liveFetched map[string][]session.RemoteSe
 	if db == nil {
 		return
 	}
-	h.remoteSessionsMu.RLock()
-	if h.remoteFetchedAt == nil {
-		h.remoteFetchedAt = make(map[string]time.Time)
+	now := time.Now()
+	h.remoteSessionsMu.Lock()
+	if !h.remoteCacheDirty || (!force && now.Sub(h.remoteCacheLastSave) < remoteSessionsCacheSaveInterval) {
+		h.remoteSessionsMu.Unlock()
+		return
 	}
-	for name := range liveFetched {
-		h.remoteFetchedAt[name] = time.Now()
+	sessions, err := json.Marshal(h.remoteSessions)
+	if err != nil {
+		h.remoteSessionsMu.Unlock()
+		uiLog.Warn("save_remote_cache_marshal_failed", slog.String("error", err.Error()))
+		return
 	}
-	snap := remoteSessionsCache{
-		SavedAt:   time.Now(),
-		Sessions:  h.remoteSessions,
+	hash := fnv.New64a()
+	_, _ = hash.Write(sessions)
+	sum := hash.Sum64()
+	h.remoteCacheDirty = false
+	unchanged := sum == h.remoteCacheLastHash && now.Sub(h.remoteCacheLastSave) < remoteSessionsCacheRefreshAge
+	if unchanged {
+		h.remoteSessionsMu.Unlock()
+		return
+	}
+	h.remoteCacheLastSave = now
+	h.remoteCacheLastHash = sum
+	doc := remoteSessionsCacheDoc{
+		SavedAt:   now,
+		Sessions:  sessions,
 		FetchedAt: h.remoteFetchedAt,
 	}
-	data, err := json.Marshal(snap)
-	h.remoteSessionsMu.RUnlock()
+	data, err := json.Marshal(doc)
+	h.remoteSessionsMu.Unlock()
 	if err != nil {
 		uiLog.Warn("save_remote_cache_marshal_failed", slog.String("error", err.Error()))
 		return

--- a/internal/ui/remote_scale_hardening_test.go
+++ b/internal/ui/remote_scale_hardening_test.go
@@ -8,10 +8,13 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/asheshgoplani/agent-deck/internal/costs"
 	"github.com/asheshgoplani/agent-deck/internal/session"
@@ -444,5 +447,145 @@ func TestRemotePush_EmptyRemoteKeepsHeaderAndGroups(t *testing.T) {
 	}
 	if !header || !inbox {
 		t.Fatalf("the empty remote's host header and its folder must still render; header=%v inbox=%v", header, inbox)
+	}
+}
+
+// Finding 10, stamped: when the listing says which DB state it was taken
+// from and the channel knows the stamp of the last mutating command, the
+// stamps decide, membership does not. A listing newer than the delete that
+// still contains the id (recreated with the same id) applies; an older
+// listing without the id is still stale.
+func TestRemotePush_StampDecidesOverMembership(t *testing.T) {
+	home := newTestHomeWithItems(100, 30, nil)
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"box": {remoteInfo("box", "s1", "doomed", "running"), remoteInfo("box", "s2", "kept", "running")},
+	}
+	var last int64
+	home.remoteMutationStamp = func(string) int64 { return last }
+	model, _ := home.Update(remoteSessionDeletedMsg{remoteName: "box", sessionID: "s1", title: "doomed"})
+	h := model.(*Home)
+
+	// The channel does not know a stamp yet: membership decides, as before.
+	model, _ = h.Update(pushWithData("box", []session.RemoteSessionInfo{{ID: "s1", Title: "doomed"}, {ID: "s2", Title: "kept"}}, nil))
+	h = model.(*Home)
+	if got := remoteTitles(h, "box"); len(got) != 1 || got[0] != "kept" {
+		t.Fatalf("without stamps membership gates the push; got %v", got)
+	}
+
+	last = 1000
+	older := pushWithData("box", []session.RemoteSessionInfo{{ID: "s2", Title: "older"}}, nil)
+	older.change.Stamp = 900
+	model, _ = h.Update(older)
+	h = model.(*Home)
+	if got := remoteTitles(h, "box"); len(got) != 1 || got[0] != "kept" {
+		t.Fatalf("a listing stamped before the delete is stale even when it agrees; got %v", got)
+	}
+	newer := pushWithData("box", []session.RemoteSessionInfo{{ID: "s1", Title: "reborn"}, {ID: "s2", Title: "kept"}}, nil)
+	newer.change.Stamp = 1000
+	model, _ = h.Update(newer)
+	h = model.(*Home)
+	if got := remoteTitles(h, "box"); len(got) != 2 || got[0] != "reborn" {
+		t.Fatalf("a listing stamped at or after the delete is the truth, id or not; got %v", got)
+	}
+
+	// Unstamped after a stamped world: the membership gate is the fallback.
+	model, _ = h.Update(remoteSessionDeletedMsg{remoteName: "box", sessionID: "s2", title: "kept"})
+	h = model.(*Home)
+	model, _ = h.Update(pushWithData("box", []session.RemoteSessionInfo{{ID: "s1", Title: "reborn"}, {ID: "s2", Title: "kept"}}, nil))
+	h = model.(*Home)
+	if got := remoteTitles(h, "box"); len(got) != 1 || got[0] != "reborn" {
+		t.Fatalf("an unstamped push falls back to the membership gate; got %v", got)
+	}
+}
+
+// A mutating command whose reply was lost with the channel (#3) has an
+// unknown outcome: nothing is confirmed or reverted on faith (a delete
+// keeps its row, a rename goes back to the old title), the footer says what
+// happened, and a fetch is started to settle it.
+func TestRemoteAction_InterruptedOutcomeIsUnknown(t *testing.T) {
+	interrupted := fmt.Errorf("ssh wrapper: %w", session.ErrRemoteInterrupted)
+	if !session.IsRemoteInterrupted(interrupted) {
+		t.Fatal("IsRemoteInterrupted must see through wrapping")
+	}
+	home := newTestHomeWithItems(100, 30, nil)
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"box": {remoteInfo("box", "s1", "maybe-gone", "running"), remoteInfo("box", "s2", "old-name", "running")},
+	}
+	home.setRemotePending("s1", "deleting…")
+	model, cmd := home.Update(remoteSessionDeletedMsg{remoteName: "box", sessionID: "s1", title: "maybe-gone", err: interrupted})
+	h := model.(*Home)
+	if cmd == nil {
+		t.Fatal("an interrupted delete must start a fetch")
+	}
+	if got := remoteTitles(h, "box"); len(got) != 2 || got[0] != "maybe-gone" {
+		t.Fatalf("an interrupted delete must keep the row until the fetch decides; got %v", got)
+	}
+	if _, pending := h.remotePending["s1"]; pending {
+		t.Fatal("the pending marker must be cleared")
+	}
+	if h.err == nil || !strings.Contains(h.err.Error(), "on box: connection dropped before the reply, refreshing") {
+		t.Fatalf("footer = %v", h.err)
+	}
+	if _, removed := h.remoteActionRemoved["box"]["s1"]; removed {
+		t.Fatal("an unconfirmed delete must not gate pushes that still list the session")
+	}
+
+	h.setRemoteSessionTitle("box", "s2", "new-name")
+	model, cmd = h.Update(remoteRenameResultMsg{remoteName: "box", sessionID: "s2", oldTitle: "old-name", newTitle: "new-name", err: interrupted})
+	h = model.(*Home)
+	if cmd == nil {
+		t.Fatal("an interrupted rename must start a fetch")
+	}
+	if got := remoteTitles(h, "box"); got[1] != "old-name" {
+		t.Fatalf("an interrupted rename reverts to the old title; got %v", got)
+	}
+
+	for _, msg := range []tea.Msg{
+		remoteSessionClosedMsg{remoteName: "box", sessionID: "s1", err: interrupted},
+		remoteSessionArchivedMsg{remoteName: "box", sessionID: "s1", archived: true, err: interrupted},
+		remoteSessionRestartedMsg{remoteName: "box", sessionID: "s1", err: interrupted},
+		remoteSessionForkedMsg{remoteName: "box", sessionID: "s1", err: interrupted},
+		remoteMoveResultMsg{remoteName: "box", sessionID: "s1", groupPath: "g", err: interrupted},
+		remoteGroupResultMsg{remoteName: "box", groupPath: "g", err: interrupted},
+		remoteGroupDeleteResultMsg{remoteName: "box", groupPath: "g", err: interrupted},
+		remoteGroupReorderResultMsg{remoteName: "box", groupPath: "g", err: interrupted},
+	} {
+		h.clearError()
+		model, cmd = h.Update(msg)
+		h = model.(*Home)
+		if cmd == nil || h.err == nil || !strings.Contains(h.err.Error(), "connection dropped before the reply") {
+			t.Fatalf("%T: want the unknown-outcome footer and a fetch; got cmd=%v err=%v", msg, cmd != nil, h.err)
+		}
+	}
+	if got := remoteTitles(h, "box"); len(got) != 2 || h.remoteSessions["box"][0].Archived {
+		t.Fatalf("interrupted actions must not patch rows; got %v", got)
+	}
+}
+
+// Finding 8: a push from a remote the config no longer lists is dropped,
+// and a push from a configured remote keeps every other configured remote
+// as it was, even one nothing has fetched rows for yet.
+func TestRemotePush_FollowsConfiguredRemotes(t *testing.T) {
+	home := newTestHomeWithItems(100, 30, nil)
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"a": {remoteInfo("a", "s1", "a-cached", "running")},
+	}
+	home.remoteConfigured = map[string]struct{}{"a": {}, "c": {}}
+	model, _ := home.Update(pushWithData("gone", []session.RemoteSessionInfo{{ID: "g1", Title: "ghost"}}, nil))
+	h := model.(*Home)
+	if _, ok := h.remoteSessions["gone"]; ok {
+		t.Fatal("a push from a remote not in the config must not add it to the tree")
+	}
+	msg := h.pushedRemoteFetch(pushWithData("a", []session.RemoteSessionInfo{{ID: "s1", Title: "a-pushed"}}, nil).change)
+	if !msg.failed["c"] || !msg.groupsFailed["c"] {
+		t.Fatalf("configured remote c must be marked failed (kept) by a push from a; failed=%v", msg.failed)
+	}
+	if msg.failed["a"] {
+		t.Fatal("the pusher itself is fresh, not failed")
+	}
+	model, _ = h.Update(pushWithData("a", []session.RemoteSessionInfo{{ID: "s1", Title: "a-pushed"}}, nil))
+	h = model.(*Home)
+	if got := remoteTitles(h, "a"); len(got) != 1 || got[0] != "a-pushed" {
+		t.Fatalf("a push from a configured remote applies; got %v", got)
 	}
 }

--- a/internal/ui/remote_scale_hardening_test.go
+++ b/internal/ui/remote_scale_hardening_test.go
@@ -1,0 +1,448 @@
+// Scale hardening of the pushed-change path (findings 1, 10, 11 and 12 of
+// the remote scale review): a chatty pushing remote must not starve or
+// hollow out the fleet poll for the quiet ones, a stale push must not bring
+// back a row the user just removed, header counts and the on-disk snapshot
+// must not cost a full rescan or a full rewrite per push, and a remote with
+// zero sessions must keep its header and folders across foreign pushes.
+
+package ui
+
+import (
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/costs"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func pushWithData(remote string, sessions []session.RemoteSessionInfo, groups []string) remoteChangedMsg {
+	for i := range sessions {
+		sessions[i].RemoteName = remote
+	}
+	return remoteChangedMsg{remoteName: remote, change: session.RemoteChange{Remote: remote, Sessions: sessions, Groups: groups, HasData: true}}
+}
+
+// Finding 1: a remote that pushes several listings a second coexists with a
+// remote that only answers the fleet poll.
+func TestRemotePush_ChattyRemoteDoesNotStarveThePoll(t *testing.T) {
+	home := newTestHomeWithItems(100, 30, nil)
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"chatty": {remoteInfo("chatty", "c1", "chatty-cached", "running")},
+		"quiet":  {remoteInfo("quiet", "q1", "quiet-cached", "running")},
+	}
+	home.remoteCosts = map[string]*costs.RemoteCostSummary{"quiet": {CostTodayMicrodollars: 5}}
+	polledAt := time.Now().Add(-20 * time.Second)
+	home.lastRemoteFetch = polledAt
+
+	// Pushes land while the poll is due: they must not reset the poll clock
+	// or raise the in-flight guard.
+	h := home
+	for i := 0; i < 3; i++ {
+		model, _ := h.Update(pushWithData("chatty", []session.RemoteSessionInfo{{ID: "c1", Title: "chatty-push"}}, nil))
+		h = model.(*Home)
+	}
+	if !h.lastRemoteFetch.Equal(polledAt) {
+		t.Fatalf("a push must not touch lastRemoteFetch; got %v want %v", h.lastRemoteFetch, polledAt)
+	}
+	if h.remotesFetchActive {
+		t.Fatal("a push must not raise the in-flight guard")
+	}
+	if !h.shouldFetchRemoteSessions(time.Now()) {
+		t.Fatal("the fleet poll must still be due after a burst of pushes")
+	}
+
+	// The poll round starts; another push beats both of its results home.
+	round := atomic.AddUint64(&h.remoteFetchSeq, 1)
+	model, _ := h.Update(remoteFetchRoundMsg{gen: round, fetches: nil})
+	h = model.(*Home)
+	h.remoteSessionsMu.Lock()
+	h.remoteFetchOutstanding = 2
+	h.remoteSessionsMu.Unlock()
+	model, _ = h.Update(pushWithData("chatty", []session.RemoteSessionInfo{{ID: "c1", Title: "chatty-newer"}}, nil))
+	h = model.(*Home)
+
+	result := func(name, title string, other string) remoteSessionsFetchedMsg {
+		return remoteSessionsFetchedMsg{
+			gen:          round,
+			inRound:      true,
+			sessions:     map[string][]session.RemoteSessionInfo{name: {remoteInfo(name, name+"1", title, "running")}},
+			costs:        map[string]*costs.RemoteCostSummary{name: {CostTodayMicrodollars: 42}},
+			groups:       map[string][]string{name: {name + "-group"}},
+			failed:       map[string]bool{other: true},
+			groupsFailed: map[string]bool{other: true},
+		}
+	}
+	// The chatty remote's poll result is older than its push: rows stay
+	// as pushed, but the cost figure and group list the push lacked apply,
+	// and the result still counts toward the round.
+	model, _ = h.Update(result("chatty", "chatty-polled", "quiet"))
+	h = model.(*Home)
+	if got := remoteTitles(h, "chatty"); len(got) != 1 || got[0] != "chatty-newer" {
+		t.Fatalf("a poll result older than the push must not overwrite its rows; got %v", got)
+	}
+	if h.remoteCosts["chatty"] == nil || h.remoteCosts["chatty"].CostTodayMicrodollars != 42 {
+		t.Fatalf("a superseded poll result must still deliver the cost summary; got %+v", h.remoteCosts["chatty"])
+	}
+	if got := h.remoteGroups["chatty"]; len(got) != 1 || got[0] != "chatty-group" {
+		t.Fatalf("a superseded poll result must still deliver the group list the push lacked; got %v", got)
+	}
+	if !h.lastRemoteFetch.After(polledAt) {
+		t.Fatal("a discarded poll result must advance lastRemoteFetch or the next tick re-polls at once")
+	}
+	if !h.remotesFetchActive {
+		t.Fatal("the round is not over while the quiet remote is outstanding")
+	}
+	// The quiet remote's result applies in full.
+	model, _ = h.Update(result("quiet", "quiet-polled", "chatty"))
+	h = model.(*Home)
+	if got := remoteTitles(h, "quiet"); len(got) != 1 || got[0] != "quiet-polled" {
+		t.Fatalf("the quiet remote's poll result must apply; got %v", got)
+	}
+	if got := remoteTitles(h, "chatty"); len(got) != 1 || got[0] != "chatty-newer" {
+		t.Fatalf("the quiet remote's result must keep the chatty remote's pushed rows; got %v", got)
+	}
+	if h.remotesFetchActive {
+		t.Fatal("the last result of the round must release the in-flight guard even when another was discarded")
+	}
+	if h.remoteCosts["quiet"] == nil || h.remoteCosts["quiet"].CostTodayMicrodollars != 42 {
+		t.Fatalf("the quiet remote's cost summary must apply; got %+v", h.remoteCosts["quiet"])
+	}
+}
+
+// Finding 1: a push that brings its own group list is newer than a poll
+// result that started earlier, so the poll's list must not replace it.
+func TestRemotePush_StalePollDoesNotRegressPushedGroups(t *testing.T) {
+	home := newTestHomeWithItems(100, 30, nil)
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{"box": {}}
+	round := atomic.AddUint64(&home.remoteFetchSeq, 1)
+	model, _ := home.Update(pushWithData("box", []session.RemoteSessionInfo{{ID: "b1", Title: "b"}}, []string{"new-folder"}))
+	h := model.(*Home)
+	model, _ = h.Update(remoteSessionsFetchedMsg{
+		gen:      round,
+		inRound:  true,
+		sessions: map[string][]session.RemoteSessionInfo{"box": {remoteInfo("box", "b1", "b-old", "running")}},
+		groups:   map[string][]string{"box": {"old-folder"}},
+		failed:   map[string]bool{},
+	})
+	h = model.(*Home)
+	if got := h.remoteGroups["box"]; len(got) != 1 || got[0] != "new-folder" {
+		t.Fatalf("a poll's group list older than the push's must not apply; got %v", got)
+	}
+}
+
+// Finding 1: a poll that could not read the config must still advance the
+// poll clock, or every tick re-reads the broken file and re-raises the error.
+func TestRemotePoll_ConfigErrorAdvancesPollClock(t *testing.T) {
+	home := newTestHomeWithItems(100, 30, nil)
+	home.lastRemoteFetch = time.Now().Add(-time.Minute)
+	model, _ := home.Update(remoteSessionsFetchedMsg{gen: 1, configErr: errTest})
+	h := model.(*Home)
+	if h.shouldFetchRemoteSessions(time.Now()) {
+		t.Fatal("a config error must not leave the poll due on the next tick")
+	}
+}
+
+var errTest = &testError{"toml: bad key"}
+
+type testError struct{ s string }
+
+func (e *testError) Error() string { return e.s }
+
+// Finding 10: the agent's probe listed the DB before the delete ran and its
+// push lands after the delete was confirmed; the row must stay gone.
+func TestRemotePush_StaleListingAfterDeleteKeepsRowGone(t *testing.T) {
+	home := newTestHomeWithItems(100, 30, nil)
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"box": {remoteInfo("box", "s1", "doomed", "running"), remoteInfo("box", "s2", "kept", "running")},
+	}
+	home.setRemotePending("s1", "deleting…")
+	if !home.remoteActionInProgress("box") {
+		t.Fatal("a pending row must count as an action in progress for its remote")
+	}
+	model, _ := home.Update(remoteSessionDeletedMsg{remoteName: "box", sessionID: "s1", title: "doomed"})
+	h := model.(*Home)
+	if got := remoteTitles(h, "box"); len(got) != 1 || got[0] != "kept" {
+		t.Fatalf("delete confirmation must drop the row; got %v", got)
+	}
+
+	// The stale push still lists s1.
+	model, _ = h.Update(pushWithData("box", []session.RemoteSessionInfo{{ID: "s1", Title: "doomed"}, {ID: "s2", Title: "kept"}}, nil))
+	h = model.(*Home)
+	if got := remoteTitles(h, "box"); len(got) != 1 || got[0] != "kept" {
+		t.Fatalf("a push listing the session the user just deleted must not resurrect it; got %v", got)
+	}
+
+	// A push that agrees with the delete applies, new rows included.
+	model, _ = h.Update(pushWithData("box", []session.RemoteSessionInfo{{ID: "s2", Title: "kept"}, {ID: "s3", Title: "fresh"}}, nil))
+	h = model.(*Home)
+	if got := remoteTitles(h, "box"); len(got) != 2 || got[1] != "fresh" {
+		t.Fatalf("a push that does not contain the removed session must apply; got %v", got)
+	}
+
+	// After the grace the remote's listing is the truth again, even if it
+	// contains the id (a session recreated with the same id, say).
+	h.remoteActionSettled["box"] = time.Now().Add(-2 * remoteActionGrace)
+	h.remoteActionRemoved["box"]["s1"] = remoteActionRecord{at: time.Now().Add(-2 * remoteActionGrace)}
+	h.remoteActionRemoved["box"]["s3"] = remoteActionRecord{at: time.Now().Add(-2 * remoteActionGrace)}
+	model, _ = h.Update(pushWithData("box", []session.RemoteSessionInfo{{ID: "s3", Title: "back"}}, nil))
+	h = model.(*Home)
+	if got := remoteTitles(h, "box"); len(got) != 1 || got[0] != "back" {
+		t.Fatalf("outside the grace a push must apply as usual; got %v", got)
+	}
+	if _, ok := h.remoteActionRemoved["box"]; ok {
+		t.Fatal("expired removal records must be dropped")
+	}
+}
+
+// Finding 10: an archive is confirmed, then a push listing the session as
+// still active lands; the row must not pop back into the active view. A
+// push that agrees with the archive applies.
+func TestRemotePush_StaleListingAfterArchiveKeepsRowArchived(t *testing.T) {
+	home := newTestHomeWithItems(100, 30, nil)
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"box": {remoteInfo("box", "s1", "shelved", "running"), remoteInfo("box", "s2", "kept", "running")},
+	}
+	model, _ := home.Update(remoteSessionArchivedMsg{remoteName: "box", sessionID: "s1", title: "shelved", archived: true})
+	h := model.(*Home)
+	if !h.remoteSessions["box"][0].Archived {
+		t.Fatal("archive confirmation must mark the row archived")
+	}
+	model, _ = h.Update(pushWithData("box", []session.RemoteSessionInfo{{ID: "s1", Title: "shelved", Status: "running"}, {ID: "s2", Title: "kept"}}, nil))
+	h = model.(*Home)
+	if !h.remoteSessions["box"][0].Archived {
+		t.Fatal("a push listing the session the user just archived as active must not apply")
+	}
+	model, _ = h.Update(pushWithData("box", []session.RemoteSessionInfo{{ID: "s1", Title: "shelved", Archived: true}, {ID: "s2", Title: "kept-pushed"}}, nil))
+	h = model.(*Home)
+	if got := remoteTitles(h, "box"); len(got) != 2 || got[1] != "kept-pushed" {
+		t.Fatalf("a push that agrees with the archive must apply; got %v", got)
+	}
+}
+
+// Finding 10: a stale push is not dropped for unrelated remotes.
+func TestRemotePush_DeleteOnOneRemoteDoesNotGateAnother(t *testing.T) {
+	home := newTestHomeWithItems(100, 30, nil)
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"a": {remoteInfo("a", "s1", "doomed", "running")},
+		"b": {remoteInfo("b", "s1", "twin", "running")},
+	}
+	model, _ := home.Update(remoteSessionDeletedMsg{remoteName: "a", sessionID: "s1", title: "doomed"})
+	h := model.(*Home)
+	model, _ = h.Update(pushWithData("b", []session.RemoteSessionInfo{{ID: "s1", Title: "twin-pushed"}}, nil))
+	h = model.(*Home)
+	if got := remoteTitles(h, "b"); len(got) != 1 || got[0] != "twin-pushed" {
+		t.Fatalf("a delete on remote a must not gate pushes from remote b; got %v", got)
+	}
+}
+
+// Finding 11: the counts computed once with the rows equal the per-header
+// scans the renderer used to run, header by header.
+func TestRemoteHeaderCounts_MatchScanHelpers(t *testing.T) {
+	sessions := []session.RemoteSessionInfo{
+		{ID: "1", Group: "", Status: "running"},
+		{ID: "2", Group: "work", Status: "waiting"},
+		{ID: "3", Group: "work/api", Status: "running"},
+		{ID: "4", Group: "work/api", Status: "running", Archived: true},
+		{ID: "5", Group: "work/web/v2", Status: "stopped"},
+		{ID: "6", Group: "/play/", Status: "waiting"},
+	}
+	items := buildRemoteFlatItemsWithEmptyGroups("box", sessions, nil, nil, []string{"work", "idle"}, true)
+	got := remoteHeaderCounts("box", sessions)
+	headers := 0
+	for _, it := range items {
+		if it.Type != session.ItemTypeRemoteGroup {
+			continue
+		}
+		headers++
+		want := remoteHeaderCount{total: len(sessions)}
+		groupPath := ""
+		if it.Level > 0 {
+			groupPath = strings.TrimPrefix(it.Path, "remotes/box/")
+			want.total = remoteSubGroupCount(sessions, groupPath)
+		}
+		want.running, want.waiting = remoteStatusCounts(sessions, groupPath)
+		if got[it.Path] != want {
+			t.Errorf("%s: counts %+v, scan helpers say %+v", it.Path, got[it.Path], want)
+		}
+	}
+	if headers < 7 {
+		t.Fatalf("expected the host header, work, work/api, work/web, work/web/v2, play, idle and my-sessions; got %d headers", headers)
+	}
+}
+
+// Finding 11: the rendered header rows are byte-identical whether the counts
+// come from the rows' side map or from the renderer's fallback scan.
+func TestRemoteHeaderCounts_RenderIdenticalToScan(t *testing.T) {
+	home := newTestHomeWithItems(120, 40, nil)
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"box": {
+			remoteInfo("box", "1", "a", "running"),
+			{ID: "2", Title: "b", Group: "work", Status: "waiting", RemoteName: "box"},
+			{ID: "3", Title: "c", Group: "work/api", Status: "running", RemoteName: "box"},
+			{ID: "4", Title: "d", Group: "work", Status: "running", Archived: true, RemoteName: "box"},
+		},
+	}
+	home.remoteGroups = map[string][]string{"box": {"work", "empty"}}
+	home.rebuildFlatItems()
+	render := func() string {
+		var b strings.Builder
+		for _, it := range home.flatItems {
+			if it.Type == session.ItemTypeRemoteGroup {
+				home.renderRemoteGroupItem(&b, it, false)
+			}
+		}
+		return b.String()
+	}
+	if len(home.remoteHeaderCounts) == 0 {
+		t.Fatal("rebuildFlatItems must compute the header counts")
+	}
+	for _, it := range home.flatItems {
+		if it.Type == session.ItemTypeRemoteGroup {
+			if _, ok := home.remoteHeaderCounts[it.Path]; !ok {
+				t.Errorf("header %s has no precomputed counts", it.Path)
+			}
+		}
+	}
+	withMap := render()
+	home.remoteHeaderCounts = nil
+	withScan := render()
+	if withMap != withScan {
+		t.Fatalf("rendering differs:\nmap:\n%s\nscan:\n%s", withMap, withScan)
+	}
+	if !strings.Contains(withMap, "(3)") || !strings.Contains(withMap, "empty") {
+		t.Fatalf("expected the host header count and the empty group; got:\n%s", withMap)
+	}
+}
+
+// Finding 11: the snapshot is written at most once per interval, only when
+// the sessions changed, and always on demand (quit).
+func TestRemoteSessionsCache_SaveIsDebounced(t *testing.T) {
+	remoteSessionsCacheEnabled = true
+	t.Cleanup(func() { remoteSessionsCacheEnabled = false })
+
+	home := NewHome()
+	if home.storage == nil || home.storage.GetDB() == nil {
+		t.Skip("no storage backend in this environment")
+	}
+	db := home.storage.GetDB()
+	t.Cleanup(func() { _ = db.SetMeta(remoteSessionsCacheKey, "") })
+	_ = db.SetMeta(remoteSessionsCacheKey, "")
+
+	meta := func() string {
+		val, _ := db.GetMeta(remoteSessionsCacheKey)
+		return val
+	}
+	set := func(title string) map[string][]session.RemoteSessionInfo {
+		live := map[string][]session.RemoteSessionInfo{"box": {remoteInfo("box", "r1", title, "running")}}
+		home.remoteSessionsMu.Lock()
+		home.remoteSessions = live
+		home.remoteSessionsMu.Unlock()
+		return live
+	}
+
+	home.saveRemoteSessionsCache(set("first"))
+	if !strings.Contains(meta(), "first") {
+		t.Fatal("the first save must write at once")
+	}
+	home.saveRemoteSessionsCache(set("second"))
+	if strings.Contains(meta(), "second") {
+		t.Fatal("a save inside the interval must be held back")
+	}
+	home.flushRemoteSessionsCache(false)
+	if strings.Contains(meta(), "second") {
+		t.Fatal("a tick flush inside the interval must be held back too")
+	}
+	home.remoteCacheLastSave = time.Now().Add(-remoteSessionsCacheSaveInterval)
+	home.flushRemoteSessionsCache(false)
+	if !strings.Contains(meta(), "second") {
+		t.Fatal("once the interval passed the held snapshot must land")
+	}
+
+	// Same sessions again after the interval: nothing to write.
+	_ = db.SetMeta(remoteSessionsCacheKey, "")
+	home.remoteCacheLastSave = time.Now().Add(-remoteSessionsCacheSaveInterval)
+	home.saveRemoteSessionsCache(set("second"))
+	if meta() != "" {
+		t.Fatal("an unchanged fleet must not be rewritten")
+	}
+
+	// Quit writes what is pending without waiting.
+	home.saveRemoteSessionsCache(set("third"))
+	home.flushRemoteSessionsCache(true)
+	if !strings.Contains(meta(), "third") {
+		t.Fatal("a forced flush must write the pending snapshot")
+	}
+
+	// And what it wrote loads back through the startup path.
+	reader := NewHome()
+	if got := reader.remoteSessions["box"]; len(got) != 1 || got[0].Title != "third" || got[0].RemoteName != "box" {
+		t.Fatalf("the debounced snapshot must round-trip; got %+v", reader.remoteSessions)
+	}
+}
+
+// Finding 12: a remote known with zero sessions keeps its entry through a
+// result that did not cover it.
+func TestMergeRemoteSessions_KeepsKnownEmptyRemote(t *testing.T) {
+	prev := map[string][]session.RemoteSessionInfo{"fresh": {}, "nilled": nil}
+	got := mergeRemoteSessions(prev, map[string][]session.RemoteSessionInfo{"other": {}}, map[string]bool{"fresh": true, "nilled": true})
+	if _, ok := got["fresh"]; !ok {
+		t.Fatal("a failed remote that existed with zero sessions must be kept")
+	}
+	if _, ok := got["nilled"]; !ok {
+		t.Fatal("a failed remote that existed with a nil slice must be kept")
+	}
+	if _, ok := mergeRemoteSessions(nil, nil, map[string]bool{"unknown": true})["unknown"]; ok {
+		t.Fatal("a failed remote never seen before must not appear")
+	}
+}
+
+// Finding 12: a push from one remote leaves an empty remote's host header
+// and folders in place.
+func TestRemotePush_EmptyRemoteKeepsHeaderAndGroups(t *testing.T) {
+	home := newTestHomeWithItems(120, 40, nil)
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"busy":  {remoteInfo("busy", "b1", "b", "running")},
+		"empty": {},
+	}
+	home.remoteGroups = map[string][]string{"empty": {"inbox"}, "groupsonly": {"todo"}}
+	home.remoteCosts = map[string]*costs.RemoteCostSummary{"costsonly": {CostTodayMicrodollars: 1}}
+
+	msg := home.pushedRemoteFetch(session.RemoteChange{Remote: "busy", HasData: true})
+	for _, name := range []string{"empty", "groupsonly", "costsonly"} {
+		if !msg.failed[name] || !msg.groupsFailed[name] {
+			t.Fatalf("a push must mark every other known remote failed; %s missing in %v / %v", name, msg.failed, msg.groupsFailed)
+		}
+	}
+
+	model, _ := home.Update(pushWithData("busy", []session.RemoteSessionInfo{{ID: "b1", Title: "b-pushed"}}, nil))
+	h := model.(*Home)
+	if _, ok := h.remoteSessions["empty"]; !ok {
+		t.Fatal("an empty remote must survive a foreign push")
+	}
+	if got := h.remoteGroups["empty"]; len(got) != 1 || got[0] != "inbox" {
+		t.Fatalf("an empty remote's group list must survive a foreign push; got %v", got)
+	}
+	if got := h.remoteGroups["groupsonly"]; len(got) != 1 || got[0] != "todo" {
+		t.Fatalf("a remote known only by its group list must keep it; got %v", got)
+	}
+	if h.remoteCosts["costsonly"] == nil {
+		t.Fatal("a remote known only by its cost figure must keep it")
+	}
+	header, inbox := false, false
+	for _, it := range h.flatItems {
+		if it.Type != session.ItemTypeRemoteGroup {
+			continue
+		}
+		if it.Path == "remotes/empty" {
+			header = true
+		}
+		if it.Path == "remotes/empty/inbox" {
+			inbox = true
+		}
+	}
+	if !header || !inbox {
+		t.Fatalf("the empty remote's host header and its folder must still render; header=%v inbox=%v", header, inbox)
+	}
+}

--- a/internal/ui/remote_tree.go
+++ b/internal/ui/remote_tree.go
@@ -278,3 +278,45 @@ func remoteStatusCounts(sessions []session.RemoteSessionInfo, groupPath string) 
 	}
 	return running, waiting
 }
+
+// remoteHeaderCount is what a remote header row shows: the sessions under it
+// (the whole remote for the host header, the subtree for a group header) and
+// how many of those are running or waiting.
+type remoteHeaderCount struct {
+	total, running, waiting int
+}
+
+// remoteHeaderCounts computes the counts of every header row one remote's
+// rows can have, keyed by Item.Path, in one pass over the sessions: the host
+// header ("remotes/<name>") and every group prefix a session's Group path
+// implies. The numbers equal remoteSubGroupCount and remoteStatusCounts for
+// the same slice; computing them once with the rows spares the renderer a
+// rescan of every session for every visible header on every frame.
+func remoteHeaderCounts(remoteName string, sessions []session.RemoteSessionInfo) map[string]remoteHeaderCount {
+	root := "remotes/" + remoteName
+	counts := make(map[string]remoteHeaderCount)
+	add := func(path string, running, waiting bool) {
+		c := counts[path]
+		c.total++
+		if running {
+			c.running++
+		}
+		if waiting {
+			c.waiting++
+		}
+		counts[path] = c
+	}
+	for i := range sessions {
+		// Archived rows count as sessions but never as running or waiting,
+		// matching remoteStatusCounts (#1945).
+		running := !sessions[i].Archived && sessions[i].Status == "running"
+		waiting := !sessions[i].Archived && sessions[i].Status == "waiting"
+		add(root, running, waiting)
+		prefix := ""
+		for _, seg := range strings.Split(normalizeRemoteGroupPath(sessions[i].Group), "/") {
+			prefix = joinGroupSegment(prefix, seg)
+			add(root+"/"+prefix, running, waiting)
+		}
+	}
+	return counts
+}


### PR DESCRIPTION
## What problem does this solve?
The adversarial scale review of the persistent remote channel (#2180) confirmed 14 problems that bite at hundreds to thousands of sessions per remote, days of uptime or flaky links: a chatty remote starving the poll, the agent re-listing on every DB write, a lost reply re-running a create or delete, half-open ssh links never detected, orphaned agents, multi-MB pushes, newest events dropped under bursts, stale pushes resurrecting deleted rows, deconfigured remotes kept alive. Closes #2180; part of #2174 / #2138.

## Why this change
Six commits, three owners with strict file ownership plus one integration commit:
- **Agent** (`remote-agent`): probes are debounced to a 2 s quiet interval, read-only (the agent never registers a global state DB, pinned by a test), re-probe when the stamp moved mid-probe; requests get a concurrency cap of 4, single-flight for identical read-only requests, `{"id":N,"cancel":true}`; liveness via `ping` events, ping acks, a 10 min idle deadline and a bounded stdout queue with backpressure (a dead pipe ends the agent instead of wedging it); listings are pushed compact, capped at 4 MB, only when well-formed, and every event and reply carries the remote DB `stamp`.
- **Channel**: a lost reply after a written mutating command returns `errChannelInterrupted` (no re-exec over plain ssh); ServerAlive options and client pings detect half-open links and mark the channel down; only a non-JSON hello marks a remote unsupported, everything else backs off 2 s..30 s with a stale-socket sweep before dialing; `ReconcileRemoteChannels(config)` / `CloseRemoteChannels()`; reader capped at 32 MiB; per-remote latest-wins mailbox replaces the FIFO fan-in.
- **TUI**: pushes never touch the poll's timing or starve other remotes; costs and groups from a poll always apply; a discarded result still advances the poll clock; cache saves debounced to 30 s and only on change; per-group counts computed once per rebuild; failed remotes keep their rows even when empty; stale pushes (by stamp, with a membership+time fallback) cannot resurrect a row the user just removed.
- **Integration**: reconcile on every fleet round, close on quit, drop pushes for unconfigured remotes, stamp ordering end to end, "outcome unknown, refreshing" for interrupted mutating commands.

## User impact
The channel behaves the same for a small deck and holds up for a large one: no CPU burn on the remote, no ghost rows, no duplicate creates on a flaky link, agents die with the TUI, memory and bandwidth bounded. Older remotes keep working; `AGENT_DECK_REMOTE_CHANNEL=0` still turns it all off.

## Evidence
Each owner's branch was adversarially reviewed by a separate agent that reran the tests and fixed what it found (ed508929 on the agent side). On the integrated stack, in the Docker test image: `internal/session -run 'Remote|SSH'` ok, `cmd/agent-deck -run RemoteAgent` ok (5 consecutive runs after making the cancel test order-independent), `internal/ui` ok. Local go test is disallowed on this host.

## AI disclosure
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5-1

## What actually bothered you
My human asked: "we need it to be working 100%, fully polished and production; there would be a lot of sessions, so it should scale and not have any issues; if there are, solve them".

## Checklist
- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5-1 intent=yes -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cancellation and ping support for remote requests.
  * Added reliable remote session updates with change tracking and stale-data protection.
  * Added automatic handling for interrupted requests and remote reconnections.
* **Bug Fixes**
  * Improved behavior when remote connections become unresponsive or stop sending data.
  * Prevented outdated updates from restoring deleted, archived, or deconfigured sessions.
* **Performance**
  * Reduced duplicate remote requests and unnecessary cache writes.
  * Improved responsiveness when monitoring multiple active remotes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->