### PR TITLE
release: v1.16.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.4] - 2026-09-07
+
+The persistent remote channel is production-grade: bounded, self-healing and honest at fleet scale, with faster pushes and a live preview pane.
+
+### Added
+
+- The remote agent's change probe lists in-process instead of spawning the CLI twice, cutting the time from a change on the remote to the local screen by roughly two thirds; events carry `probe_ms` ([#2182](https://github.com/asheshgoplani/agent-deck/pull/2182)).
+- Each remote's poll result is delivered as it lands, so a slow host never delays a fast one; the header latency figure now measures the transport round trip, not a remote process start ([#2181](https://github.com/asheshgoplani/agent-deck/pull/2181)).
+- The focused remote session's pane is pushed over the channel instead of polled ([#2183](https://github.com/asheshgoplani/agent-deck/pull/2183)).
+- A remote session you just created is drawn the moment you detach from it ([#2179](https://github.com/asheshgoplani/agent-deck/pull/2179)).
+
+### Fixed
+
+- Channel hardening for large fleets ([#2187](https://github.com/asheshgoplani/agent-deck/pull/2187), closes #2180): the agent debounces probes, never writes to the remote DB, caps concurrent requests, honours cancels, keeps itself alive with pings and an idle deadline, pushes only well-formed compact listings capped at 4 MB, and stamps every event and reply; the client never re-runs a mutating command after a lost reply, detects half-open links, backs off on transient failures instead of disabling itself, reconciles channels against config, closes them on quit, caps frames, and keeps only the latest push per remote; the TUI never lets pushes starve the poll, saves the remote cache at most every 30 s, computes group counts once per rebuild, keeps empty remotes, and refuses stale pushes that would resurrect a row you just removed.
+
 ## [1.16.3] - 2026-09-06
 
 Changes on a remote deck reach the local TUI within about a second instead of at the next poll, and the PR gate runs in a third of the time.

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -41,7 +41,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-var Version = "1.16.3" // overridden at build time via -ldflags "-X main.Version=..."
+var Version = "1.16.4" // overridden at build time via -ldflags "-X main.Version=..."
 
 // Table column widths for list command output
 const (


### PR DESCRIPTION
## What problem does this solve?
Cuts v1.16.4 so the maintainer gets the production-hardened remote channel (#2187, closes #2180), in-process probes (#2182), per-host delivery and honest latency (#2181), pane over the channel (#2183) and the instant row on create (#2179). Version bump and CHANGELOG entry only. After merge the maintainer pushes the `v1.16.4` tag and release.yml publishes. Part of #2138.

## Why this change
Same flow as v1.16.3 (#2178): release commit on main, tag pushed, CI is the only publisher.

## User impact
`agent-deck version` reports 1.16.4 after the tag; release notes as listed in CHANGELOG.md.

## Evidence
`grep 'var Version' cmd/agent-deck/main.go` reads `1.16.4`, which release.yml validates against the tag. Every included PR passed the sharded gate; the hardening batch was adversarially reviewed per owner. Local go test is disallowed on this host; nothing here is Go logic.

## AI disclosure
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-fable-5-1

## What actually bothered you
My human asked: "we need it to be working 100%, fully polished and production".

## Checklist
- [x] Targeted diff: one problem, no unrelated changes
- [ ] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-fable-5-1 intent=yes -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application version to 1.16.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->