### PR TITLE
feat(quota): report Claude subscription quota via `agent-deck usage`

### DIFF
--- a/README.md
+++ b/README.md
@@ -810,6 +810,51 @@ cost_line_template = "{cost_yesterday} yda | {cost_today} today | {cost_projecte
 
 Resolution chain: `profiles.<active>.costs.cost_line_template > [costs].cost_line_template > hardcoded "{cost_today} today"`. Setting the template to an empty string explicitly disables the segment.
 
+### Provider Quota (`agent-deck usage`)
+
+Cost tracking answers "how many dollars"; this answers "how much of my
+subscription is left". When you run several agents at once, the limit you hit
+first is usually the provider's 5-hour or weekly plan window, not a dollar
+budget.
+
+The numbers come from the providers themselves — nothing here is estimated from
+token counts.
+
+```
+$ agent-deck usage
+Claude  updated 2m ago
+  5h       23.5%  resets in 2h14m
+  7d       41.2%  resets in 3d6h
+```
+
+`agent-deck usage --json` prints the same report for scripting.
+
+**Claude** is read from the documented `rate_limits` block in the JSON Claude
+Code pipes to a `statusLine` command. Wire the ingester into
+`~/.claude/settings.json`:
+
+```json
+{"statusLine": {"type": "command", "command": "agent-deck usage ingest claude"}}
+```
+
+If you already have a status line, keep it by wrapping it — the same payload is
+passed through and your command's output and exit status are forwarded verbatim:
+
+```json
+{"statusLine": {"type": "command",
+                "command": "agent-deck usage ingest claude -- your-existing-command"}}
+```
+
+Only `rate_limits` is kept. The transcript path, cwd, prompt and model in that
+payload are never stored or printed.
+
+`agent-deck usage` itself makes no network request: it reads the cache the
+ingester wrote.
+
+Snapshots are cached under `$XDG_CACHE_HOME/agent-deck/quota/<profile>/`. A
+snapshot older than the freshness bound is still shown, marked `(stale)` — a
+Claude snapshot only refreshes while Claude is actually running.
+
 ### Socket Isolation (v1.7.50+)
 
 Run agent-deck on its own tmux server so it never touches your interactive tmux's config, bindings, or sessions. Opt-in via a single config line:

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -99,7 +99,7 @@ func recordCLITelemetry(subcommand string, rest []string) {
 	case "add", "list", "ls", "remove", "rm", "rename", "mv", "status", "profile", "update",
 		"session", "fleet", "mcp", "plugin", "skill", "mcp-proxy", "group", "try", "launch",
 		"accounts", "conductor", "agents", "agent", "telegram-doctor", "watcher", "openclaw", "oc",
-		"remote", "worktree", "wt", "costs", "web", "uninstall", "migrate-paths", "hooks",
+		"remote", "worktree", "wt", "costs", "usage", "web", "uninstall", "migrate-paths", "hooks",
 		"codex-hooks", "gemini-hooks", "hermes-hooks", "cursor-hooks", "deepseek", "feedback", "creds-refresh":
 	default:
 		return
@@ -432,6 +432,9 @@ func main() {
 			return
 		case "costs":
 			handleCosts(profile, args[1:])
+			return
+		case "usage":
+			handleUsage(profile, args[1:])
 			return
 		case "web":
 			webEnabled = true
@@ -1065,7 +1068,7 @@ var commandRegistry = map[string]bool{
 	"group": true, "try": true, "launch": true, "conductor": true,
 	"agents": true, "agent": true,
 	"telegram-doctor": true, "watcher": true, "openclaw": true, "oc": true,
-	"remote": true, "remote-agent": true, "worktree": true, "wt": true, "costs": true, "web": true,
+	"remote": true, "remote-agent": true, "worktree": true, "wt": true, "costs": true, "usage": true, "web": true,
 	"uninstall": true, "migrate-paths": true, "hook-handler": true,
 	"codex-notify": true, "hooks": true, "codex-hooks": true, "gemini-hooks": true,
 	"hermes-hooks": true, "cursor-hooks": true, "deepseek": true, "notify-daemon": true,
@@ -3686,6 +3689,7 @@ func printHelp() {
 	fmt.Println("  deepseek         Inspect the DeepSeek Harness (dsh) integration")
 	fmt.Println("  group            Manage groups")
 	fmt.Println("  worktree, wt     Manage git worktrees")
+	fmt.Println("  usage            Show remaining provider subscription quota")
 	fmt.Println("  web              Start TUI with web UI server running alongside")
 	fmt.Println("  remote           Manage remote agent-deck instances")
 	fmt.Println("  conductor        Manage conductor meta-agent orchestration")

--- a/cmd/agent-deck/usage_cmd.go
+++ b/cmd/agent-deck/usage_cmd.go
@@ -1,0 +1,308 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/quota"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+const usageUsage = `Usage: agent-deck usage [--json]
+       agent-deck usage ingest claude [-- <command> [args...]]
+
+Show how much of each provider's subscription quota is left, from the
+provider's own numbers.
+
+Options:
+  --json      Print the report as JSON
+
+Subcommands:
+  ingest claude   Read a Claude Code statusLine payload on stdin and cache the
+                  rate_limits it carries. With a trailing "-- <command>", the
+                  same bytes are passed to that command and its output and exit
+                  status are forwarded, so an existing statusLine keeps working.`
+
+// handleUsage is the `agent-deck usage` entry point.
+func handleUsage(profile string, args []string) {
+	if len(args) > 0 && args[0] == "ingest" {
+		handleUsageIngest(profile, args[1:])
+		return
+	}
+
+	flags := flag.NewFlagSet("usage", flag.ContinueOnError)
+	flags.SetOutput(os.Stdout)
+	flags.Usage = func() { fmt.Println(usageUsage) }
+	asJSON := flags.Bool("json", false, "print the report as JSON")
+	if len(args) > 0 && args[0] == "help" {
+		flags.Usage()
+		return
+	}
+	if err := flags.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return
+		}
+		os.Exit(2)
+	}
+	if flags.NArg() > 0 {
+		fmt.Fprintf(os.Stderr, "Unknown usage argument: %s\n", flags.Arg(0))
+		fmt.Fprintln(os.Stderr, usageUsage)
+		os.Exit(2)
+	}
+
+	store := openQuotaStore(profile)
+	report := quota.Report{Providers: collectQuota(store)}
+
+	if *asJSON {
+		encoded, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: encoding usage report: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(encoded))
+		return
+	}
+	fmt.Print(renderUsage(report, time.Now()))
+	// Exit 0 even when a provider reported an error: a provider outage is data
+	// about that provider, not a failure of the command, and a script gating on
+	// the exit status must not read one as the other.
+}
+
+// openQuotaStore resolves the profile the same way every other on-disk-state
+// command does. ResolveProfileForStorage carries the #1790 guard that stops a
+// CLAUDE_CONFIG_DIR-inferred profile from materialising a phantom directory.
+func openQuotaStore(profile string) *quota.Store {
+	resolved, err := session.ResolveProfileForStorage(profile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: resolving profile: %v\n", err)
+		os.Exit(1)
+	}
+	store, err := quota.NewStore(resolved)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: opening quota cache: %v\n", err)
+		os.Exit(1)
+	}
+	return store
+}
+
+// collectQuota reads the cached snapshots.
+//
+// Claude is PUSH-only: its snapshot arrives from whatever statusLine invocation
+// last ran, and there is no endpoint to ask. So this reads the cache and
+// nothing else — `agent-deck usage` makes no network request. A pull-based
+// provider would fetch here, on this user-triggered path, and never on a TUI
+// render path.
+//
+// A cache that cannot be read at all is a warning on stderr, not a failure: the
+// providers that did load still print.
+func collectQuota(store *quota.Store) []quota.Snapshot {
+	cached, err := store.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: reading quota cache: %v\n", err)
+	}
+	// Never nil: `--json` must emit "providers": [] rather than null so a
+	// consumer can range over it without a nil check.
+	if cached == nil {
+		return []quota.Snapshot{}
+	}
+	return cached
+}
+
+// renderUsage is the human rendering. It is a pure function of the report and a
+// clock so the shape can be pinned by a test without a subprocess.
+func renderUsage(report quota.Report, now time.Time) string {
+	if len(report.Providers) == 0 {
+		return "No provider quota cached yet.\n" +
+			"Claude: wire `agent-deck usage ingest claude` into your statusLine.\n"
+	}
+
+	var out strings.Builder
+	for _, provider := range report.Providers {
+		header := provider.Label
+		if provider.Error != "" {
+			// The failing provider names itself, so a reader can tell which one
+			// is out without inferring it from which line went missing.
+			fmt.Fprintf(&out, "%s  unavailable: %s\n", header, provider.Error)
+			if len(provider.Windows) == 0 {
+				continue
+			}
+			// Last known numbers are still worth having, clearly marked.
+			fmt.Fprintf(&out, "%s  last known %s\n", header, describeAge(provider, now))
+		} else {
+			fmt.Fprintf(&out, "%s  %s\n", header, describeAge(provider, now))
+		}
+		for _, window := range provider.Windows {
+			fmt.Fprintf(&out, "  %-6s %6.1f%%%s\n", window.Label, window.UsedPercentage, describeReset(window.ResetsAt, now))
+		}
+	}
+	return out.String()
+}
+
+// describeAge says when the snapshot was taken, and says "stale" when the store
+// judged it past its freshness bound. A stale number is shown rather than
+// hidden — dropping it would leave the user with less than they had — but it is
+// never presented as current.
+func describeAge(provider quota.Snapshot, now time.Time) string {
+	marker := ""
+	if provider.Stale {
+		marker = " (stale)"
+	}
+	if provider.UpdatedAt <= 0 {
+		return "updated at an unknown time (stale)"
+	}
+	age := now.Sub(time.Unix(provider.UpdatedAt, 0))
+	if age < 0 {
+		age = 0
+	}
+	return "updated " + shortDuration(age) + " ago" + marker
+}
+
+// describeReset renders the provider's own reset time. Nothing is printed when
+// the provider did not report one: an invented "resets in ~5h" would be a
+// promise agent-deck is in no position to make.
+func describeReset(resetsAt *int64, now time.Time) string {
+	if resetsAt == nil {
+		return ""
+	}
+	remaining := time.Unix(*resetsAt, 0).Sub(now)
+	if remaining <= 0 {
+		return "  window has reset"
+	}
+	return "  resets in " + shortDuration(remaining)
+}
+
+func shortDuration(d time.Duration) string {
+	switch {
+	case d >= 24*time.Hour:
+		return fmt.Sprintf("%dd%dh", int(d.Hours())/24, int(d.Hours())%24)
+	case d >= time.Hour:
+		return fmt.Sprintf("%dh%dm", int(d.Hours()), int(d.Minutes())%60)
+	case d >= time.Minute:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	default:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+}
+
+const usageIngestUsage = `Usage: agent-deck usage ingest claude [-- <command> [args...]]
+
+Read a Claude Code statusLine payload on stdin and cache the rate_limits it
+carries. Only rate_limits is kept: the transcript path, cwd, prompt and model in
+that payload are never stored or printed.
+
+Wire it into ~/.claude/settings.json:
+
+  "statusLine": {"type": "command", "command": "agent-deck usage ingest claude"}
+
+If you already have a statusLine command, keep it by wrapping it:
+
+  "statusLine": {"type": "command",
+                 "command": "agent-deck usage ingest claude -- your-existing-command"}`
+
+// handleUsageIngest implements `agent-deck usage ingest claude`.
+func handleUsageIngest(profile string, args []string) {
+	if len(args) == 0 || helpRequested(args) || args[0] == "help" {
+		fmt.Println(usageIngestUsage)
+		return
+	}
+	if args[0] != "claude" {
+		fmt.Fprintf(os.Stderr, "Unknown ingest source: %s\n", args[0])
+		fmt.Fprintln(os.Stderr, usageIngestUsage)
+		os.Exit(2)
+	}
+	rest := args[1:]
+	if helpRequested(rest) || (len(rest) > 0 && rest[0] == "help") {
+		fmt.Println(usageIngestUsage)
+		return
+	}
+
+	var wrapped []string
+	if len(rest) > 0 {
+		if rest[0] != "--" {
+			fmt.Fprintf(os.Stderr, "Unknown ingest argument: %s\n", rest[0])
+			fmt.Fprintln(os.Stderr, usageIngestUsage)
+			os.Exit(2)
+		}
+		wrapped = rest[1:]
+	}
+
+	// The payload is read once and reused, because stdin cannot be replayed and
+	// the wrapped command must receive exactly what Claude sent.
+	payload, err := readStatusLinePayload(os.Stdin)
+	if err != nil {
+		// Claude Code renders a statusLine command's failure as a BLANK status
+		// line, so a loud failure here would replace the user's status bar with
+		// nothing. The diagnostic goes to stderr and the wrapped command still
+		// runs.
+		fmt.Fprintf(os.Stderr, "agent-deck: reading statusLine payload: %v\n", err)
+	} else if snapshot, ok, parseErr := quota.ParseStatusLine(strings.NewReader(string(payload))); parseErr != nil {
+		fmt.Fprintf(os.Stderr, "agent-deck: parsing statusLine payload: %v\n", parseErr)
+	} else if ok {
+		if saveErr := openQuotaStore(profile).Save(snapshot); saveErr != nil {
+			fmt.Fprintf(os.Stderr, "agent-deck: caching Claude quota: %v\n", saveErr)
+		}
+	}
+
+	if len(wrapped) == 0 {
+		// Nothing is printed. A user with no statusLine before gets no status
+		// line now, which is the only non-surprising outcome.
+		return
+	}
+	runWrappedStatusLine(wrapped, payload)
+}
+
+// maxIngestBytes bounds the stdin read at the same size the parser accepts, so
+// an oversized payload is refused rather than buffered.
+const maxIngestBytes = 1 << 20
+
+func readStatusLinePayload(stdin *os.File) ([]byte, error) {
+	limited := make([]byte, 0, 4096)
+	buffer := make([]byte, 4096)
+	for {
+		n, err := stdin.Read(buffer)
+		limited = append(limited, buffer[:n]...)
+		if len(limited) > maxIngestBytes {
+			return limited[:maxIngestBytes], errors.New("statusLine payload exceeds size cap")
+		}
+		if err != nil {
+			if errors.Is(err, os.ErrClosed) || err.Error() == "EOF" {
+				return limited, nil
+			}
+			return limited, err
+		}
+		if n == 0 {
+			return limited, nil
+		}
+	}
+}
+
+// runWrappedStatusLine runs the user's own statusLine command with the same
+// bytes on stdin and forwards its stdout, stderr and exit status.
+//
+// argv comes straight from os.Args and is passed to exec.Command as separate
+// arguments: there is no shell and no string interpolation anywhere on this
+// path, so nothing in the payload or the settings file can become a command.
+func runWrappedStatusLine(argv []string, payload []byte) {
+	// #nosec G204 G702 -- argv is the user's own statusLine command, taken verbatim
+	// from their settings.json via os.Args and passed as separate arguments.
+	// There is no shell and no string interpolation on this path, so neither
+	// the payload nor anything Claude sends can become a command.
+	command := exec.Command(argv[0], argv[1:]...)
+	command.Stdin = strings.NewReader(string(payload))
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	if err := command.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			os.Exit(exitErr.ExitCode())
+		}
+		fmt.Fprintf(os.Stderr, "agent-deck: running statusLine command: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/agent-deck/usage_cmd_test.go
+++ b/cmd/agent-deck/usage_cmd_test.go
@@ -1,0 +1,317 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/quota"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// usageSentinelToken stands in for a provider credential in the environment: it
+// is exported into every `usage` subprocess so the JSON and human renderings
+// can be checked for a leak against something that would only be there by
+// mistake.
+const usageSentinelToken = "SENTINEL-USAGE-TOKEN-do-not-leak"
+
+type usageResult struct {
+	stdout   string
+	stderr   string
+	exitCode int
+}
+
+// runUsageCLI runs `agent-deck <args...>` in a subprocess with an isolated HOME
+// and XDG tree, so a test never reads or writes the developer's real cache.
+func runUsageCLI(t *testing.T, home string, stdin string, args ...string) usageResult {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmdArgs := append([]string{"-test.run=^TestUsageHelperProcess$", "--"}, args...)
+	cmd := exec.CommandContext(ctx, os.Args[0], cmdArgs...)
+	cmd.Env = append(os.Environ(),
+		"AGENT_DECK_USAGE_HELPER=1",
+		"AGENT_DECK_TASK6_HELPER_PROCESS=1",
+		"HOME="+home,
+		"XDG_CONFIG_HOME="+filepath.Join(home, ".config"),
+		"XDG_CACHE_HOME="+filepath.Join(home, ".cache"),
+		"XDG_DATA_HOME="+filepath.Join(home, ".local", "share"),
+		"XDG_STATE_HOME="+filepath.Join(home, ".local", "state"),
+		"AGENTDECK_PROFILE=",
+		"CLAUDE_CONFIG_DIR=",
+		"ANTHROPIC_AUTH_TOKEN="+usageSentinelToken,
+	)
+	cmd.Stdin = strings.NewReader(stdin)
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	require.NoError(t, ctx.Err(), "usage command did not return promptly")
+
+	result := usageResult{stdout: stdout.String(), stderr: stderr.String()}
+	var exitErr *exec.ExitError
+	switch {
+	case err == nil:
+	case asExitError(err, &exitErr):
+		result.exitCode = exitErr.ExitCode()
+	default:
+		t.Fatalf("running usage: %v\nstdout:%s\nstderr:%s", err, result.stdout, result.stderr)
+	}
+	return result
+}
+
+func asExitError(err error, target **exec.ExitError) bool {
+	exitErr, ok := err.(*exec.ExitError)
+	if ok {
+		*target = exitErr
+	}
+	return ok
+}
+
+func TestUsageHelperProcess(t *testing.T) {
+	if os.Getenv("AGENT_DECK_USAGE_HELPER") != "1" {
+		return
+	}
+	separator := 0
+	for i, arg := range os.Args {
+		if arg == "--" {
+			separator = i
+			break
+		}
+	}
+	os.Args = append([]string{"agent-deck"}, os.Args[separator+1:]...)
+	main()
+	// Exit rather than return: letting the test framework resume would append
+	// its own "PASS" to stdout, and the passthrough assertions below compare
+	// the statusLine output byte for byte.
+	os.Exit(0)
+}
+
+// usageHelperProfile is the profile the helper subprocess resolves to. This
+// package's TestMain forces AGENTDECK_PROFILE=_test (2025-12-11 incident: tests
+// overwrote production sessions) and that runs inside the helper too, so the
+// cache lands under _test rather than default.
+const usageHelperProfile = "_test"
+
+// seedSnapshot writes a provider file straight into the profile's quota cache,
+// standing in for an earlier ingest or fetch.
+func seedSnapshot(t *testing.T, home, profile string, snapshot quota.Snapshot) {
+	t.Helper()
+	dir := filepath.Join(home, ".cache", "agent-deck", "quota", profile)
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	encoded, err := json.Marshal(snapshot)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, snapshot.ID+".json"), encoded, 0o644))
+}
+
+func freshClaudeSnapshot() quota.Snapshot {
+	resets := time.Now().Add(2 * time.Hour).Unix()
+	return quota.Snapshot{
+		ID:    quota.ProviderClaude,
+		Label: "Claude",
+		Windows: []quota.Window{
+			{Kind: quota.WindowFiveHour, Label: "5h", UsedPercentage: 23.5, ResetsAt: &resets},
+			{Kind: quota.WindowSevenDay, Label: "7d", UsedPercentage: 41.2},
+		},
+		UpdatedAt: time.Now().Unix(),
+	}
+}
+
+func TestUsageJSONShapeIsStable(t *testing.T) {
+	home := t.TempDir()
+	seedSnapshot(t, home, usageHelperProfile, freshClaudeSnapshot())
+
+	result := runUsageCLI(t, home, "", "usage", "--json")
+	require.Equal(t, 0, result.exitCode, result.stderr)
+
+	var report quota.Report
+	require.NoError(t, json.Unmarshal([]byte(result.stdout), &report))
+	require.Len(t, report.Providers, 1)
+
+	claude := report.Providers[0]
+	assert.Equal(t, "claude", claude.ID)
+	assert.Equal(t, "Claude", claude.Label)
+	assert.False(t, claude.Stale)
+	require.Len(t, claude.Windows, 2)
+	assert.Equal(t, quota.WindowFiveHour, claude.Windows[0].Kind)
+	assert.Equal(t, "5h", claude.Windows[0].Label)
+	assert.Equal(t, 23.5, claude.Windows[0].UsedPercentage)
+	assert.NotNil(t, claude.Windows[0].ResetsAt)
+	// A window the provider gave no reset for must not acquire one.
+	assert.Nil(t, claude.Windows[1].ResetsAt)
+
+	// The field names are the contract for anything scripting against this.
+	var generic map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.stdout), &generic))
+	providers, ok := generic["providers"].([]any)
+	require.True(t, ok, "providers key must be present: %s", result.stdout)
+	first, ok := providers[0].(map[string]any)
+	require.True(t, ok)
+	for _, key := range []string{"id", "label", "windows", "updated_at", "stale"} {
+		assert.Contains(t, first, key)
+	}
+}
+
+func TestUsageJSONWithEmptyCacheStillHasProvidersKey(t *testing.T) {
+	home := t.TempDir()
+	result := runUsageCLI(t, home, "", "usage", "--json")
+	require.Equal(t, 0, result.exitCode, result.stderr)
+
+	var generic map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.stdout), &generic))
+	providers, ok := generic["providers"]
+	require.True(t, ok, "providers key must be present even with nothing cached: %s", result.stdout)
+	assert.NotNil(t, providers, "providers must be [] not null so consumers can range over it")
+}
+
+func TestUsageOutputCarriesNoCredential(t *testing.T) {
+	home := t.TempDir()
+	seedSnapshot(t, home, usageHelperProfile, freshClaudeSnapshot())
+
+	for _, args := range [][]string{{"usage"}, {"usage", "--json"}} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			result := runUsageCLI(t, home, "", args...)
+			assert.NotContains(t, result.stdout, usageSentinelToken)
+			assert.NotContains(t, result.stderr, usageSentinelToken)
+		})
+	}
+}
+
+func TestUsageProviderFailureDoesNotSuppressOthers(t *testing.T) {
+	// The isolation requirement: one provider going wrong must never blank out
+	// a provider that is working. A corrupt cache entry is the cheapest way to
+	// produce a genuine per-provider failure. The id is one this build does not
+	// know, which also pins the label fallback: an entry written by a newer
+	// build must still be shown, under its own id, rather than disappearing.
+	home := t.TempDir()
+	seedSnapshot(t, home, usageHelperProfile, freshClaudeSnapshot())
+	dir := filepath.Join(home, ".cache", "agent-deck", "quota", usageHelperProfile)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "some-other-provider.json"), []byte("{not json"), 0o644))
+
+	result := runUsageCLI(t, home, "", "usage")
+	// A failing provider is data, not a CLI failure: a script that checks the
+	// exit status must not see one provider's outage as `usage` being broken.
+	require.Equal(t, 0, result.exitCode, result.stderr)
+	assert.Contains(t, result.stdout, "some-other-provider")
+	assert.Contains(t, result.stdout, "unavailable")
+	// ...and Claude still prints its numbers.
+	assert.Contains(t, result.stdout, "Claude")
+	assert.Contains(t, result.stdout, "23.5%")
+}
+
+func TestUsageMarksStaleSnapshot(t *testing.T) {
+	home := t.TempDir()
+	stale := freshClaudeSnapshot()
+	stale.UpdatedAt = time.Now().Add(-24 * time.Hour).Unix()
+	seedSnapshot(t, home, usageHelperProfile, stale)
+
+	result := runUsageCLI(t, home, "", "usage")
+	require.Equal(t, 0, result.exitCode, result.stderr)
+	// Shown, but never presented as current.
+	assert.Contains(t, result.stdout, "23.5%")
+	assert.Contains(t, result.stdout, "stale")
+}
+
+func TestUsageReadsTheSelectedProfilesCache(t *testing.T) {
+	home := t.TempDir()
+	work := freshClaudeSnapshot()
+	work.Windows[0].UsedPercentage = 77.7
+	seedSnapshot(t, home, "work", work)
+
+	inWork := runUsageCLI(t, home, "", "-p", "work", "usage")
+	require.Equal(t, 0, inWork.exitCode, inWork.stderr)
+	assert.Contains(t, inWork.stdout, "77.7%")
+
+	inDefault := runUsageCLI(t, home, "", "-p", "default", "usage")
+	require.Equal(t, 0, inDefault.exitCode, inDefault.stderr)
+	assert.NotContains(t, inDefault.stdout, "77.7%")
+}
+
+const usageStatusLinePayload = `{"session_id":"abc","cwd":"/home/someone/private",` +
+	`"rate_limits":{"five_hour":{"used_percentage":31.5,"resets_at":1738425600}}}`
+
+func TestUsageIngestClaudeWritesCacheAndPrintsNothing(t *testing.T) {
+	home := t.TempDir()
+
+	result := runUsageCLI(t, home, usageStatusLinePayload, "usage", "ingest", "claude")
+	require.Equal(t, 0, result.exitCode, result.stderr)
+	// Without a wrapped command there was no status line before, so emitting
+	// anything would put text on the user's status bar that they did not ask for.
+	assert.Empty(t, result.stdout)
+
+	shown := runUsageCLI(t, home, "", "usage")
+	require.Equal(t, 0, shown.exitCode, shown.stderr)
+	assert.Contains(t, shown.stdout, "31.5%")
+}
+
+func TestUsageIngestClaudePassesPayloadThroughToWrappedCommand(t *testing.T) {
+	// Claude Code treats empty stdout or a non-zero exit from a statusLine
+	// command as "blank status line". An ingester that swallowed either would
+	// silently destroy a status line the user already had, so the wrapped
+	// command gets the same bytes and its stdout and exit status are forwarded.
+	home := t.TempDir()
+
+	result := runUsageCLI(t, home, usageStatusLinePayload,
+		"usage", "ingest", "claude", "--", "cat")
+	require.Equal(t, 0, result.exitCode, result.stderr)
+	assert.Equal(t, usageStatusLinePayload, result.stdout)
+
+	shown := runUsageCLI(t, home, "", "usage")
+	assert.Contains(t, shown.stdout, "31.5%")
+}
+
+func TestUsageIngestClaudeForwardsWrappedExitStatus(t *testing.T) {
+	home := t.TempDir()
+
+	result := runUsageCLI(t, home, usageStatusLinePayload,
+		"usage", "ingest", "claude", "--", "sh", "-c", "printf custom-line; exit 3")
+	assert.Equal(t, 3, result.exitCode)
+	assert.Equal(t, "custom-line", result.stdout)
+}
+
+func TestUsageIngestClaudeStoresNothingButRateLimits(t *testing.T) {
+	home := t.TempDir()
+	require.Equal(t, 0, runUsageCLI(t, home, usageStatusLinePayload, "usage", "ingest", "claude").exitCode)
+
+	cached, err := os.ReadFile(filepath.Join(home, ".cache", "agent-deck", "quota", usageHelperProfile, "claude.json"))
+	require.NoError(t, err)
+	assert.NotContains(t, string(cached), "/home/someone/private")
+	assert.NotContains(t, string(cached), "session_id")
+}
+
+func TestUsageIngestClaudeWithoutRateLimitsIsNotAnError(t *testing.T) {
+	// The normal state before the session's first API response.
+	home := t.TempDir()
+	result := runUsageCLI(t, home, `{"session_id":"abc"}`, "usage", "ingest", "claude", "--", "echo", "my-status")
+	require.Equal(t, 0, result.exitCode, result.stderr)
+	assert.Equal(t, "my-status\n", result.stdout)
+}
+
+func TestUsageHelpIsUsageOnly(t *testing.T) {
+	home := t.TempDir()
+	for _, args := range [][]string{
+		{"usage", "--help"},
+		{"usage", "-h"},
+		{"usage", "help"},
+		{"usage", "ingest", "--help"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			result := runUsageCLI(t, home, "", args...)
+			require.Equal(t, 0, result.exitCode, result.stderr)
+			assert.Contains(t, result.stdout, "Usage: agent-deck usage")
+		})
+	}
+}
+
+func TestUsageIsRegisteredAndDispatched(t *testing.T) {
+	// extractProfileFlag stops honoring the global -p at the first registry
+	// token, so registration is what makes `agent-deck -p work usage` parse.
+	assert.True(t, commandRegistry["usage"])
+}

--- a/internal/quota/claude.go
+++ b/internal/quota/claude.go
@@ -1,0 +1,100 @@
+package quota
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+)
+
+// maxStatusLineBytes caps the statusLine payload read from stdin.
+//
+// The documented payload is a few hundred bytes of session metadata; 1 MiB is
+// three orders of magnitude of headroom and still bounds the allocation for a
+// process that a user's Claude Code invokes on every status refresh. It is a
+// var rather than a const so the oversized-input test can exercise the cap
+// without allocating a megabyte of padding per run.
+var maxStatusLineBytes int64 = 1 << 20
+
+// claudeLabel is the display name. Spelled once so the CLI and the cache agree.
+const claudeLabel = "Claude"
+
+// statusLinePayload decodes ONLY the rate_limits block.
+//
+// Everything else Claude pipes in — transcript_path, cwd, the model, the
+// session id — is deliberately absent from this struct rather than being
+// decoded and then ignored: a field that does not exist cannot be accidentally
+// logged, persisted, or added to an error string later.
+type statusLinePayload struct {
+	RateLimits *struct {
+		FiveHour   *statusLineWindow `json:"five_hour"`
+		SevenDay   *statusLineWindow `json:"seven_day"`
+		SpendLimit *statusLineWindow `json:"spend_limit"`
+	} `json:"rate_limits"`
+}
+
+type statusLineWindow struct {
+	UsedPercentage float64 `json:"used_percentage"`
+	// ResetsAt is epoch SECONDS here, matching Snapshot's unit, so it is
+	// carried through without conversion.
+	ResetsAt *int64 `json:"resets_at"`
+}
+
+// ParseStatusLine extracts a Claude quota snapshot from a statusLine payload.
+//
+// ok is false, with no error, when the payload carries no rate_limits block.
+// That is the normal state before the session's first API response and the
+// permanent state for API-key, Bedrock and Vertex auth, so treating it as a
+// failure would make the common case look broken.
+func ParseStatusLine(r io.Reader) (Snapshot, bool, error) {
+	raw, err := io.ReadAll(io.LimitReader(r, maxStatusLineBytes+1))
+	if err != nil {
+		return Snapshot{}, false, fmt.Errorf("reading statusLine payload: %w", err)
+	}
+	if int64(len(raw)) > maxStatusLineBytes {
+		return Snapshot{}, false, errors.New("statusLine payload exceeds size cap")
+	}
+
+	var payload statusLinePayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return Snapshot{}, false, fmt.Errorf("decoding statusLine payload: %w", err)
+	}
+	if payload.RateLimits == nil {
+		return Snapshot{}, false, nil
+	}
+
+	snapshot := Snapshot{
+		ID:        ProviderClaude,
+		Label:     claudeLabel,
+		UpdatedAt: time.Now().Unix(),
+	}
+	// Windows are appended in this fixed order so the rendering is stable
+	// across refreshes; Claude drops a window from the block once its reset
+	// passes, so a missing one is expected and simply contributes nothing.
+	for _, candidate := range []struct {
+		kind   WindowKind
+		label  string
+		window *statusLineWindow
+	}{
+		{WindowFiveHour, "5h", payload.RateLimits.FiveHour},
+		{WindowSevenDay, "7d", payload.RateLimits.SevenDay},
+		{WindowSpendLimit, "spend", payload.RateLimits.SpendLimit},
+	} {
+		if candidate.window == nil {
+			continue
+		}
+		snapshot.Windows = append(snapshot.Windows, Window{
+			Kind:  candidate.kind,
+			Label: candidate.label,
+			// Not clamped: spend_limit exceeds 100 in overage and that is the
+			// reading the user most needs to see.
+			UsedPercentage: candidate.window.UsedPercentage,
+			ResetsAt:       candidate.window.ResetsAt,
+		})
+	}
+	if len(snapshot.Windows) == 0 {
+		return Snapshot{}, false, nil
+	}
+	return snapshot, true, nil
+}

--- a/internal/quota/claude_test.go
+++ b/internal/quota/claude_test.go
@@ -1,0 +1,154 @@
+package quota
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// windowByKind is a test helper: the model stores windows as a slice (unknown
+// provider windows must stay representable), so assertions look them up.
+func windowByKind(t *testing.T, snapshot Snapshot, kind WindowKind) Window {
+	t.Helper()
+	for _, window := range snapshot.Windows {
+		if window.Kind == kind {
+			return window
+		}
+	}
+	t.Fatalf("window %q not present in %+v", kind, snapshot.Windows)
+	return Window{}
+}
+
+func TestParseStatusLineWindows(t *testing.T) {
+	const payload = `{
+	  "session_id": "abc-123",
+	  "transcript_path": "/home/someone/.claude/projects/x/abc-123.jsonl",
+	  "cwd": "/home/someone/secret-project",
+	  "model": {"id": "claude-opus-5", "display_name": "Opus"},
+	  "rate_limits": {
+	    "five_hour":   {"used_percentage": 23.5, "resets_at": 1738425600},
+	    "seven_day":   {"used_percentage": 41.2, "resets_at": 1738857600},
+	    "spend_limit": {"used_percentage": 162.8, "resets_at": 1740787200}
+	  }
+	}`
+
+	snapshot, ok, err := ParseStatusLine(strings.NewReader(payload))
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	assert.Equal(t, ProviderClaude, snapshot.ID)
+	require.Len(t, snapshot.Windows, 3)
+
+	fiveHour := windowByKind(t, snapshot, WindowFiveHour)
+	// The float must survive: 23.5 rounded to 23 is a different claim about
+	// how much of the window is gone.
+	assert.Equal(t, 23.5, fiveHour.UsedPercentage)
+	require.NotNil(t, fiveHour.ResetsAt)
+	assert.Equal(t, int64(1738425600), *fiveHour.ResetsAt)
+
+	sevenDay := windowByKind(t, snapshot, WindowSevenDay)
+	assert.Equal(t, 41.2, sevenDay.UsedPercentage)
+
+	// spend_limit legitimately exceeds 100 once the account is in overage.
+	// Clamping it would report a breached limit as an exactly-met one.
+	spend := windowByKind(t, snapshot, WindowSpendLimit)
+	assert.Equal(t, 162.8, spend.UsedPercentage)
+}
+
+func TestParseStatusLineAbsentRateLimits(t *testing.T) {
+	// The normal state before the session's first API response, and the
+	// permanent state for API-key / Bedrock / Vertex auth. Not an error.
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{"no rate_limits key", `{"session_id":"abc","model":{"id":"claude-opus-5"}}`},
+		{"rate_limits null", `{"rate_limits": null}`},
+		{"rate_limits empty", `{"rate_limits": {}}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			snapshot, ok, err := ParseStatusLine(strings.NewReader(tt.payload))
+			require.NoError(t, err)
+			assert.False(t, ok)
+			assert.Empty(t, snapshot.Windows)
+		})
+	}
+}
+
+func TestParseStatusLineSingleWindowInventsNothing(t *testing.T) {
+	// Claude drops a window from the block once its reset passes.
+	const payload = `{"rate_limits": {"five_hour": {"used_percentage": 7, "resets_at": 1738425600}}}`
+
+	snapshot, ok, err := ParseStatusLine(strings.NewReader(payload))
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, snapshot.Windows, 1)
+	assert.Equal(t, WindowFiveHour, snapshot.Windows[0].Kind)
+}
+
+func TestParseStatusLineMissingResetIsNil(t *testing.T) {
+	// nil means "the provider did not tell us". Zero would mean 1970 and
+	// would render as a window that reset long ago.
+	const payload = `{"rate_limits": {"five_hour": {"used_percentage": 7}}}`
+
+	snapshot, ok, err := ParseStatusLine(strings.NewReader(payload))
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, snapshot.Windows, 1)
+	assert.Nil(t, snapshot.Windows[0].ResetsAt)
+}
+
+func TestParseStatusLineKeepsOnlyRateLimits(t *testing.T) {
+	// The statusLine payload carries the user's cwd, transcript path and
+	// prompt. None of it may reach a file agent-deck writes.
+	const payload = `{
+	  "session_id": "SENTINEL-SESSION",
+	  "transcript_path": "/home/someone/SENTINEL-TRANSCRIPT.jsonl",
+	  "cwd": "/home/someone/SENTINEL-CWD",
+	  "model": {"id": "SENTINEL-MODEL"},
+	  "rate_limits": {"five_hour": {"used_percentage": 10, "resets_at": 1738425600}}
+	}`
+
+	snapshot, ok, err := ParseStatusLine(strings.NewReader(payload))
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	encoded, err := json.Marshal(snapshot)
+	require.NoError(t, err)
+	for _, sentinel := range []string{"SENTINEL-SESSION", "SENTINEL-TRANSCRIPT", "SENTINEL-CWD", "SENTINEL-MODEL"} {
+		assert.NotContains(t, string(encoded), sentinel)
+	}
+}
+
+func TestParseStatusLineMalformed(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{"truncated", `{"rate_limits": {"five_hour":`},
+		{"not an object", `["five_hour"]`},
+		{"empty input", ``},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ok, err := ParseStatusLine(strings.NewReader(tt.payload))
+			require.Error(t, err)
+			assert.False(t, ok)
+		})
+	}
+}
+
+func TestParseStatusLineCapsInput(t *testing.T) {
+	// stdin is attacker-adjacent only in the sense that it is whatever the
+	// caller pipes in; an unbounded read is still an unbounded allocation.
+	oversized := `{"rate_limits": {"five_hour": {"used_percentage": 1}}, "pad": "` +
+		strings.Repeat("x", int(maxStatusLineBytes)+1) + `"}`
+
+	_, ok, err := ParseStatusLine(strings.NewReader(oversized))
+	require.Error(t, err)
+	assert.False(t, ok)
+}

--- a/internal/quota/model.go
+++ b/internal/quota/model.go
@@ -1,0 +1,97 @@
+// Package quota reports how much of a provider's SUBSCRIPTION allowance is
+// left, from the provider's own numbers.
+//
+// This is the forward-looking half of a signal agent-deck already has one half
+// of. internal/session/usagelimit.go detects that a plan window is exhausted,
+// after the fact, from the rejection turn in Claude's transcript — it answers
+// "this session is blocked". It cannot answer "how much is left", and it says
+// so itself: its staleness bound carries a "KNOWN LIMITATION, accepted
+// deliberately" note that it does not read the real reset time, so a rejection
+// can be believed for up to ~5h after the window actually reopened. The
+// provider-reported reset in this package is exactly that missing number.
+// Rewiring usagelimit.go to consume it is deliberately NOT done here.
+//
+// The source for Claude, and what was rejected: the JSON Claude Code pipes to a
+// configured statusLine command, whose `rate_limits` block is documented
+// (code.claude.com/docs/en/statusline). Every other candidate on this machine
+// was checked on 2026-09-07 and does not carry the numbers: none of the 31 hook
+// events, no `claude usage` subcommand, no OTel metric, no file under
+// ~/.claude. The undocumented oauth usage endpoint some tools call is
+// deliberately not used — it needs a bearer token replayed out of the user's
+// credential store, and this package never reads a credential store.
+//
+// Nothing here derives a percentage from token counts. A locally computed
+// estimate is a different number that happens to share a unit with the one the
+// user is asking about, and being wrong about a quota is worse than not showing
+// one.
+//
+// The model, the store and the CLI are deliberately shaped for more than one
+// provider even though Claude is the only one wired up here: the store is
+// one-file-per-provider and the report is a list, so a second provider is a new
+// file rather than a change to this contract.
+package quota
+
+// Provider IDs. These are the on-disk filenames in the cache and the stable
+// keys in `agent-deck usage --json`, so they are part of the contract and are
+// spelled once here rather than as literals at each call site.
+const (
+	ProviderClaude = "claude"
+)
+
+// WindowKind names a quota window. It is a named kind rather than a bare map
+// key because the kind is part of the `--json` contract: a consumer selects the
+// five-hour window by name, without having to parse the human label.
+type WindowKind string
+
+const (
+	WindowFiveHour   WindowKind = "five_hour"
+	WindowSevenDay   WindowKind = "seven_day"
+	WindowSpendLimit WindowKind = "spend_limit"
+)
+
+// Window is one quota window as the provider reported it.
+type Window struct {
+	Kind WindowKind `json:"kind"`
+	// Label is the short human rendering ("5h", "7d", "spend"). It is carried
+	// rather than derived from Kind so a provider whose window this build
+	// cannot name in advance can still label itself from its own numbers.
+	Label string `json:"label"`
+	// UsedPercentage is percent CONSUMED, 0-100 — except that Claude's
+	// spend_limit exceeds 100 in overage. It is NOT clamped: reporting a
+	// breached limit as an exactly-met one hides the very thing the user
+	// opened this to see.
+	UsedPercentage float64 `json:"used_percentage"`
+	// ResetsAt is epoch SECONDS, or nil when the provider said nothing.
+	//
+	// The pointer is the whole point: Claude omits the reset for a window it
+	// has not populated. A zero would render as a window that reset in 1970,
+	// and a synthesised "now + 5h" would be a promise this package is in no
+	// position to make. Never fill this in from the window's nominal duration.
+	ResetsAt *int64 `json:"resets_at,omitempty"`
+}
+
+// Snapshot is one provider's quota state as of UpdatedAt.
+type Snapshot struct {
+	ID        string   `json:"id"`
+	Label     string   `json:"label"`
+	Windows   []Window `json:"windows"`
+	UpdatedAt int64    `json:"updated_at"`
+	// Error is a short, provider-attributed message. A provider that failed is
+	// reported as data alongside the ones that succeeded — one unreadable
+	// provider must never blank out the others, which is the whole reason a
+	// failure lives in the model instead of being returned as an error.
+	//
+	// It must never carry a token, an account id, or a URL with credentials in
+	// it: this field is persisted and printed.
+	Error string `json:"error,omitempty"`
+	// Stale is computed at READ time against the store's TTL and is never
+	// persisted — a snapshot that was fresh when written would otherwise claim
+	// to be fresh forever. A stale snapshot is shown, marked; hiding it would
+	// leave the user with nothing where they previously had a number.
+	Stale bool `json:"stale"`
+}
+
+// Report is the shape of `agent-deck usage --json`.
+type Report struct {
+	Providers []Snapshot `json:"providers"`
+}

--- a/internal/quota/store.go
+++ b/internal/quota/store.go
@@ -1,0 +1,198 @@
+package quota
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
+	"github.com/asheshgoplani/agent-deck/internal/atomicfile"
+)
+
+// DefaultStaleAfter is how long a cached snapshot is presented without a stale
+// marker.
+//
+// The shortest window a provider reports is five hours, and its percentage
+// therefore moves on a scale of tens of minutes even under a fleet of agents.
+// Fifteen minutes is short enough that a number the user acts on is still
+// roughly current, and long enough that the common `agent-deck usage` in a
+// terminal loop does not turn into a request per invocation.
+//
+// KNOWN LIMITATION, accepted deliberately: this is a freshness marker, not a
+// refresh. Claude's provider is PUSH-only — its snapshot is written by whatever
+// statusLine invocation last ran — so a Claude snapshot goes stale whenever the
+// user simply is not running Claude, and no amount of asking will refresh it.
+// That is the honest state and it is shown as such rather than hidden, because
+// the alternative (dropping the last known numbers) leaves the user with less
+// than they had.
+const DefaultStaleAfter = 15 * time.Minute
+
+// maxProviderIDLen bounds the provider id, which becomes a filename. Provider
+// ids are compile-time constants in this package, so this guards against a
+// future caller rather than against today's data.
+const maxProviderIDLen = 64
+
+// Store is the on-disk quota cache for one profile.
+//
+// ONE FILE PER PROVIDER, deliberately. Claude's snapshot is PUSHED by the
+// statusLine ingester, potentially by several concurrent Claude sessions, and a
+// second provider would have a writer of its own. Separate files mean those
+// writers never read-modify-write the same file, so there is no lock to hold
+// and no lost update to reason about. Load simply reads the directory.
+//
+// The per-profile subdirectory keeps a future multi-account story open without
+// a schema change, and matches how the rest of agent-deck keys on-disk state.
+type Store struct {
+	dir string
+	// StaleAfter is per-store so a caller with a different tolerance (a status
+	// bar refreshing on a tick, say) can set its own without a global.
+	StaleAfter time.Duration
+}
+
+// NewStore returns the quota cache for a profile. It does not create anything
+// on disk: `agent-deck usage --help` must not leave a directory behind, which
+// the repo's help-is-read-only test enforces for every registered command.
+func NewStore(profile string) (*Store, error) {
+	cacheDir, err := agentpaths.CacheDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolving cache dir: %w", err)
+	}
+	cleanProfile := strings.TrimSpace(profile)
+	if cleanProfile == "" || !validProviderID(cleanProfile) {
+		return nil, fmt.Errorf("unusable profile name %q for quota cache", profile)
+	}
+	return &Store{dir: filepath.Join(cacheDir, "quota", cleanProfile), StaleAfter: DefaultStaleAfter}, nil
+}
+
+// Dir is the directory holding this profile's provider files.
+func (s *Store) Dir() string { return s.dir }
+
+// Save writes one provider's snapshot.
+//
+// Stale is cleared before writing: it is a read-time computation, and
+// persisting it would let a snapshot that was fresh at write time claim to be
+// fresh forever.
+func (s *Store) Save(snapshot Snapshot) error {
+	if !validProviderID(snapshot.ID) {
+		return fmt.Errorf("unusable provider id %q", snapshot.ID)
+	}
+	snapshot.Stale = false
+
+	encoded, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding %s snapshot: %w", snapshot.ID, err)
+	}
+	// 0o700: the numbers are not secret, but the set of providers a user has
+	// configured is theirs alone, and a private directory costs nothing.
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+		return fmt.Errorf("creating quota cache dir: %w", err)
+	}
+	// internal/atomicfile documents itself as being for user-managed config
+	// files, in contrast with the unexported temp+rename helpers agent-deck
+	// uses for its own state. It is used here anyway: those helpers are
+	// unexported, this one is stdlib-only so it introduces no import cycle, and
+	// its temp+rename semantics for a regular file are identical. The only
+	// difference — it preserves a symlink AT the path — is immaterial for a
+	// file that only agent-deck writes.
+	//
+	// 0o644: the file holds percentages and reset timestamps, never a token.
+	// The store round-trip test asserts that against a sentinel credential.
+	path := filepath.Join(s.dir, snapshot.ID+".json")
+	if err := atomicfile.WriteFile(path, encoded, 0o644); err != nil {
+		return fmt.Errorf("writing %s snapshot: %w", snapshot.ID, err)
+	}
+	return nil
+}
+
+// Load returns every cached provider snapshot, ordered by provider id so the
+// rendering does not reshuffle between invocations.
+//
+// A missing cache directory is the normal state before anything has been
+// ingested or fetched, and yields an empty report rather than an error.
+func (s *Store) Load() ([]Snapshot, error) {
+	entries, err := os.ReadDir(s.dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading quota cache: %w", err)
+	}
+
+	staleAfter := s.StaleAfter
+	if staleAfter <= 0 {
+		staleAfter = DefaultStaleAfter
+	}
+	now := time.Now()
+
+	var snapshots []Snapshot
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		id := strings.TrimSuffix(entry.Name(), ".json")
+		snapshots = append(snapshots, s.loadOne(id, now, staleAfter))
+	}
+	sort.Slice(snapshots, func(i, j int) bool { return snapshots[i].ID < snapshots[j].ID })
+	return snapshots, nil
+}
+
+// loadOne turns one cache file into a snapshot. An unreadable or corrupt file
+// becomes a snapshot carrying the failure rather than disappearing: a provider
+// the user configured going silently missing from the output is the one
+// outcome that would send them to a vendor dashboard, which is the thing this
+// feature exists to avoid.
+func (s *Store) loadOne(id string, now time.Time, staleAfter time.Duration) Snapshot {
+	raw, err := os.ReadFile(filepath.Join(s.dir, id+".json"))
+	if err != nil {
+		return Snapshot{ID: id, Label: ProviderLabel(id), Error: "cached snapshot unreadable", Stale: true}
+	}
+	var snapshot Snapshot
+	if err := json.Unmarshal(raw, &snapshot); err != nil {
+		return Snapshot{ID: id, Label: ProviderLabel(id), Error: "cached snapshot is corrupt", Stale: true}
+	}
+	// The filename is authoritative for the id: it is what Load enumerates and
+	// what a second writer would collide on.
+	snapshot.ID = id
+	if snapshot.Label == "" {
+		snapshot.Label = ProviderLabel(id)
+	}
+	snapshot.Stale = snapshot.UpdatedAt <= 0 || now.Sub(time.Unix(snapshot.UpdatedAt, 0)) > staleAfter
+	return snapshot
+}
+
+// ProviderLabel is the display name for a provider id, falling back to the id
+// itself for a cache file this build does not know about — a downgrade should
+// show the entry, not hide it.
+func ProviderLabel(id string) string {
+	switch id {
+	case ProviderClaude:
+		return claudeLabel
+	default:
+		return id
+	}
+}
+
+// validProviderID keeps the id usable as a single filename component. The id
+// reaches filepath.Join, so a traversal component would write outside the
+// cache directory.
+func validProviderID(id string) bool {
+	if id == "" || len(id) > maxProviderIDLen {
+		return false
+	}
+	if id != filepath.Base(id) || id == "." || id == ".." {
+		return false
+	}
+	for _, r := range id {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/quota/store_test.go
+++ b/internal/quota/store_test.go
@@ -1,0 +1,190 @@
+package quota
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// secondProviderID stands in for a provider other than Claude. The store is
+// one-file-per-provider so that independent writers never collide, and these
+// tests pin that with two ids; it sorts after "claude", which the ordering
+// assertions rely on.
+const secondProviderID = "other"
+
+// sentinelToken is a value that would only ever reach the cache by mistake. The
+// cache holds percentages and reset times, never a credential.
+const sentinelToken = "SENTINEL-QUOTA-TOKEN-do-not-leak"
+
+// newTestStore points the store at a per-test XDG cache root so nothing leaks
+// between tests or onto the developer's machine.
+func newTestStore(t *testing.T, profile string) *Store {
+	t.Helper()
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	store, err := NewStore(profile)
+	require.NoError(t, err)
+	return store
+}
+
+func TestStoreRoundTrip(t *testing.T) {
+	store := newTestStore(t, "default")
+	resets := int64(1738425600)
+	saved := Snapshot{
+		ID:        ProviderClaude,
+		Label:     claudeLabel,
+		Windows:   []Window{{Kind: WindowFiveHour, Label: "5h", UsedPercentage: 23.5, ResetsAt: &resets}},
+		UpdatedAt: time.Now().Unix(),
+	}
+	require.NoError(t, store.Save(saved))
+
+	loaded, err := store.Load()
+	require.NoError(t, err)
+	require.Len(t, loaded, 1)
+	assert.Equal(t, ProviderClaude, loaded[0].ID)
+	require.Len(t, loaded[0].Windows, 1)
+	assert.Equal(t, 23.5, loaded[0].Windows[0].UsedPercentage)
+	require.NotNil(t, loaded[0].Windows[0].ResetsAt)
+	assert.Equal(t, resets, *loaded[0].Windows[0].ResetsAt)
+}
+
+func TestStoreStalenessIsComputedAtReadAndStillReturned(t *testing.T) {
+	tests := []struct {
+		name      string
+		age       time.Duration
+		wantStale bool
+	}{
+		{"fresh", time.Minute, false},
+		{"older than ttl", DefaultStaleAfter + time.Minute, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newTestStore(t, "default")
+			require.NoError(t, store.Save(Snapshot{
+				ID:        secondProviderID,
+				Label:     secondProviderID,
+				UpdatedAt: time.Now().Add(-tt.age).Unix(),
+				// Stale is never persisted: a snapshot written as fresh would
+				// otherwise claim to be fresh forever.
+				Stale: false,
+			}))
+
+			loaded, err := store.Load()
+			require.NoError(t, err)
+			// A stale snapshot is still RETURNED, marked. Hiding it leaves the
+			// user with nothing where they previously had a number.
+			require.Len(t, loaded, 1)
+			assert.Equal(t, tt.wantStale, loaded[0].Stale)
+		})
+	}
+}
+
+func TestStoreConcurrentProvidersBothSurvive(t *testing.T) {
+	// Claude's snapshot is PUSHED by the statusLine ingester, possibly by
+	// several Claude sessions at once, and a second provider would have a
+	// writer of its own. One file per provider is what makes that safe; a
+	// shared file would lose one of these writes.
+	store := newTestStore(t, "default")
+
+	var wg sync.WaitGroup
+	for _, id := range []string{ProviderClaude, secondProviderID} {
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			for i := 0; i < 20; i++ {
+				assert.NoError(t, store.Save(Snapshot{ID: id, Label: id, UpdatedAt: time.Now().Unix()}))
+			}
+		}(id)
+	}
+	wg.Wait()
+
+	loaded, err := store.Load()
+	require.NoError(t, err)
+	require.Len(t, loaded, 2)
+	assert.Equal(t, ProviderClaude, loaded[0].ID)
+	assert.Equal(t, secondProviderID, loaded[1].ID)
+}
+
+func TestStoreCorruptFileDoesNotHideOtherProvider(t *testing.T) {
+	store := newTestStore(t, "default")
+	require.NoError(t, store.Save(Snapshot{ID: secondProviderID, Label: secondProviderID, UpdatedAt: time.Now().Unix()}))
+	require.NoError(t, os.WriteFile(filepath.Join(store.Dir(), ProviderClaude+".json"), []byte("{not json"), 0o644))
+
+	loaded, err := store.Load()
+	require.NoError(t, err)
+	require.Len(t, loaded, 2)
+
+	assert.Equal(t, ProviderClaude, loaded[0].ID)
+	assert.NotEmpty(t, loaded[0].Error, "a corrupt cache entry is reported, not silently dropped")
+	assert.Equal(t, secondProviderID, loaded[1].ID)
+	assert.Empty(t, loaded[1].Error)
+}
+
+func TestStoreWritesNoCredential(t *testing.T) {
+	store := newTestStore(t, "default")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", sentinelToken)
+	require.NoError(t, store.Save(Snapshot{
+		ID:        secondProviderID,
+		Label:     secondProviderID,
+		Windows:   []Window{{Kind: WindowSevenDay, Label: "7d", UsedPercentage: 22}},
+		UpdatedAt: time.Now().Unix(),
+	}))
+
+	entries, err := os.ReadDir(store.Dir())
+	require.NoError(t, err)
+	require.NotEmpty(t, entries)
+	for _, entry := range entries {
+		contents, err := os.ReadFile(filepath.Join(store.Dir(), entry.Name()))
+		require.NoError(t, err)
+		assert.NotContains(t, string(contents), sentinelToken)
+	}
+}
+
+func TestStoreDirIsPrivate(t *testing.T) {
+	store := newTestStore(t, "default")
+	require.NoError(t, store.Save(Snapshot{ID: secondProviderID, Label: secondProviderID, UpdatedAt: time.Now().Unix()}))
+
+	info, err := os.Stat(store.Dir())
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm())
+}
+
+func TestStoreProfilesAreIsolated(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	work, err := NewStore("work")
+	require.NoError(t, err)
+	personal, err := NewStore("personal")
+	require.NoError(t, err)
+
+	require.NoError(t, work.Save(Snapshot{ID: secondProviderID, Label: secondProviderID, UpdatedAt: time.Now().Unix()}))
+
+	loaded, err := personal.Load()
+	require.NoError(t, err)
+	assert.Empty(t, loaded)
+	assert.NotEqual(t, work.Dir(), personal.Dir())
+}
+
+func TestStoreLoadOnMissingDirIsEmptyNotAnError(t *testing.T) {
+	// The state before anything has ever been ingested or fetched. `usage` must
+	// print an empty report there, not fail.
+	store := newTestStore(t, "default")
+	loaded, err := store.Load()
+	require.NoError(t, err)
+	assert.Empty(t, loaded)
+	_, statErr := os.Stat(store.Dir())
+	assert.True(t, os.IsNotExist(statErr), "Load must not create the cache directory")
+}
+
+func TestStoreRejectsUnusableProviderID(t *testing.T) {
+	// The provider id becomes a filename. A traversal component in it would
+	// write outside the cache directory.
+	store := newTestStore(t, "default")
+	for _, id := range []string{"", "../escape", "a/b", strings.Repeat("x", 300)} {
+		assert.Error(t, store.Save(Snapshot{ID: id, UpdatedAt: time.Now().Unix()}), "id %q", id)
+	}
+}

--- a/internal/quota/testmain_test.go
+++ b/internal/quota/testmain_test.go
@@ -1,0 +1,33 @@
+package quota
+
+import (
+	"os"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(runTestMain(m))
+}
+
+// runTestMain holds the real body so the cleanup defer runs: TestMain calls
+// os.Exit, which does not run deferred functions.
+func runTestMain(m *testing.M) int {
+	// Isolate HOME+XDG so agent-deck path resolution lands in a temp dir, never
+	// the real ~/.cache/agent-deck (2026-06-04 data-loss incident).
+	// See internal/testutil/homeenv.go.
+	cleanupHome := testutil.IsolateHome()
+	defer cleanupHome()
+
+	// This package never shells out to tmux, but the repo-wide audit in
+	// internal/testutil/testmain_audit_test.go requires every TestMain to
+	// isolate the socket anyway: the guarantee is only worth anything if it
+	// holds unconditionally, and a package that grows a tmux call later must
+	// not have to remember. 2026-04-17 incident, see
+	// internal/testutil/tmuxenv.go.
+	cleanupTmux := testutil.IsolateTmuxSocket()
+	defer cleanupTmux()
+
+	return m.Run()
+}


### PR DESCRIPTION
## What problem does this solve?

agent-deck can already tell you that a Claude session's plan window is
exhausted — `internal/session/usagelimit.go` detects the rejection turn after
the fact — but it cannot tell you how much of the window is left before you get
there, and it cannot tell you when the window actually reopens. Its own comment
records that gap:

> KNOWN LIMITATION, accepted deliberately: this bounds the staleness but does
> not track the ACTUAL reset. The banner carries one ("resets 8:50pm (UTC)")
> and this does not read it [...] up to ~5h of false usage-limit

When several agents run in parallel, the subscription window — not the dollar
cost the cost dashboard tracks — is usually the thing that stops the work.

This adds `internal/quota` plus an `agent-deck usage` command that reports the
remaining Claude allowance from the provider's own numbers.

Related to Discussion #2082 ("Plan-usage (quota) display for Claude / Codex /
Gemini in the deck"), and specifically an answer to its open question #1 — see
the next section.

**This is PR 1 of 2.** It is the half with no network surface at all: model,
store, Claude statusLine parsing, ingest, and the `usage` command. A Z.ai/GLM
provider and `--refresh` follow in PR 2, which is stacked on this branch and
adds a provider file rather than changing anything here. PR 1 stands on its own:
if you want only the documented-source half, it is complete as it is.

## Why this change

Discussion #2082 by @hfreire proposes the fuller version of this (footer bar,
`/api/quota`, cost-dashboard section, session badge) and it is stalled on the
question its author put first:

> None of these three endpoints is a documented public API. [...] I would rather
> agree the shape here than open a PR and find out the maintainers do not want
> undocumented endpoints in the tree at all — that is the main question I am
> asking.

That question is unanswered, so this PR is deliberately the small, documented-
source slice of it rather than a competing design. I commented on #2082 before
writing any code:
https://github.com/asheshgoplani/agent-deck/discussions/2082#discussioncomment-18327949

For Claude there IS a supported shape, which is what makes this slice possible:
the `rate_limits` block in the JSON Claude Code pipes to a configured
`statusLine` command — documented at code.claude.com/docs/en/statusline. No
undocumented endpoint, no reading of `.credentials.json` or the macOS keychain,
no bearer replay. I checked every other candidate on this machine on 2026-09-07:
none of the 31 hook events carry `rate_limits`, there is no `claude usage`
subcommand, no OTel quota metric and no file under `~/.claude`. statusLine is the
only documented source, so an ingestion path is genuinely required — there is
nothing to piggyback on.

Design decisions worth flagging for review:

- **No estimation.** Nothing here derives a percentage from token counts. A
  locally computed estimate is a different number that happens to share a unit
  with the one the user asked for.
- **No synthesised reset times.** `ResetsAt` is a `*int64` precisely so "the
  provider said nothing" is representable. A zero would render as 1970 and a
  "now + 5h" would be a promise agent-deck cannot make.
- **No network.** Claude's quota is push-only: the snapshot arrives from whatever
  statusLine invocation last ran. `agent-deck usage` reads the cache and makes no
  request. That is also why a Claude snapshot goes stale simply because you are
  not running Claude — it is shown, marked `(stale)`, rather than dropped.
- **statusLine passthrough is mandatory, not a nicety.** Claude Code renders an
  empty stdout or a non-zero exit from a statusLine command as a *blank status
  line*, so an ingester that swallowed either would silently destroy a status
  line the user already had. `usage ingest claude -- <cmd>` forwards the same
  bytes, the command's stdout/stderr, and its exit status. `exec.Command` gets
  argv as separate arguments; there is no shell and no interpolation on that path.
- **Only `rate_limits` is decoded.** `transcript_path`, `cwd`, the prompt and the
  model are absent from the struct rather than decoded and ignored: a field that
  does not exist cannot later be logged, persisted, or appended to an error.
- **One cache file per provider.** Claude's snapshot is pushed by the ingester,
  possibly by several concurrent Claude sessions, and a future provider has a
  writer of its own. Separate files mean no lock and no lost update.
- **A failing provider is data, not a CLI failure.** A corrupt or unreadable
  cache entry is reported under its own id and never suppresses a provider that
  is working; `usage` still exits 0.

Explicitly out of scope, to keep this reviewable and to avoid claiming a surface
#2082's own PR 1 claims: the TUI status-bar segment, `/api/quota`, the cost
dashboard section, the session badge, and rewiring `usagelimit.go` to consume the
real `resets_at` (a valuable follow-up — that is the exact number its KNOWN
LIMITATION note says it lacks).

## User impact

New command, no change to any existing behaviour:

```
$ agent-deck usage
Claude  updated 2m ago
  5h       23.5%  resets in 2h13m
  7d       41.2%  resets in 3d5h
```

`--json` prints the same report for scripting. Claude quota requires opting in by
pointing `statusLine` at `agent-deck usage ingest claude` (README documents both
the plain and the wrap-your-existing-command form). Nothing is installed into the
user's `settings.json` automatically. A user who has not opted in sees one line
telling them how to.

## Evidence

Observed on this branch, in an isolated HOME, with a synthetic statusLine
payload (no live provider account involved):

    $ agent-deck usage
    No provider quota cached yet.
    Claude: wire `agent-deck usage ingest claude` into your statusLine.
    $ echo $?
    0

    $ echo '{"session_id":"x","cwd":"/private","rate_limits":{
              "five_hour":{"used_percentage":23.5,"resets_at":...},
              "seven_day":{"used_percentage":41.2,"resets_at":...}}}' \
        | agent-deck usage ingest claude          # prints nothing, exit 0
    $ agent-deck usage
    Claude  updated 0s ago
      5h       23.5%  resets in 2h13m
      7d       41.2%  resets in 3d5h
    $ echo $?
    0

`--json` on the same cache emits only `id`, `label`, `windows`, `updated_at`,
`stale` — the `cwd` and `session_id` from that payload are nowhere in the cache
file, which `TestUsageIngestClaudeStoresNothingButRateLimits` asserts.

End to end on a real machine, with the ingester actually wired into
`~/.claude/settings.json` and a live Claude Code session pushing the payload:

    $ agent-deck usage
    Claude  updated 1s ago
      5h        3.0%  resets in 4h35m
      7d       21.0%  resets in 1d7h

"updated 1s ago" is the statusLine invocation that ran a moment earlier; those
are provider-reported windows and provider-reported resets, not estimates.

That run was made from **inside** an agent-deck session, which is the case worth
confirming for this command: `usage` dispatches in `main()` and returns before
the nested-session guard that blocks a TUI launch, so it is usable exactly where
you would reach for it. A user who has not opted into the statusLine sees the
one-line hint instead, and `usage` still exits 0.

Sandboxed suite: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
→ every package passes except `internal/tmux`, and the bootstrap-leak sentinel in
`internal/testutil` that watches it, which fail under the full parallel run and
pass on re-run in isolation (`go test ./internal/tmux/ ./internal/testutil/` →
ok, 60s / 24s). They fail the same way on a clean `upstream/main` worktree, and
nothing in this branch touches the tmux layer.

One more thing worth knowing if you run the suite from inside an agent-deck
session: `cmd/agent-deck` fails unless `AGENTDECK_INSTANCE_ID` is unset, because
a test spawns `main()`, which then tries to resolve the inherited id as a parent
session. `env -u AGENTDECK_INSTANCE_ID go test ./cmd/agent-deck/` → ok. Also
pre-existing on `upstream/main`.

`golangci-lint run` (v2.13.2, whole repo) → 0 issues. `gofmt -l`, `go vet ./...`,
`go build ./...` clean.

Revert-check note: the new tests do not compile against `upstream/main` (the
`internal/quota` package does not exist there), so the whole-diff revert the
script attempts cannot run. Reverted per-hunk instead — removing the
"no rate_limits block" guard in `ParseStatusLine`:

    --- FAIL: TestParseStatusLineAbsentRateLimits/no_rate_limits_key
        panic: runtime error: invalid memory address or nil pointer dereference
            .../internal/quota/claude.go:77

That is the common case, not an edge one: a payload without `rate_limits` is
what Claude sends before the session's first API response, and permanently under
API-key, Bedrock and Vertex auth.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-5

**Prompt / session log (optional):** —

## What actually bothered you

My human asked (in French; translated):

"I run several Claude Code and Z.ai/GLM agents at once through Agent Deck. What
actually stops me is the provider's 5-hour and weekly subscription quota, not the
dollar cost. I want to see the real subscription limits in Agent Deck — not an
estimate derived from token counts — instead of opening provider dashboards or
running separate tools."

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

**On diff size (`self-check.sh` oversized WARN):** 1448 added lines across 10
files, of which ~808 are tests and ~640 production — a new package, a new
subcommand and its subprocess-level tests. It is over the 400-line guide and I
would rather say so than pretend otherwise. This is already the smaller of two
PRs: the Z.ai provider and every line of outbound-network code live in PR 2.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiXDy2qqQ6aLr7HV2jye1t

<!-- gate:ai=authored model=claude-opus-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `agent-deck usage` command to view remaining provider subscription quota.
  * Added human-readable and JSON output formats, including usage windows, reset times, and stale-data indicators.
  * Added Claude Code status-line ingestion to cache quota information and optionally forward command output unchanged.
  * Added profile-aware quota caching with protection for sensitive data and graceful handling of unavailable or corrupted entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->