### PR TITLE
feat(quota): add the Z.ai/GLM provider and `agent-deck usage --refresh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,9 +825,13 @@ $ agent-deck usage
 Claude  updated 2m ago
   5h       23.5%  resets in 2h14m
   7d       41.2%  resets in 3d6h
+Z.ai (pro)  updated 1m ago
+  5h        0.0%
+  7d       22.0%  resets in 4d3h
 ```
 
-`agent-deck usage --json` prints the same report for scripting.
+`agent-deck usage --json` prints the same report for scripting. `--refresh`
+forces a fetch for pull-based providers.
 
 **Claude** is read from the documented `rate_limits` block in the JSON Claude
 Code pipes to a `statusLine` command. Wire the ingester into
@@ -848,8 +852,12 @@ passed through and your command's output and exit status are forwarded verbatim:
 Only `rate_limits` is kept. The transcript path, cwd, prompt and model in that
 payload are never stored or printed.
 
-`agent-deck usage` itself makes no network request: it reads the cache the
-ingester wrote.
+**Z.ai / GLM Coding Plan** is read from the monitor endpoint the vendor's own
+coding plugin calls, on the host you configured in `ANTHROPIC_BASE_URL`, using
+`ANTHROPIC_AUTH_TOKEN`. There is no default host: if `ANTHROPIC_BASE_URL` is
+unset or does not point at a Z.ai host, the provider is skipped and no request
+is made. Run `agent-deck usage` inside a session where those variables are set
+(an agent-deck-launched session has already sourced its profile's env file).
 
 Snapshots are cached under `$XDG_CACHE_HOME/agent-deck/quota/<profile>/`. A
 snapshot older than the freshness bound is still shown, marked `(stale)` — a

--- a/README.md
+++ b/README.md
@@ -810,6 +810,51 @@ cost_line_template = "{cost_yesterday} yda | {cost_today} today | {cost_projecte
 
 Resolution chain: `profiles.<active>.costs.cost_line_template > [costs].cost_line_template > hardcoded "{cost_today} today"`. Setting the template to an empty string explicitly disables the segment.
 
+### Provider Quota (`agent-deck usage`)
+
+Cost tracking answers "how many dollars"; this answers "how much of my
+subscription is left". When you run several agents at once, the limit you hit
+first is usually the provider's 5-hour or weekly plan window, not a dollar
+budget.
+
+The numbers come from the providers themselves — nothing here is estimated from
+token counts.
+
+```
+$ agent-deck usage
+Claude  updated 2m ago
+  5h       23.5%  resets in 2h14m
+  7d       41.2%  resets in 3d6h
+```
+
+`agent-deck usage --json` prints the same report for scripting.
+
+**Claude** is read from the documented `rate_limits` block in the JSON Claude
+Code pipes to a `statusLine` command. Wire the ingester into
+`~/.claude/settings.json`:
+
+```json
+{"statusLine": {"type": "command", "command": "agent-deck usage ingest claude"}}
+```
+
+If you already have a status line, keep it by wrapping it — the same payload is
+passed through and your command's output and exit status are forwarded verbatim:
+
+```json
+{"statusLine": {"type": "command",
+                "command": "agent-deck usage ingest claude -- your-existing-command"}}
+```
+
+Only `rate_limits` is kept. The transcript path, cwd, prompt and model in that
+payload are never stored or printed.
+
+`agent-deck usage` itself makes no network request: it reads the cache the
+ingester wrote.
+
+Snapshots are cached under `$XDG_CACHE_HOME/agent-deck/quota/<profile>/`. A
+snapshot older than the freshness bound is still shown, marked `(stale)` — a
+Claude snapshot only refreshes while Claude is actually running.
+
 ### Socket Isolation (v1.7.50+)
 
 Run agent-deck on its own tmux server so it never touches your interactive tmux's config, bindings, or sessions. Opt-in via a single config line:

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -99,7 +99,7 @@ func recordCLITelemetry(subcommand string, rest []string) {
 	case "add", "list", "ls", "remove", "rm", "rename", "mv", "status", "profile", "update",
 		"session", "fleet", "mcp", "plugin", "skill", "mcp-proxy", "group", "try", "launch",
 		"accounts", "conductor", "agents", "agent", "telegram-doctor", "watcher", "openclaw", "oc",
-		"remote", "worktree", "wt", "costs", "web", "uninstall", "migrate-paths", "hooks",
+		"remote", "worktree", "wt", "costs", "usage", "web", "uninstall", "migrate-paths", "hooks",
 		"codex-hooks", "gemini-hooks", "hermes-hooks", "cursor-hooks", "deepseek", "feedback", "creds-refresh":
 	default:
 		return
@@ -432,6 +432,9 @@ func main() {
 			return
 		case "costs":
 			handleCosts(profile, args[1:])
+			return
+		case "usage":
+			handleUsage(profile, args[1:])
 			return
 		case "web":
 			webEnabled = true
@@ -1065,7 +1068,7 @@ var commandRegistry = map[string]bool{
 	"group": true, "try": true, "launch": true, "conductor": true,
 	"agents": true, "agent": true,
 	"telegram-doctor": true, "watcher": true, "openclaw": true, "oc": true,
-	"remote": true, "remote-agent": true, "worktree": true, "wt": true, "costs": true, "web": true,
+	"remote": true, "remote-agent": true, "worktree": true, "wt": true, "costs": true, "usage": true, "web": true,
 	"uninstall": true, "migrate-paths": true, "hook-handler": true,
 	"codex-notify": true, "hooks": true, "codex-hooks": true, "gemini-hooks": true,
 	"hermes-hooks": true, "cursor-hooks": true, "deepseek": true, "notify-daemon": true,
@@ -3686,6 +3689,7 @@ func printHelp() {
 	fmt.Println("  deepseek         Inspect the DeepSeek Harness (dsh) integration")
 	fmt.Println("  group            Manage groups")
 	fmt.Println("  worktree, wt     Manage git worktrees")
+	fmt.Println("  usage            Show remaining provider subscription quota")
 	fmt.Println("  web              Start TUI with web UI server running alongside")
 	fmt.Println("  remote           Manage remote agent-deck instances")
 	fmt.Println("  conductor        Manage conductor meta-agent orchestration")

--- a/cmd/agent-deck/usage_cmd.go
+++ b/cmd/agent-deck/usage_cmd.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"strings"
@@ -14,7 +16,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
-const usageUsage = `Usage: agent-deck usage [--json]
+const usageUsage = `Usage: agent-deck usage [--json] [--refresh]
        agent-deck usage ingest claude [-- <command> [args...]]
 
 Show how much of each provider's subscription quota is left, from the
@@ -22,6 +24,7 @@ provider's own numbers.
 
 Options:
   --json      Print the report as JSON
+  --refresh   Force a fetch for pull-based providers, ignoring the cache
 
 Subcommands:
   ingest claude   Read a Claude Code statusLine payload on stdin and cache the
@@ -40,6 +43,7 @@ func handleUsage(profile string, args []string) {
 	flags.SetOutput(os.Stdout)
 	flags.Usage = func() { fmt.Println(usageUsage) }
 	asJSON := flags.Bool("json", false, "print the report as JSON")
+	refresh := flags.Bool("refresh", false, "force a fetch for pull-based providers")
 	if len(args) > 0 && args[0] == "help" {
 		flags.Usage()
 		return
@@ -57,7 +61,7 @@ func handleUsage(profile string, args []string) {
 	}
 
 	store := openQuotaStore(profile)
-	report := quota.Report{Providers: collectQuota(store)}
+	report := quota.Report{Providers: collectQuota(store, *refresh)}
 
 	if *asJSON {
 		encoded, err := json.MarshalIndent(report, "", "  ")
@@ -91,27 +95,85 @@ func openQuotaStore(profile string) *quota.Store {
 	return store
 }
 
-// collectQuota reads the cached snapshots.
+// collectQuota merges what is cached with a live fetch of the pull-based
+// providers.
 //
 // Claude is PUSH-only: its snapshot arrives from whatever statusLine invocation
-// last ran, and there is no endpoint to ask. So this reads the cache and
-// nothing else — `agent-deck usage` makes no network request. A pull-based
-// provider would fetch here, on this user-triggered path, and never on a TUI
-// render path.
-//
-// A cache that cannot be read at all is a warning on stderr, not a failure: the
-// providers that did load still print.
-func collectQuota(store *quota.Store) []quota.Snapshot {
+// last ran, and there is no endpoint to ask. Z.ai is PULL-based, so it is
+// fetched when its cache is older than the store's staleness bound, or on
+// --refresh. That split is what gives --refresh a real meaning instead of being
+// a flag that sometimes does nothing.
+func collectQuota(store *quota.Store, refresh bool) []quota.Snapshot {
 	cached, err := store.Load()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: reading quota cache: %v\n", err)
 	}
-	// Never nil: `--json` must emit "providers": [] rather than null so a
-	// consumer can range over it without a nil check.
-	if cached == nil {
-		return []quota.Snapshot{}
+
+	byID := make(map[string]quota.Snapshot, len(cached))
+	order := make([]string, 0, len(cached)+1)
+	for _, snapshot := range cached {
+		byID[snapshot.ID] = snapshot
+		order = append(order, snapshot.ID)
 	}
-	return cached
+
+	existing, haveZai := byID[quota.ProviderZai]
+	if refresh || !haveZai || existing.Stale {
+		if fetched, ok := fetchZaiSnapshot(existing, haveZai); ok {
+			if _, known := byID[quota.ProviderZai]; !known {
+				order = append(order, quota.ProviderZai)
+			}
+			byID[quota.ProviderZai] = fetched
+			if fetched.Error == "" {
+				if err := store.Save(fetched); err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: caching Z.ai quota: %v\n", err)
+				}
+			}
+		}
+	}
+
+	providers := make([]quota.Snapshot, 0, len(order))
+	for _, id := range order {
+		providers = append(providers, byID[id])
+	}
+	return providers
+}
+
+// fetchZaiSnapshot performs the one outbound request this feature makes.
+//
+// It is user-triggered (only from `agent-deck usage`), bounded by an explicit
+// client timeout, cached, and never on a TUI render path. The destination is
+// the host the user configured in ANTHROPIC_BASE_URL; there is no hardcoded
+// fallback, so a machine that never configured Z.ai generates no traffic.
+//
+// ok is false when the provider is simply not configured — that is not a
+// failure worth a line in the output, it is a provider the user does not use.
+//
+// A fetch failure is NOT persisted: the cache holds numbers, and overwriting a
+// good snapshot with a transient timeout would turn one bad minute into a
+// permanently blank provider. The last known numbers are kept and shown with
+// the failure attached.
+func fetchZaiSnapshot(cachedSnapshot quota.Snapshot, haveCached bool) (quota.Snapshot, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), quota.DefaultZaiTimeout)
+	defer cancel()
+
+	client := &http.Client{Timeout: quota.DefaultZaiTimeout}
+	fetched, err := quota.FetchZai(ctx, client)
+	switch {
+	case err == nil:
+		return fetched, true
+	case errors.Is(err, quota.ErrNotConfigured):
+		return quota.Snapshot{}, false
+	case haveCached:
+		cachedSnapshot.Error = err.Error()
+		return cachedSnapshot, true
+	default:
+		return quota.Snapshot{
+			ID:        quota.ProviderZai,
+			Label:     quota.ProviderLabel(quota.ProviderZai),
+			Error:     err.Error(),
+			UpdatedAt: time.Now().Unix(),
+		}, true
+	}
 }
 
 // renderUsage is the human rendering. It is a pure function of the report and a
@@ -119,12 +181,16 @@ func collectQuota(store *quota.Store) []quota.Snapshot {
 func renderUsage(report quota.Report, now time.Time) string {
 	if len(report.Providers) == 0 {
 		return "No provider quota cached yet.\n" +
-			"Claude: wire `agent-deck usage ingest claude` into your statusLine.\n"
+			"Claude: wire `agent-deck usage ingest claude` into your statusLine.\n" +
+			"Z.ai:   run this inside a session whose ANTHROPIC_BASE_URL/ANTHROPIC_AUTH_TOKEN are set.\n"
 	}
 
 	var out strings.Builder
 	for _, provider := range report.Providers {
 		header := provider.Label
+		if provider.Plan != "" {
+			header += " (" + provider.Plan + ")"
+		}
 		if provider.Error != "" {
 			// The failing provider names itself, so a reader can tell which one
 			// is out without inferring it from which line went missing.

--- a/cmd/agent-deck/usage_cmd.go
+++ b/cmd/agent-deck/usage_cmd.go
@@ -1,0 +1,308 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/quota"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+const usageUsage = `Usage: agent-deck usage [--json]
+       agent-deck usage ingest claude [-- <command> [args...]]
+
+Show how much of each provider's subscription quota is left, from the
+provider's own numbers.
+
+Options:
+  --json      Print the report as JSON
+
+Subcommands:
+  ingest claude   Read a Claude Code statusLine payload on stdin and cache the
+                  rate_limits it carries. With a trailing "-- <command>", the
+                  same bytes are passed to that command and its output and exit
+                  status are forwarded, so an existing statusLine keeps working.`
+
+// handleUsage is the `agent-deck usage` entry point.
+func handleUsage(profile string, args []string) {
+	if len(args) > 0 && args[0] == "ingest" {
+		handleUsageIngest(profile, args[1:])
+		return
+	}
+
+	flags := flag.NewFlagSet("usage", flag.ContinueOnError)
+	flags.SetOutput(os.Stdout)
+	flags.Usage = func() { fmt.Println(usageUsage) }
+	asJSON := flags.Bool("json", false, "print the report as JSON")
+	if len(args) > 0 && args[0] == "help" {
+		flags.Usage()
+		return
+	}
+	if err := flags.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return
+		}
+		os.Exit(2)
+	}
+	if flags.NArg() > 0 {
+		fmt.Fprintf(os.Stderr, "Unknown usage argument: %s\n", flags.Arg(0))
+		fmt.Fprintln(os.Stderr, usageUsage)
+		os.Exit(2)
+	}
+
+	store := openQuotaStore(profile)
+	report := quota.Report{Providers: collectQuota(store)}
+
+	if *asJSON {
+		encoded, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: encoding usage report: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(encoded))
+		return
+	}
+	fmt.Print(renderUsage(report, time.Now()))
+	// Exit 0 even when a provider reported an error: a provider outage is data
+	// about that provider, not a failure of the command, and a script gating on
+	// the exit status must not read one as the other.
+}
+
+// openQuotaStore resolves the profile the same way every other on-disk-state
+// command does. ResolveProfileForStorage carries the #1790 guard that stops a
+// CLAUDE_CONFIG_DIR-inferred profile from materialising a phantom directory.
+func openQuotaStore(profile string) *quota.Store {
+	resolved, err := session.ResolveProfileForStorage(profile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: resolving profile: %v\n", err)
+		os.Exit(1)
+	}
+	store, err := quota.NewStore(resolved)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: opening quota cache: %v\n", err)
+		os.Exit(1)
+	}
+	return store
+}
+
+// collectQuota reads the cached snapshots.
+//
+// Claude is PUSH-only: its snapshot arrives from whatever statusLine invocation
+// last ran, and there is no endpoint to ask. So this reads the cache and
+// nothing else — `agent-deck usage` makes no network request. A pull-based
+// provider would fetch here, on this user-triggered path, and never on a TUI
+// render path.
+//
+// A cache that cannot be read at all is a warning on stderr, not a failure: the
+// providers that did load still print.
+func collectQuota(store *quota.Store) []quota.Snapshot {
+	cached, err := store.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: reading quota cache: %v\n", err)
+	}
+	// Never nil: `--json` must emit "providers": [] rather than null so a
+	// consumer can range over it without a nil check.
+	if cached == nil {
+		return []quota.Snapshot{}
+	}
+	return cached
+}
+
+// renderUsage is the human rendering. It is a pure function of the report and a
+// clock so the shape can be pinned by a test without a subprocess.
+func renderUsage(report quota.Report, now time.Time) string {
+	if len(report.Providers) == 0 {
+		return "No provider quota cached yet.\n" +
+			"Claude: wire `agent-deck usage ingest claude` into your statusLine.\n"
+	}
+
+	var out strings.Builder
+	for _, provider := range report.Providers {
+		header := provider.Label
+		if provider.Error != "" {
+			// The failing provider names itself, so a reader can tell which one
+			// is out without inferring it from which line went missing.
+			fmt.Fprintf(&out, "%s  unavailable: %s\n", header, provider.Error)
+			if len(provider.Windows) == 0 {
+				continue
+			}
+			// Last known numbers are still worth having, clearly marked.
+			fmt.Fprintf(&out, "%s  last known %s\n", header, describeAge(provider, now))
+		} else {
+			fmt.Fprintf(&out, "%s  %s\n", header, describeAge(provider, now))
+		}
+		for _, window := range provider.Windows {
+			fmt.Fprintf(&out, "  %-6s %6.1f%%%s\n", window.Label, window.UsedPercentage, describeReset(window.ResetsAt, now))
+		}
+	}
+	return out.String()
+}
+
+// describeAge says when the snapshot was taken, and says "stale" when the store
+// judged it past its freshness bound. A stale number is shown rather than
+// hidden — dropping it would leave the user with less than they had — but it is
+// never presented as current.
+func describeAge(provider quota.Snapshot, now time.Time) string {
+	marker := ""
+	if provider.Stale {
+		marker = " (stale)"
+	}
+	if provider.UpdatedAt <= 0 {
+		return "updated at an unknown time (stale)"
+	}
+	age := now.Sub(time.Unix(provider.UpdatedAt, 0))
+	if age < 0 {
+		age = 0
+	}
+	return "updated " + shortDuration(age) + " ago" + marker
+}
+
+// describeReset renders the provider's own reset time. Nothing is printed when
+// the provider did not report one: an invented "resets in ~5h" would be a
+// promise agent-deck is in no position to make.
+func describeReset(resetsAt *int64, now time.Time) string {
+	if resetsAt == nil {
+		return ""
+	}
+	remaining := time.Unix(*resetsAt, 0).Sub(now)
+	if remaining <= 0 {
+		return "  window has reset"
+	}
+	return "  resets in " + shortDuration(remaining)
+}
+
+func shortDuration(d time.Duration) string {
+	switch {
+	case d >= 24*time.Hour:
+		return fmt.Sprintf("%dd%dh", int(d.Hours())/24, int(d.Hours())%24)
+	case d >= time.Hour:
+		return fmt.Sprintf("%dh%dm", int(d.Hours()), int(d.Minutes())%60)
+	case d >= time.Minute:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	default:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+}
+
+const usageIngestUsage = `Usage: agent-deck usage ingest claude [-- <command> [args...]]
+
+Read a Claude Code statusLine payload on stdin and cache the rate_limits it
+carries. Only rate_limits is kept: the transcript path, cwd, prompt and model in
+that payload are never stored or printed.
+
+Wire it into ~/.claude/settings.json:
+
+  "statusLine": {"type": "command", "command": "agent-deck usage ingest claude"}
+
+If you already have a statusLine command, keep it by wrapping it:
+
+  "statusLine": {"type": "command",
+                 "command": "agent-deck usage ingest claude -- your-existing-command"}`
+
+// handleUsageIngest implements `agent-deck usage ingest claude`.
+func handleUsageIngest(profile string, args []string) {
+	if len(args) == 0 || helpRequested(args) || args[0] == "help" {
+		fmt.Println(usageIngestUsage)
+		return
+	}
+	if args[0] != "claude" {
+		fmt.Fprintf(os.Stderr, "Unknown ingest source: %s\n", args[0])
+		fmt.Fprintln(os.Stderr, usageIngestUsage)
+		os.Exit(2)
+	}
+	rest := args[1:]
+	if helpRequested(rest) || (len(rest) > 0 && rest[0] == "help") {
+		fmt.Println(usageIngestUsage)
+		return
+	}
+
+	var wrapped []string
+	if len(rest) > 0 {
+		if rest[0] != "--" {
+			fmt.Fprintf(os.Stderr, "Unknown ingest argument: %s\n", rest[0])
+			fmt.Fprintln(os.Stderr, usageIngestUsage)
+			os.Exit(2)
+		}
+		wrapped = rest[1:]
+	}
+
+	// The payload is read once and reused, because stdin cannot be replayed and
+	// the wrapped command must receive exactly what Claude sent.
+	payload, err := readStatusLinePayload(os.Stdin)
+	if err != nil {
+		// Claude Code renders a statusLine command's failure as a BLANK status
+		// line, so a loud failure here would replace the user's status bar with
+		// nothing. The diagnostic goes to stderr and the wrapped command still
+		// runs.
+		fmt.Fprintf(os.Stderr, "agent-deck: reading statusLine payload: %v\n", err)
+	} else if snapshot, ok, parseErr := quota.ParseStatusLine(strings.NewReader(string(payload))); parseErr != nil {
+		fmt.Fprintf(os.Stderr, "agent-deck: parsing statusLine payload: %v\n", parseErr)
+	} else if ok {
+		if saveErr := openQuotaStore(profile).Save(snapshot); saveErr != nil {
+			fmt.Fprintf(os.Stderr, "agent-deck: caching Claude quota: %v\n", saveErr)
+		}
+	}
+
+	if len(wrapped) == 0 {
+		// Nothing is printed. A user with no statusLine before gets no status
+		// line now, which is the only non-surprising outcome.
+		return
+	}
+	runWrappedStatusLine(wrapped, payload)
+}
+
+// maxIngestBytes bounds the stdin read at the same size the parser accepts, so
+// an oversized payload is refused rather than buffered.
+const maxIngestBytes = 1 << 20
+
+func readStatusLinePayload(stdin *os.File) ([]byte, error) {
+	limited := make([]byte, 0, 4096)
+	buffer := make([]byte, 4096)
+	for {
+		n, err := stdin.Read(buffer)
+		limited = append(limited, buffer[:n]...)
+		if len(limited) > maxIngestBytes {
+			return limited[:maxIngestBytes], errors.New("statusLine payload exceeds size cap")
+		}
+		if err != nil {
+			if errors.Is(err, os.ErrClosed) || err.Error() == "EOF" {
+				return limited, nil
+			}
+			return limited, err
+		}
+		if n == 0 {
+			return limited, nil
+		}
+	}
+}
+
+// runWrappedStatusLine runs the user's own statusLine command with the same
+// bytes on stdin and forwards its stdout, stderr and exit status.
+//
+// argv comes straight from os.Args and is passed to exec.Command as separate
+// arguments: there is no shell and no string interpolation anywhere on this
+// path, so nothing in the payload or the settings file can become a command.
+func runWrappedStatusLine(argv []string, payload []byte) {
+	// #nosec G204 G702 -- argv is the user's own statusLine command, taken verbatim
+	// from their settings.json via os.Args and passed as separate arguments.
+	// There is no shell and no string interpolation on this path, so neither
+	// the payload nor anything Claude sends can become a command.
+	command := exec.Command(argv[0], argv[1:]...)
+	command.Stdin = strings.NewReader(string(payload))
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	if err := command.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			os.Exit(exitErr.ExitCode())
+		}
+		fmt.Fprintf(os.Stderr, "agent-deck: running statusLine command: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/agent-deck/usage_cmd_test.go
+++ b/cmd/agent-deck/usage_cmd_test.go
@@ -1,0 +1,317 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/quota"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// usageSentinelToken stands in for a provider credential in the environment: it
+// is exported into every `usage` subprocess so the JSON and human renderings
+// can be checked for a leak against something that would only be there by
+// mistake.
+const usageSentinelToken = "SENTINEL-USAGE-TOKEN-do-not-leak"
+
+type usageResult struct {
+	stdout   string
+	stderr   string
+	exitCode int
+}
+
+// runUsageCLI runs `agent-deck <args...>` in a subprocess with an isolated HOME
+// and XDG tree, so a test never reads or writes the developer's real cache.
+func runUsageCLI(t *testing.T, home string, stdin string, args ...string) usageResult {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmdArgs := append([]string{"-test.run=^TestUsageHelperProcess$", "--"}, args...)
+	cmd := exec.CommandContext(ctx, os.Args[0], cmdArgs...)
+	cmd.Env = append(os.Environ(),
+		"AGENT_DECK_USAGE_HELPER=1",
+		"AGENT_DECK_TASK6_HELPER_PROCESS=1",
+		"HOME="+home,
+		"XDG_CONFIG_HOME="+filepath.Join(home, ".config"),
+		"XDG_CACHE_HOME="+filepath.Join(home, ".cache"),
+		"XDG_DATA_HOME="+filepath.Join(home, ".local", "share"),
+		"XDG_STATE_HOME="+filepath.Join(home, ".local", "state"),
+		"AGENTDECK_PROFILE=",
+		"CLAUDE_CONFIG_DIR=",
+		"ANTHROPIC_AUTH_TOKEN="+usageSentinelToken,
+	)
+	cmd.Stdin = strings.NewReader(stdin)
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	require.NoError(t, ctx.Err(), "usage command did not return promptly")
+
+	result := usageResult{stdout: stdout.String(), stderr: stderr.String()}
+	var exitErr *exec.ExitError
+	switch {
+	case err == nil:
+	case asExitError(err, &exitErr):
+		result.exitCode = exitErr.ExitCode()
+	default:
+		t.Fatalf("running usage: %v\nstdout:%s\nstderr:%s", err, result.stdout, result.stderr)
+	}
+	return result
+}
+
+func asExitError(err error, target **exec.ExitError) bool {
+	exitErr, ok := err.(*exec.ExitError)
+	if ok {
+		*target = exitErr
+	}
+	return ok
+}
+
+func TestUsageHelperProcess(t *testing.T) {
+	if os.Getenv("AGENT_DECK_USAGE_HELPER") != "1" {
+		return
+	}
+	separator := 0
+	for i, arg := range os.Args {
+		if arg == "--" {
+			separator = i
+			break
+		}
+	}
+	os.Args = append([]string{"agent-deck"}, os.Args[separator+1:]...)
+	main()
+	// Exit rather than return: letting the test framework resume would append
+	// its own "PASS" to stdout, and the passthrough assertions below compare
+	// the statusLine output byte for byte.
+	os.Exit(0)
+}
+
+// usageHelperProfile is the profile the helper subprocess resolves to. This
+// package's TestMain forces AGENTDECK_PROFILE=_test (2025-12-11 incident: tests
+// overwrote production sessions) and that runs inside the helper too, so the
+// cache lands under _test rather than default.
+const usageHelperProfile = "_test"
+
+// seedSnapshot writes a provider file straight into the profile's quota cache,
+// standing in for an earlier ingest or fetch.
+func seedSnapshot(t *testing.T, home, profile string, snapshot quota.Snapshot) {
+	t.Helper()
+	dir := filepath.Join(home, ".cache", "agent-deck", "quota", profile)
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	encoded, err := json.Marshal(snapshot)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, snapshot.ID+".json"), encoded, 0o644))
+}
+
+func freshClaudeSnapshot() quota.Snapshot {
+	resets := time.Now().Add(2 * time.Hour).Unix()
+	return quota.Snapshot{
+		ID:    quota.ProviderClaude,
+		Label: "Claude",
+		Windows: []quota.Window{
+			{Kind: quota.WindowFiveHour, Label: "5h", UsedPercentage: 23.5, ResetsAt: &resets},
+			{Kind: quota.WindowSevenDay, Label: "7d", UsedPercentage: 41.2},
+		},
+		UpdatedAt: time.Now().Unix(),
+	}
+}
+
+func TestUsageJSONShapeIsStable(t *testing.T) {
+	home := t.TempDir()
+	seedSnapshot(t, home, usageHelperProfile, freshClaudeSnapshot())
+
+	result := runUsageCLI(t, home, "", "usage", "--json")
+	require.Equal(t, 0, result.exitCode, result.stderr)
+
+	var report quota.Report
+	require.NoError(t, json.Unmarshal([]byte(result.stdout), &report))
+	require.Len(t, report.Providers, 1)
+
+	claude := report.Providers[0]
+	assert.Equal(t, "claude", claude.ID)
+	assert.Equal(t, "Claude", claude.Label)
+	assert.False(t, claude.Stale)
+	require.Len(t, claude.Windows, 2)
+	assert.Equal(t, quota.WindowFiveHour, claude.Windows[0].Kind)
+	assert.Equal(t, "5h", claude.Windows[0].Label)
+	assert.Equal(t, 23.5, claude.Windows[0].UsedPercentage)
+	assert.NotNil(t, claude.Windows[0].ResetsAt)
+	// A window the provider gave no reset for must not acquire one.
+	assert.Nil(t, claude.Windows[1].ResetsAt)
+
+	// The field names are the contract for anything scripting against this.
+	var generic map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.stdout), &generic))
+	providers, ok := generic["providers"].([]any)
+	require.True(t, ok, "providers key must be present: %s", result.stdout)
+	first, ok := providers[0].(map[string]any)
+	require.True(t, ok)
+	for _, key := range []string{"id", "label", "windows", "updated_at", "stale"} {
+		assert.Contains(t, first, key)
+	}
+}
+
+func TestUsageJSONWithEmptyCacheStillHasProvidersKey(t *testing.T) {
+	home := t.TempDir()
+	result := runUsageCLI(t, home, "", "usage", "--json")
+	require.Equal(t, 0, result.exitCode, result.stderr)
+
+	var generic map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.stdout), &generic))
+	providers, ok := generic["providers"]
+	require.True(t, ok, "providers key must be present even with nothing cached: %s", result.stdout)
+	assert.NotNil(t, providers, "providers must be [] not null so consumers can range over it")
+}
+
+func TestUsageOutputCarriesNoCredential(t *testing.T) {
+	home := t.TempDir()
+	seedSnapshot(t, home, usageHelperProfile, freshClaudeSnapshot())
+
+	for _, args := range [][]string{{"usage"}, {"usage", "--json"}} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			result := runUsageCLI(t, home, "", args...)
+			assert.NotContains(t, result.stdout, usageSentinelToken)
+			assert.NotContains(t, result.stderr, usageSentinelToken)
+		})
+	}
+}
+
+func TestUsageProviderFailureDoesNotSuppressOthers(t *testing.T) {
+	// The isolation requirement: one provider going wrong must never blank out
+	// a provider that is working. A corrupt cache entry is the cheapest way to
+	// produce a genuine per-provider failure. The id is one this build does not
+	// know, which also pins the label fallback: an entry written by a newer
+	// build must still be shown, under its own id, rather than disappearing.
+	home := t.TempDir()
+	seedSnapshot(t, home, usageHelperProfile, freshClaudeSnapshot())
+	dir := filepath.Join(home, ".cache", "agent-deck", "quota", usageHelperProfile)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "some-other-provider.json"), []byte("{not json"), 0o644))
+
+	result := runUsageCLI(t, home, "", "usage")
+	// A failing provider is data, not a CLI failure: a script that checks the
+	// exit status must not see one provider's outage as `usage` being broken.
+	require.Equal(t, 0, result.exitCode, result.stderr)
+	assert.Contains(t, result.stdout, "some-other-provider")
+	assert.Contains(t, result.stdout, "unavailable")
+	// ...and Claude still prints its numbers.
+	assert.Contains(t, result.stdout, "Claude")
+	assert.Contains(t, result.stdout, "23.5%")
+}
+
+func TestUsageMarksStaleSnapshot(t *testing.T) {
+	home := t.TempDir()
+	stale := freshClaudeSnapshot()
+	stale.UpdatedAt = time.Now().Add(-24 * time.Hour).Unix()
+	seedSnapshot(t, home, usageHelperProfile, stale)
+
+	result := runUsageCLI(t, home, "", "usage")
+	require.Equal(t, 0, result.exitCode, result.stderr)
+	// Shown, but never presented as current.
+	assert.Contains(t, result.stdout, "23.5%")
+	assert.Contains(t, result.stdout, "stale")
+}
+
+func TestUsageReadsTheSelectedProfilesCache(t *testing.T) {
+	home := t.TempDir()
+	work := freshClaudeSnapshot()
+	work.Windows[0].UsedPercentage = 77.7
+	seedSnapshot(t, home, "work", work)
+
+	inWork := runUsageCLI(t, home, "", "-p", "work", "usage")
+	require.Equal(t, 0, inWork.exitCode, inWork.stderr)
+	assert.Contains(t, inWork.stdout, "77.7%")
+
+	inDefault := runUsageCLI(t, home, "", "-p", "default", "usage")
+	require.Equal(t, 0, inDefault.exitCode, inDefault.stderr)
+	assert.NotContains(t, inDefault.stdout, "77.7%")
+}
+
+const usageStatusLinePayload = `{"session_id":"abc","cwd":"/home/someone/private",` +
+	`"rate_limits":{"five_hour":{"used_percentage":31.5,"resets_at":1738425600}}}`
+
+func TestUsageIngestClaudeWritesCacheAndPrintsNothing(t *testing.T) {
+	home := t.TempDir()
+
+	result := runUsageCLI(t, home, usageStatusLinePayload, "usage", "ingest", "claude")
+	require.Equal(t, 0, result.exitCode, result.stderr)
+	// Without a wrapped command there was no status line before, so emitting
+	// anything would put text on the user's status bar that they did not ask for.
+	assert.Empty(t, result.stdout)
+
+	shown := runUsageCLI(t, home, "", "usage")
+	require.Equal(t, 0, shown.exitCode, shown.stderr)
+	assert.Contains(t, shown.stdout, "31.5%")
+}
+
+func TestUsageIngestClaudePassesPayloadThroughToWrappedCommand(t *testing.T) {
+	// Claude Code treats empty stdout or a non-zero exit from a statusLine
+	// command as "blank status line". An ingester that swallowed either would
+	// silently destroy a status line the user already had, so the wrapped
+	// command gets the same bytes and its stdout and exit status are forwarded.
+	home := t.TempDir()
+
+	result := runUsageCLI(t, home, usageStatusLinePayload,
+		"usage", "ingest", "claude", "--", "cat")
+	require.Equal(t, 0, result.exitCode, result.stderr)
+	assert.Equal(t, usageStatusLinePayload, result.stdout)
+
+	shown := runUsageCLI(t, home, "", "usage")
+	assert.Contains(t, shown.stdout, "31.5%")
+}
+
+func TestUsageIngestClaudeForwardsWrappedExitStatus(t *testing.T) {
+	home := t.TempDir()
+
+	result := runUsageCLI(t, home, usageStatusLinePayload,
+		"usage", "ingest", "claude", "--", "sh", "-c", "printf custom-line; exit 3")
+	assert.Equal(t, 3, result.exitCode)
+	assert.Equal(t, "custom-line", result.stdout)
+}
+
+func TestUsageIngestClaudeStoresNothingButRateLimits(t *testing.T) {
+	home := t.TempDir()
+	require.Equal(t, 0, runUsageCLI(t, home, usageStatusLinePayload, "usage", "ingest", "claude").exitCode)
+
+	cached, err := os.ReadFile(filepath.Join(home, ".cache", "agent-deck", "quota", usageHelperProfile, "claude.json"))
+	require.NoError(t, err)
+	assert.NotContains(t, string(cached), "/home/someone/private")
+	assert.NotContains(t, string(cached), "session_id")
+}
+
+func TestUsageIngestClaudeWithoutRateLimitsIsNotAnError(t *testing.T) {
+	// The normal state before the session's first API response.
+	home := t.TempDir()
+	result := runUsageCLI(t, home, `{"session_id":"abc"}`, "usage", "ingest", "claude", "--", "echo", "my-status")
+	require.Equal(t, 0, result.exitCode, result.stderr)
+	assert.Equal(t, "my-status\n", result.stdout)
+}
+
+func TestUsageHelpIsUsageOnly(t *testing.T) {
+	home := t.TempDir()
+	for _, args := range [][]string{
+		{"usage", "--help"},
+		{"usage", "-h"},
+		{"usage", "help"},
+		{"usage", "ingest", "--help"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			result := runUsageCLI(t, home, "", args...)
+			require.Equal(t, 0, result.exitCode, result.stderr)
+			assert.Contains(t, result.stdout, "Usage: agent-deck usage")
+		})
+	}
+}
+
+func TestUsageIsRegisteredAndDispatched(t *testing.T) {
+	// extractProfileFlag stops honoring the global -p at the first registry
+	// token, so registration is what makes `agent-deck -p work usage` parse.
+	assert.True(t, commandRegistry["usage"])
+}

--- a/cmd/agent-deck/usage_cmd_test.go
+++ b/cmd/agent-deck/usage_cmd_test.go
@@ -15,10 +15,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// usageSentinelToken stands in for a provider credential in the environment: it
-// is exported into every `usage` subprocess so the JSON and human renderings
-// can be checked for a leak against something that would only be there by
-// mistake.
+// usageSentinelToken stands in for the user's Z.ai credential: it is exported
+// into every `usage` subprocess so the JSON and human renderings can be checked
+// for a leak against something that would only be there by mistake.
 const usageSentinelToken = "SENTINEL-USAGE-TOKEN-do-not-leak"
 
 type usageResult struct {
@@ -29,6 +28,9 @@ type usageResult struct {
 
 // runUsageCLI runs `agent-deck <args...>` in a subprocess with an isolated HOME
 // and XDG tree, so a test never reads or writes the developer's real cache.
+// ANTHROPIC_BASE_URL is cleared on purpose: `usage` must reach no network in
+// the suite, and an unconfigured Z.ai provider is exactly the state that
+// guarantees it.
 func runUsageCLI(t *testing.T, home string, stdin string, args ...string) usageResult {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -46,6 +48,7 @@ func runUsageCLI(t *testing.T, home string, stdin string, args ...string) usageR
 		"XDG_STATE_HOME="+filepath.Join(home, ".local", "state"),
 		"AGENTDECK_PROFILE=",
 		"CLAUDE_CONFIG_DIR=",
+		"ANTHROPIC_BASE_URL=",
 		"ANTHROPIC_AUTH_TOKEN="+usageSentinelToken,
 	)
 	cmd.Stdin = strings.NewReader(stdin)

--- a/internal/quota/claude.go
+++ b/internal/quota/claude.go
@@ -1,0 +1,100 @@
+package quota
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+)
+
+// maxStatusLineBytes caps the statusLine payload read from stdin.
+//
+// The documented payload is a few hundred bytes of session metadata; 1 MiB is
+// three orders of magnitude of headroom and still bounds the allocation for a
+// process that a user's Claude Code invokes on every status refresh. It is a
+// var rather than a const so the oversized-input test can exercise the cap
+// without allocating a megabyte of padding per run.
+var maxStatusLineBytes int64 = 1 << 20
+
+// claudeLabel is the display name. Spelled once so the CLI and the cache agree.
+const claudeLabel = "Claude"
+
+// statusLinePayload decodes ONLY the rate_limits block.
+//
+// Everything else Claude pipes in — transcript_path, cwd, the model, the
+// session id — is deliberately absent from this struct rather than being
+// decoded and then ignored: a field that does not exist cannot be accidentally
+// logged, persisted, or added to an error string later.
+type statusLinePayload struct {
+	RateLimits *struct {
+		FiveHour   *statusLineWindow `json:"five_hour"`
+		SevenDay   *statusLineWindow `json:"seven_day"`
+		SpendLimit *statusLineWindow `json:"spend_limit"`
+	} `json:"rate_limits"`
+}
+
+type statusLineWindow struct {
+	UsedPercentage float64 `json:"used_percentage"`
+	// ResetsAt is epoch SECONDS here, matching Snapshot's unit, so it is
+	// carried through without conversion.
+	ResetsAt *int64 `json:"resets_at"`
+}
+
+// ParseStatusLine extracts a Claude quota snapshot from a statusLine payload.
+//
+// ok is false, with no error, when the payload carries no rate_limits block.
+// That is the normal state before the session's first API response and the
+// permanent state for API-key, Bedrock and Vertex auth, so treating it as a
+// failure would make the common case look broken.
+func ParseStatusLine(r io.Reader) (Snapshot, bool, error) {
+	raw, err := io.ReadAll(io.LimitReader(r, maxStatusLineBytes+1))
+	if err != nil {
+		return Snapshot{}, false, fmt.Errorf("reading statusLine payload: %w", err)
+	}
+	if int64(len(raw)) > maxStatusLineBytes {
+		return Snapshot{}, false, errors.New("statusLine payload exceeds size cap")
+	}
+
+	var payload statusLinePayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return Snapshot{}, false, fmt.Errorf("decoding statusLine payload: %w", err)
+	}
+	if payload.RateLimits == nil {
+		return Snapshot{}, false, nil
+	}
+
+	snapshot := Snapshot{
+		ID:        ProviderClaude,
+		Label:     claudeLabel,
+		UpdatedAt: time.Now().Unix(),
+	}
+	// Windows are appended in this fixed order so the rendering is stable
+	// across refreshes; Claude drops a window from the block once its reset
+	// passes, so a missing one is expected and simply contributes nothing.
+	for _, candidate := range []struct {
+		kind   WindowKind
+		label  string
+		window *statusLineWindow
+	}{
+		{WindowFiveHour, "5h", payload.RateLimits.FiveHour},
+		{WindowSevenDay, "7d", payload.RateLimits.SevenDay},
+		{WindowSpendLimit, "spend", payload.RateLimits.SpendLimit},
+	} {
+		if candidate.window == nil {
+			continue
+		}
+		snapshot.Windows = append(snapshot.Windows, Window{
+			Kind:  candidate.kind,
+			Label: candidate.label,
+			// Not clamped: spend_limit exceeds 100 in overage and that is the
+			// reading the user most needs to see.
+			UsedPercentage: candidate.window.UsedPercentage,
+			ResetsAt:       candidate.window.ResetsAt,
+		})
+	}
+	if len(snapshot.Windows) == 0 {
+		return Snapshot{}, false, nil
+	}
+	return snapshot, true, nil
+}

--- a/internal/quota/claude.go
+++ b/internal/quota/claude.go
@@ -36,8 +36,8 @@ type statusLinePayload struct {
 
 type statusLineWindow struct {
 	UsedPercentage float64 `json:"used_percentage"`
-	// ResetsAt is epoch SECONDS here, matching Snapshot's unit, so it is
-	// carried through without conversion.
+	// ResetsAt is epoch SECONDS here. Z.ai reports MILLISECONDS for the same
+	// concept, which is why the two providers do not share a decoder.
 	ResetsAt *int64 `json:"resets_at"`
 }
 

--- a/internal/quota/claude_test.go
+++ b/internal/quota/claude_test.go
@@ -1,0 +1,154 @@
+package quota
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// windowByKind is a test helper: the model stores windows as a slice (unknown
+// provider windows must stay representable), so assertions look them up.
+func windowByKind(t *testing.T, snapshot Snapshot, kind WindowKind) Window {
+	t.Helper()
+	for _, window := range snapshot.Windows {
+		if window.Kind == kind {
+			return window
+		}
+	}
+	t.Fatalf("window %q not present in %+v", kind, snapshot.Windows)
+	return Window{}
+}
+
+func TestParseStatusLineWindows(t *testing.T) {
+	const payload = `{
+	  "session_id": "abc-123",
+	  "transcript_path": "/home/someone/.claude/projects/x/abc-123.jsonl",
+	  "cwd": "/home/someone/secret-project",
+	  "model": {"id": "claude-opus-5", "display_name": "Opus"},
+	  "rate_limits": {
+	    "five_hour":   {"used_percentage": 23.5, "resets_at": 1738425600},
+	    "seven_day":   {"used_percentage": 41.2, "resets_at": 1738857600},
+	    "spend_limit": {"used_percentage": 162.8, "resets_at": 1740787200}
+	  }
+	}`
+
+	snapshot, ok, err := ParseStatusLine(strings.NewReader(payload))
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	assert.Equal(t, ProviderClaude, snapshot.ID)
+	require.Len(t, snapshot.Windows, 3)
+
+	fiveHour := windowByKind(t, snapshot, WindowFiveHour)
+	// The float must survive: 23.5 rounded to 23 is a different claim about
+	// how much of the window is gone.
+	assert.Equal(t, 23.5, fiveHour.UsedPercentage)
+	require.NotNil(t, fiveHour.ResetsAt)
+	assert.Equal(t, int64(1738425600), *fiveHour.ResetsAt)
+
+	sevenDay := windowByKind(t, snapshot, WindowSevenDay)
+	assert.Equal(t, 41.2, sevenDay.UsedPercentage)
+
+	// spend_limit legitimately exceeds 100 once the account is in overage.
+	// Clamping it would report a breached limit as an exactly-met one.
+	spend := windowByKind(t, snapshot, WindowSpendLimit)
+	assert.Equal(t, 162.8, spend.UsedPercentage)
+}
+
+func TestParseStatusLineAbsentRateLimits(t *testing.T) {
+	// The normal state before the session's first API response, and the
+	// permanent state for API-key / Bedrock / Vertex auth. Not an error.
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{"no rate_limits key", `{"session_id":"abc","model":{"id":"claude-opus-5"}}`},
+		{"rate_limits null", `{"rate_limits": null}`},
+		{"rate_limits empty", `{"rate_limits": {}}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			snapshot, ok, err := ParseStatusLine(strings.NewReader(tt.payload))
+			require.NoError(t, err)
+			assert.False(t, ok)
+			assert.Empty(t, snapshot.Windows)
+		})
+	}
+}
+
+func TestParseStatusLineSingleWindowInventsNothing(t *testing.T) {
+	// Claude drops a window from the block once its reset passes.
+	const payload = `{"rate_limits": {"five_hour": {"used_percentage": 7, "resets_at": 1738425600}}}`
+
+	snapshot, ok, err := ParseStatusLine(strings.NewReader(payload))
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, snapshot.Windows, 1)
+	assert.Equal(t, WindowFiveHour, snapshot.Windows[0].Kind)
+}
+
+func TestParseStatusLineMissingResetIsNil(t *testing.T) {
+	// nil means "the provider did not tell us". Zero would mean 1970 and
+	// would render as a window that reset long ago.
+	const payload = `{"rate_limits": {"five_hour": {"used_percentage": 7}}}`
+
+	snapshot, ok, err := ParseStatusLine(strings.NewReader(payload))
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, snapshot.Windows, 1)
+	assert.Nil(t, snapshot.Windows[0].ResetsAt)
+}
+
+func TestParseStatusLineKeepsOnlyRateLimits(t *testing.T) {
+	// The statusLine payload carries the user's cwd, transcript path and
+	// prompt. None of it may reach a file agent-deck writes.
+	const payload = `{
+	  "session_id": "SENTINEL-SESSION",
+	  "transcript_path": "/home/someone/SENTINEL-TRANSCRIPT.jsonl",
+	  "cwd": "/home/someone/SENTINEL-CWD",
+	  "model": {"id": "SENTINEL-MODEL"},
+	  "rate_limits": {"five_hour": {"used_percentage": 10, "resets_at": 1738425600}}
+	}`
+
+	snapshot, ok, err := ParseStatusLine(strings.NewReader(payload))
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	encoded, err := json.Marshal(snapshot)
+	require.NoError(t, err)
+	for _, sentinel := range []string{"SENTINEL-SESSION", "SENTINEL-TRANSCRIPT", "SENTINEL-CWD", "SENTINEL-MODEL"} {
+		assert.NotContains(t, string(encoded), sentinel)
+	}
+}
+
+func TestParseStatusLineMalformed(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{"truncated", `{"rate_limits": {"five_hour":`},
+		{"not an object", `["five_hour"]`},
+		{"empty input", ``},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ok, err := ParseStatusLine(strings.NewReader(tt.payload))
+			require.Error(t, err)
+			assert.False(t, ok)
+		})
+	}
+}
+
+func TestParseStatusLineCapsInput(t *testing.T) {
+	// stdin is attacker-adjacent only in the sense that it is whatever the
+	// caller pipes in; an unbounded read is still an unbounded allocation.
+	oversized := `{"rate_limits": {"five_hour": {"used_percentage": 1}}, "pad": "` +
+		strings.Repeat("x", int(maxStatusLineBytes)+1) + `"}`
+
+	_, ok, err := ParseStatusLine(strings.NewReader(oversized))
+	require.Error(t, err)
+	assert.False(t, ok)
+}

--- a/internal/quota/model.go
+++ b/internal/quota/model.go
@@ -11,24 +11,26 @@
 // provider-reported reset in this package is exactly that missing number.
 // Rewiring usagelimit.go to consume it is deliberately NOT done here.
 //
-// The source for Claude, and what was rejected: the JSON Claude Code pipes to a
-// configured statusLine command, whose `rate_limits` block is documented
-// (code.claude.com/docs/en/statusline). Every other candidate on this machine
-// was checked on 2026-09-07 and does not carry the numbers: none of the 31 hook
-// events, no `claude usage` subcommand, no OTel metric, no file under
-// ~/.claude. The undocumented oauth usage endpoint some tools call is
-// deliberately not used — it needs a bearer token replayed out of the user's
-// credential store, and this package never reads a credential store.
+// Source selection, and what was rejected:
+//
+//   - Claude: the JSON Claude Code pipes to a configured statusLine command,
+//     whose `rate_limits` block is documented (code.claude.com/docs/en/statusline).
+//     Every other candidate on this machine was checked on 2026-09-07 and does
+//     not carry the numbers: none of the 31 hook events, no `claude usage`
+//     subcommand, no OTel metric, no file under ~/.claude. The undocumented
+//     oauth usage endpoint some tools call is deliberately not used — it needs a
+//     bearer token replayed out of the user's credential store, and this package
+//     never reads a credential store.
+//   - Z.ai / GLM: the same monitor endpoint the vendor's own coding plugin calls,
+//     on the host the user themselves put in ANTHROPIC_BASE_URL. There is no
+//     hardcoded fallback host: an outbound destination this package invents
+//     rather than the user configuring it is the thing the repo's security lens
+//     forbids.
 //
 // Nothing here derives a percentage from token counts. A locally computed
 // estimate is a different number that happens to share a unit with the one the
 // user is asking about, and being wrong about a quota is worse than not showing
 // one.
-//
-// The model, the store and the CLI are deliberately shaped for more than one
-// provider even though Claude is the only one wired up here: the store is
-// one-file-per-provider and the report is a list, so a second provider is a new
-// file rather than a change to this contract.
 package quota
 
 // Provider IDs. These are the on-disk filenames in the cache and the stable
@@ -36,25 +38,29 @@ package quota
 // spelled once here rather than as literals at each call site.
 const (
 	ProviderClaude = "claude"
+	ProviderZai    = "zai"
 )
 
-// WindowKind names a quota window. It is a named kind rather than a bare map
-// key because the kind is part of the `--json` contract: a consumer selects the
-// five-hour window by name, without having to parse the human label.
+// WindowKind names a quota window. It is a named kind rather than a map key
+// because Z.ai returns windows this package cannot name in advance: its windows
+// are discriminated by a (unit, number) pair for which only two values have
+// been observed, so anything else has to remain representable without being
+// given a name it may not deserve. WindowOther is that honest fallback.
 type WindowKind string
 
 const (
 	WindowFiveHour   WindowKind = "five_hour"
 	WindowSevenDay   WindowKind = "seven_day"
 	WindowSpendLimit WindowKind = "spend_limit"
+	WindowOther      WindowKind = "other"
 )
 
 // Window is one quota window as the provider reported it.
 type Window struct {
 	Kind WindowKind `json:"kind"`
 	// Label is the short human rendering ("5h", "7d", "spend"). It is carried
-	// rather than derived from Kind so a provider whose window this build
-	// cannot name in advance can still label itself from its own numbers.
+	// rather than derived from Kind because a WindowOther window's only useful
+	// label is the one built from the provider's own numbers at parse time.
 	Label string `json:"label"`
 	// UsedPercentage is percent CONSUMED, 0-100 — except that Claude's
 	// spend_limit exceeds 100 in overage. It is NOT clamped: reporting a
@@ -63,21 +69,26 @@ type Window struct {
 	UsedPercentage float64 `json:"used_percentage"`
 	// ResetsAt is epoch SECONDS, or nil when the provider said nothing.
 	//
-	// The pointer is the whole point: Claude omits the reset for a window it
-	// has not populated. A zero would render as a window that reset in 1970,
-	// and a synthesised "now + 5h" would be a promise this package is in no
-	// position to make. Never fill this in from the window's nominal duration.
+	// The pointer is the whole point: Z.ai omits the reset for a window with no
+	// consumption yet, and Claude omits it for a window it has not populated. A
+	// zero would render as a window that reset in 1970, and a synthesised
+	// "now + 5h" would be a promise this package is in no position to make.
+	// Never fill this in from the window's nominal duration.
 	ResetsAt *int64 `json:"resets_at,omitempty"`
 }
 
 // Snapshot is one provider's quota state as of UpdatedAt.
 type Snapshot struct {
-	ID        string   `json:"id"`
-	Label     string   `json:"label"`
+	ID    string `json:"id"`
+	Label string `json:"label"`
+	// Plan is the provider's own name for the subscription tier, when it
+	// reports one (Z.ai's data.level). Claude's statusLine does not carry the
+	// plan name, so it stays empty rather than being guessed from the limits.
+	Plan      string   `json:"plan,omitempty"`
 	Windows   []Window `json:"windows"`
 	UpdatedAt int64    `json:"updated_at"`
 	// Error is a short, provider-attributed message. A provider that failed is
-	// reported as data alongside the ones that succeeded — one unreadable
+	// reported as data alongside the ones that succeeded — one unreachable
 	// provider must never blank out the others, which is the whole reason a
 	// failure lives in the model instead of being returned as an error.
 	//

--- a/internal/quota/model.go
+++ b/internal/quota/model.go
@@ -1,0 +1,97 @@
+// Package quota reports how much of a provider's SUBSCRIPTION allowance is
+// left, from the provider's own numbers.
+//
+// This is the forward-looking half of a signal agent-deck already has one half
+// of. internal/session/usagelimit.go detects that a plan window is exhausted,
+// after the fact, from the rejection turn in Claude's transcript — it answers
+// "this session is blocked". It cannot answer "how much is left", and it says
+// so itself: its staleness bound carries a "KNOWN LIMITATION, accepted
+// deliberately" note that it does not read the real reset time, so a rejection
+// can be believed for up to ~5h after the window actually reopened. The
+// provider-reported reset in this package is exactly that missing number.
+// Rewiring usagelimit.go to consume it is deliberately NOT done here.
+//
+// The source for Claude, and what was rejected: the JSON Claude Code pipes to a
+// configured statusLine command, whose `rate_limits` block is documented
+// (code.claude.com/docs/en/statusline). Every other candidate on this machine
+// was checked on 2026-09-07 and does not carry the numbers: none of the 31 hook
+// events, no `claude usage` subcommand, no OTel metric, no file under
+// ~/.claude. The undocumented oauth usage endpoint some tools call is
+// deliberately not used — it needs a bearer token replayed out of the user's
+// credential store, and this package never reads a credential store.
+//
+// Nothing here derives a percentage from token counts. A locally computed
+// estimate is a different number that happens to share a unit with the one the
+// user is asking about, and being wrong about a quota is worse than not showing
+// one.
+//
+// The model, the store and the CLI are deliberately shaped for more than one
+// provider even though Claude is the only one wired up here: the store is
+// one-file-per-provider and the report is a list, so a second provider is a new
+// file rather than a change to this contract.
+package quota
+
+// Provider IDs. These are the on-disk filenames in the cache and the stable
+// keys in `agent-deck usage --json`, so they are part of the contract and are
+// spelled once here rather than as literals at each call site.
+const (
+	ProviderClaude = "claude"
+)
+
+// WindowKind names a quota window. It is a named kind rather than a bare map
+// key because the kind is part of the `--json` contract: a consumer selects the
+// five-hour window by name, without having to parse the human label.
+type WindowKind string
+
+const (
+	WindowFiveHour   WindowKind = "five_hour"
+	WindowSevenDay   WindowKind = "seven_day"
+	WindowSpendLimit WindowKind = "spend_limit"
+)
+
+// Window is one quota window as the provider reported it.
+type Window struct {
+	Kind WindowKind `json:"kind"`
+	// Label is the short human rendering ("5h", "7d", "spend"). It is carried
+	// rather than derived from Kind so a provider whose window this build
+	// cannot name in advance can still label itself from its own numbers.
+	Label string `json:"label"`
+	// UsedPercentage is percent CONSUMED, 0-100 — except that Claude's
+	// spend_limit exceeds 100 in overage. It is NOT clamped: reporting a
+	// breached limit as an exactly-met one hides the very thing the user
+	// opened this to see.
+	UsedPercentage float64 `json:"used_percentage"`
+	// ResetsAt is epoch SECONDS, or nil when the provider said nothing.
+	//
+	// The pointer is the whole point: Claude omits the reset for a window it
+	// has not populated. A zero would render as a window that reset in 1970,
+	// and a synthesised "now + 5h" would be a promise this package is in no
+	// position to make. Never fill this in from the window's nominal duration.
+	ResetsAt *int64 `json:"resets_at,omitempty"`
+}
+
+// Snapshot is one provider's quota state as of UpdatedAt.
+type Snapshot struct {
+	ID        string   `json:"id"`
+	Label     string   `json:"label"`
+	Windows   []Window `json:"windows"`
+	UpdatedAt int64    `json:"updated_at"`
+	// Error is a short, provider-attributed message. A provider that failed is
+	// reported as data alongside the ones that succeeded — one unreadable
+	// provider must never blank out the others, which is the whole reason a
+	// failure lives in the model instead of being returned as an error.
+	//
+	// It must never carry a token, an account id, or a URL with credentials in
+	// it: this field is persisted and printed.
+	Error string `json:"error,omitempty"`
+	// Stale is computed at READ time against the store's TTL and is never
+	// persisted — a snapshot that was fresh when written would otherwise claim
+	// to be fresh forever. A stale snapshot is shown, marked; hiding it would
+	// leave the user with nothing where they previously had a number.
+	Stale bool `json:"stale"`
+}
+
+// Report is the shape of `agent-deck usage --json`.
+type Report struct {
+	Providers []Snapshot `json:"providers"`
+}

--- a/internal/quota/store.go
+++ b/internal/quota/store.go
@@ -1,0 +1,198 @@
+package quota
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
+	"github.com/asheshgoplani/agent-deck/internal/atomicfile"
+)
+
+// DefaultStaleAfter is how long a cached snapshot is presented without a stale
+// marker.
+//
+// The shortest window a provider reports is five hours, and its percentage
+// therefore moves on a scale of tens of minutes even under a fleet of agents.
+// Fifteen minutes is short enough that a number the user acts on is still
+// roughly current, and long enough that the common `agent-deck usage` in a
+// terminal loop does not turn into a request per invocation.
+//
+// KNOWN LIMITATION, accepted deliberately: this is a freshness marker, not a
+// refresh. Claude's provider is PUSH-only — its snapshot is written by whatever
+// statusLine invocation last ran — so a Claude snapshot goes stale whenever the
+// user simply is not running Claude, and no amount of asking will refresh it.
+// That is the honest state and it is shown as such rather than hidden, because
+// the alternative (dropping the last known numbers) leaves the user with less
+// than they had.
+const DefaultStaleAfter = 15 * time.Minute
+
+// maxProviderIDLen bounds the provider id, which becomes a filename. Provider
+// ids are compile-time constants in this package, so this guards against a
+// future caller rather than against today's data.
+const maxProviderIDLen = 64
+
+// Store is the on-disk quota cache for one profile.
+//
+// ONE FILE PER PROVIDER, deliberately. Claude's snapshot is PUSHED by the
+// statusLine ingester, potentially by several concurrent Claude sessions, and a
+// second provider would have a writer of its own. Separate files mean those
+// writers never read-modify-write the same file, so there is no lock to hold
+// and no lost update to reason about. Load simply reads the directory.
+//
+// The per-profile subdirectory keeps a future multi-account story open without
+// a schema change, and matches how the rest of agent-deck keys on-disk state.
+type Store struct {
+	dir string
+	// StaleAfter is per-store so a caller with a different tolerance (a status
+	// bar refreshing on a tick, say) can set its own without a global.
+	StaleAfter time.Duration
+}
+
+// NewStore returns the quota cache for a profile. It does not create anything
+// on disk: `agent-deck usage --help` must not leave a directory behind, which
+// the repo's help-is-read-only test enforces for every registered command.
+func NewStore(profile string) (*Store, error) {
+	cacheDir, err := agentpaths.CacheDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolving cache dir: %w", err)
+	}
+	cleanProfile := strings.TrimSpace(profile)
+	if cleanProfile == "" || !validProviderID(cleanProfile) {
+		return nil, fmt.Errorf("unusable profile name %q for quota cache", profile)
+	}
+	return &Store{dir: filepath.Join(cacheDir, "quota", cleanProfile), StaleAfter: DefaultStaleAfter}, nil
+}
+
+// Dir is the directory holding this profile's provider files.
+func (s *Store) Dir() string { return s.dir }
+
+// Save writes one provider's snapshot.
+//
+// Stale is cleared before writing: it is a read-time computation, and
+// persisting it would let a snapshot that was fresh at write time claim to be
+// fresh forever.
+func (s *Store) Save(snapshot Snapshot) error {
+	if !validProviderID(snapshot.ID) {
+		return fmt.Errorf("unusable provider id %q", snapshot.ID)
+	}
+	snapshot.Stale = false
+
+	encoded, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding %s snapshot: %w", snapshot.ID, err)
+	}
+	// 0o700: the numbers are not secret, but the set of providers a user has
+	// configured is theirs alone, and a private directory costs nothing.
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+		return fmt.Errorf("creating quota cache dir: %w", err)
+	}
+	// internal/atomicfile documents itself as being for user-managed config
+	// files, in contrast with the unexported temp+rename helpers agent-deck
+	// uses for its own state. It is used here anyway: those helpers are
+	// unexported, this one is stdlib-only so it introduces no import cycle, and
+	// its temp+rename semantics for a regular file are identical. The only
+	// difference — it preserves a symlink AT the path — is immaterial for a
+	// file that only agent-deck writes.
+	//
+	// 0o644: the file holds percentages and reset timestamps, never a token.
+	// The store round-trip test asserts that against a sentinel credential.
+	path := filepath.Join(s.dir, snapshot.ID+".json")
+	if err := atomicfile.WriteFile(path, encoded, 0o644); err != nil {
+		return fmt.Errorf("writing %s snapshot: %w", snapshot.ID, err)
+	}
+	return nil
+}
+
+// Load returns every cached provider snapshot, ordered by provider id so the
+// rendering does not reshuffle between invocations.
+//
+// A missing cache directory is the normal state before anything has been
+// ingested or fetched, and yields an empty report rather than an error.
+func (s *Store) Load() ([]Snapshot, error) {
+	entries, err := os.ReadDir(s.dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading quota cache: %w", err)
+	}
+
+	staleAfter := s.StaleAfter
+	if staleAfter <= 0 {
+		staleAfter = DefaultStaleAfter
+	}
+	now := time.Now()
+
+	var snapshots []Snapshot
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		id := strings.TrimSuffix(entry.Name(), ".json")
+		snapshots = append(snapshots, s.loadOne(id, now, staleAfter))
+	}
+	sort.Slice(snapshots, func(i, j int) bool { return snapshots[i].ID < snapshots[j].ID })
+	return snapshots, nil
+}
+
+// loadOne turns one cache file into a snapshot. An unreadable or corrupt file
+// becomes a snapshot carrying the failure rather than disappearing: a provider
+// the user configured going silently missing from the output is the one
+// outcome that would send them to a vendor dashboard, which is the thing this
+// feature exists to avoid.
+func (s *Store) loadOne(id string, now time.Time, staleAfter time.Duration) Snapshot {
+	raw, err := os.ReadFile(filepath.Join(s.dir, id+".json"))
+	if err != nil {
+		return Snapshot{ID: id, Label: ProviderLabel(id), Error: "cached snapshot unreadable", Stale: true}
+	}
+	var snapshot Snapshot
+	if err := json.Unmarshal(raw, &snapshot); err != nil {
+		return Snapshot{ID: id, Label: ProviderLabel(id), Error: "cached snapshot is corrupt", Stale: true}
+	}
+	// The filename is authoritative for the id: it is what Load enumerates and
+	// what a second writer would collide on.
+	snapshot.ID = id
+	if snapshot.Label == "" {
+		snapshot.Label = ProviderLabel(id)
+	}
+	snapshot.Stale = snapshot.UpdatedAt <= 0 || now.Sub(time.Unix(snapshot.UpdatedAt, 0)) > staleAfter
+	return snapshot
+}
+
+// ProviderLabel is the display name for a provider id, falling back to the id
+// itself for a cache file this build does not know about — a downgrade should
+// show the entry, not hide it.
+func ProviderLabel(id string) string {
+	switch id {
+	case ProviderClaude:
+		return claudeLabel
+	default:
+		return id
+	}
+}
+
+// validProviderID keeps the id usable as a single filename component. The id
+// reaches filepath.Join, so a traversal component would write outside the
+// cache directory.
+func validProviderID(id string) bool {
+	if id == "" || len(id) > maxProviderIDLen {
+		return false
+	}
+	if id != filepath.Base(id) || id == "." || id == ".." {
+		return false
+	}
+	for _, r := range id {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/quota/store.go
+++ b/internal/quota/store.go
@@ -40,8 +40,8 @@ const maxProviderIDLen = 64
 // Store is the on-disk quota cache for one profile.
 //
 // ONE FILE PER PROVIDER, deliberately. Claude's snapshot is PUSHED by the
-// statusLine ingester, potentially by several concurrent Claude sessions, and a
-// second provider would have a writer of its own. Separate files mean those
+// statusLine ingester — potentially by several concurrent Claude sessions —
+// while Z.ai's is PULLED by `agent-deck usage`. Separate files mean those
 // writers never read-modify-write the same file, so there is no lock to hold
 // and no lost update to reason about. Load simply reads the directory.
 //
@@ -172,6 +172,8 @@ func ProviderLabel(id string) string {
 	switch id {
 	case ProviderClaude:
 		return claudeLabel
+	case ProviderZai:
+		return "Z.ai"
 	default:
 		return id
 	}

--- a/internal/quota/store_test.go
+++ b/internal/quota/store_test.go
@@ -1,0 +1,190 @@
+package quota
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// secondProviderID stands in for a provider other than Claude. The store is
+// one-file-per-provider so that independent writers never collide, and these
+// tests pin that with two ids; it sorts after "claude", which the ordering
+// assertions rely on.
+const secondProviderID = "other"
+
+// sentinelToken is a value that would only ever reach the cache by mistake. The
+// cache holds percentages and reset times, never a credential.
+const sentinelToken = "SENTINEL-QUOTA-TOKEN-do-not-leak"
+
+// newTestStore points the store at a per-test XDG cache root so nothing leaks
+// between tests or onto the developer's machine.
+func newTestStore(t *testing.T, profile string) *Store {
+	t.Helper()
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	store, err := NewStore(profile)
+	require.NoError(t, err)
+	return store
+}
+
+func TestStoreRoundTrip(t *testing.T) {
+	store := newTestStore(t, "default")
+	resets := int64(1738425600)
+	saved := Snapshot{
+		ID:        ProviderClaude,
+		Label:     claudeLabel,
+		Windows:   []Window{{Kind: WindowFiveHour, Label: "5h", UsedPercentage: 23.5, ResetsAt: &resets}},
+		UpdatedAt: time.Now().Unix(),
+	}
+	require.NoError(t, store.Save(saved))
+
+	loaded, err := store.Load()
+	require.NoError(t, err)
+	require.Len(t, loaded, 1)
+	assert.Equal(t, ProviderClaude, loaded[0].ID)
+	require.Len(t, loaded[0].Windows, 1)
+	assert.Equal(t, 23.5, loaded[0].Windows[0].UsedPercentage)
+	require.NotNil(t, loaded[0].Windows[0].ResetsAt)
+	assert.Equal(t, resets, *loaded[0].Windows[0].ResetsAt)
+}
+
+func TestStoreStalenessIsComputedAtReadAndStillReturned(t *testing.T) {
+	tests := []struct {
+		name      string
+		age       time.Duration
+		wantStale bool
+	}{
+		{"fresh", time.Minute, false},
+		{"older than ttl", DefaultStaleAfter + time.Minute, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newTestStore(t, "default")
+			require.NoError(t, store.Save(Snapshot{
+				ID:        secondProviderID,
+				Label:     secondProviderID,
+				UpdatedAt: time.Now().Add(-tt.age).Unix(),
+				// Stale is never persisted: a snapshot written as fresh would
+				// otherwise claim to be fresh forever.
+				Stale: false,
+			}))
+
+			loaded, err := store.Load()
+			require.NoError(t, err)
+			// A stale snapshot is still RETURNED, marked. Hiding it leaves the
+			// user with nothing where they previously had a number.
+			require.Len(t, loaded, 1)
+			assert.Equal(t, tt.wantStale, loaded[0].Stale)
+		})
+	}
+}
+
+func TestStoreConcurrentProvidersBothSurvive(t *testing.T) {
+	// Claude's snapshot is PUSHED by the statusLine ingester, possibly by
+	// several Claude sessions at once, and a second provider would have a
+	// writer of its own. One file per provider is what makes that safe; a
+	// shared file would lose one of these writes.
+	store := newTestStore(t, "default")
+
+	var wg sync.WaitGroup
+	for _, id := range []string{ProviderClaude, secondProviderID} {
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			for i := 0; i < 20; i++ {
+				assert.NoError(t, store.Save(Snapshot{ID: id, Label: id, UpdatedAt: time.Now().Unix()}))
+			}
+		}(id)
+	}
+	wg.Wait()
+
+	loaded, err := store.Load()
+	require.NoError(t, err)
+	require.Len(t, loaded, 2)
+	assert.Equal(t, ProviderClaude, loaded[0].ID)
+	assert.Equal(t, secondProviderID, loaded[1].ID)
+}
+
+func TestStoreCorruptFileDoesNotHideOtherProvider(t *testing.T) {
+	store := newTestStore(t, "default")
+	require.NoError(t, store.Save(Snapshot{ID: secondProviderID, Label: secondProviderID, UpdatedAt: time.Now().Unix()}))
+	require.NoError(t, os.WriteFile(filepath.Join(store.Dir(), ProviderClaude+".json"), []byte("{not json"), 0o644))
+
+	loaded, err := store.Load()
+	require.NoError(t, err)
+	require.Len(t, loaded, 2)
+
+	assert.Equal(t, ProviderClaude, loaded[0].ID)
+	assert.NotEmpty(t, loaded[0].Error, "a corrupt cache entry is reported, not silently dropped")
+	assert.Equal(t, secondProviderID, loaded[1].ID)
+	assert.Empty(t, loaded[1].Error)
+}
+
+func TestStoreWritesNoCredential(t *testing.T) {
+	store := newTestStore(t, "default")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", sentinelToken)
+	require.NoError(t, store.Save(Snapshot{
+		ID:        secondProviderID,
+		Label:     secondProviderID,
+		Windows:   []Window{{Kind: WindowSevenDay, Label: "7d", UsedPercentage: 22}},
+		UpdatedAt: time.Now().Unix(),
+	}))
+
+	entries, err := os.ReadDir(store.Dir())
+	require.NoError(t, err)
+	require.NotEmpty(t, entries)
+	for _, entry := range entries {
+		contents, err := os.ReadFile(filepath.Join(store.Dir(), entry.Name()))
+		require.NoError(t, err)
+		assert.NotContains(t, string(contents), sentinelToken)
+	}
+}
+
+func TestStoreDirIsPrivate(t *testing.T) {
+	store := newTestStore(t, "default")
+	require.NoError(t, store.Save(Snapshot{ID: secondProviderID, Label: secondProviderID, UpdatedAt: time.Now().Unix()}))
+
+	info, err := os.Stat(store.Dir())
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm())
+}
+
+func TestStoreProfilesAreIsolated(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	work, err := NewStore("work")
+	require.NoError(t, err)
+	personal, err := NewStore("personal")
+	require.NoError(t, err)
+
+	require.NoError(t, work.Save(Snapshot{ID: secondProviderID, Label: secondProviderID, UpdatedAt: time.Now().Unix()}))
+
+	loaded, err := personal.Load()
+	require.NoError(t, err)
+	assert.Empty(t, loaded)
+	assert.NotEqual(t, work.Dir(), personal.Dir())
+}
+
+func TestStoreLoadOnMissingDirIsEmptyNotAnError(t *testing.T) {
+	// The state before anything has ever been ingested or fetched. `usage` must
+	// print an empty report there, not fail.
+	store := newTestStore(t, "default")
+	loaded, err := store.Load()
+	require.NoError(t, err)
+	assert.Empty(t, loaded)
+	_, statErr := os.Stat(store.Dir())
+	assert.True(t, os.IsNotExist(statErr), "Load must not create the cache directory")
+}
+
+func TestStoreRejectsUnusableProviderID(t *testing.T) {
+	// The provider id becomes a filename. A traversal component in it would
+	// write outside the cache directory.
+	store := newTestStore(t, "default")
+	for _, id := range []string{"", "../escape", "a/b", strings.Repeat("x", 300)} {
+		assert.Error(t, store.Save(Snapshot{ID: id, UpdatedAt: time.Now().Unix()}), "id %q", id)
+	}
+}

--- a/internal/quota/store_test.go
+++ b/internal/quota/store_test.go
@@ -19,7 +19,8 @@ import (
 const secondProviderID = "other"
 
 // sentinelToken is a value that would only ever reach the cache by mistake. The
-// cache holds percentages and reset times, never a credential.
+// cache holds percentages and reset times, never a credential; the Z.ai tests
+// check every error path in this package against the same constant.
 const sentinelToken = "SENTINEL-QUOTA-TOKEN-do-not-leak"
 
 // newTestStore points the store at a per-test XDG cache root so nothing leaks

--- a/internal/quota/testmain_test.go
+++ b/internal/quota/testmain_test.go
@@ -1,0 +1,33 @@
+package quota
+
+import (
+	"os"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(runTestMain(m))
+}
+
+// runTestMain holds the real body so the cleanup defer runs: TestMain calls
+// os.Exit, which does not run deferred functions.
+func runTestMain(m *testing.M) int {
+	// Isolate HOME+XDG so agent-deck path resolution lands in a temp dir, never
+	// the real ~/.cache/agent-deck (2026-06-04 data-loss incident).
+	// See internal/testutil/homeenv.go.
+	cleanupHome := testutil.IsolateHome()
+	defer cleanupHome()
+
+	// This package never shells out to tmux, but the repo-wide audit in
+	// internal/testutil/testmain_audit_test.go requires every TestMain to
+	// isolate the socket anyway: the guarantee is only worth anything if it
+	// holds unconditionally, and a package that grows a tmux call later must
+	// not have to remember. 2026-04-17 incident, see
+	// internal/testutil/tmuxenv.go.
+	cleanupTmux := testutil.IsolateTmuxSocket()
+	defer cleanupTmux()
+
+	return m.Run()
+}

--- a/internal/quota/zai.go
+++ b/internal/quota/zai.go
@@ -1,0 +1,254 @@
+package quota
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// ErrNotConfigured means the provider has nothing to talk to: the user has not
+// configured this provider on this machine. It is a sentinel because the CLI
+// renders it differently from a failure — "not configured" is a fact about the
+// setup, while a timeout or a 401 is a problem to look at.
+var ErrNotConfigured = errors.New("provider not configured")
+
+// zaiMonitorPath is the endpoint the vendor's own coding plugin calls.
+const zaiMonitorPath = "/api/monitor/usage/quota/limit"
+
+// zaiHostSuffixes is the set of hosts this package is willing to send a token
+// to. It exists because ANTHROPIC_BASE_URL is a general-purpose Anthropic-compat
+// setting: pointed at some other gateway, an unguarded fetch would replay the
+// user's credential to a host that has nothing to do with Z.ai. The guard means
+// the worst case of a mis-set variable is "not configured", not a leak.
+//
+// It is a var, not a const, for one reason: the httptest stub in zai_test.go
+// serves from 127.0.0.1 and has to be reachable without weakening the
+// production default. Nothing in production writes to it.
+var zaiHostSuffixes = []string{"z.ai"}
+
+// zaiAnthropicPathSuffix is what the Anthropic-compat base URL carries and the
+// monitor endpoint does not. It is stripped rather than the host being
+// reassembled from scratch so that a regional or self-hosted deployment keeps
+// whatever host the user configured.
+const zaiAnthropicPathSuffix = "/api/anthropic"
+
+// maxZaiBodyBytes caps the monitor response.
+//
+// The observed body is ~400 bytes; 256 KiB is ample headroom while still
+// bounding what a compromised or confused endpoint can make agent-deck
+// allocate. A var so the cap test can shrink it instead of generating a
+// quarter-megabyte fixture.
+var maxZaiBodyBytes int64 = 256 << 10
+
+// DefaultZaiTimeout matches the repo's existing outbound norm (see
+// internal/credrefresh and internal/update, both 5-10s). This request is
+// user-triggered and never runs on a render path, so the ceiling only has to be
+// short enough that `agent-deck usage` stays interactive.
+const DefaultZaiTimeout = 10 * time.Second
+
+// zaiResponse is the monitor payload. Decoding is deliberately tolerant:
+// unknown fields are ignored and every optional field is a pointer or a
+// zero-tolerant scalar, because this endpoint is the vendor's own and has
+// already been observed returning a `type` its own plugin does not expect.
+type zaiResponse struct {
+	Data struct {
+		Level  string     `json:"level"`
+		Limits []zaiLimit `json:"limits"`
+	} `json:"data"`
+}
+
+type zaiLimit struct {
+	// Unit and Number discriminate the window: unit is a time-unit enum and
+	// number the multiplier. Live evidence (2026-09-07) covers unit=3 (hour,
+	// number=5 -> the 5-hour window) and unit=6 (week, number=1 -> the weekly
+	// window) and NOTHING else, so the rest of the enum is not extrapolated.
+	//
+	// `type` is NOT used and is not decoded at all: the live payload returned
+	// "CREDIT_LIMIT" for BOTH windows while the vendor's own plugin still
+	// branches on TOKENS_LIMIT/TIME_LIMIT, so it neither discriminates nor is
+	// stable. Array order is not relied on either.
+	Unit   int `json:"unit"`
+	Number int `json:"number"`
+	// Usage is the BUDGET and CurrentValue the consumption — the field names
+	// invite exactly the opposite reading, so nothing here is named after them.
+	Usage        float64 `json:"usage"`
+	CurrentValue float64 `json:"currentValue"`
+	// Percentage is percent consumed, and is a pointer so that "0% consumed"
+	// (a window with no activity, which is what the live 5-hour window showed)
+	// is distinguishable from "the field was absent".
+	Percentage *float64 `json:"percentage"`
+	// NextResetTime is epoch MILLISECONDS and OPTIONAL — the live 5-hour window
+	// omitted it. Claude's equivalent is in seconds; do not share a decoder.
+	NextResetTime *int64 `json:"nextResetTime"`
+}
+
+// FetchZai reads the Z.ai / GLM Coding Plan quota from the monitor endpoint on
+// the host the user configured in ANTHROPIC_BASE_URL.
+//
+// Credentials come from the process environment only. The repo has no parser
+// for a profile's env_file — those entries are `source`d by the spawned shell
+// (internal/session/env.go) and never parsed in Go — and adding a shell-syntax
+// parser (quoting, export, command substitution) to reach them would be new,
+// fragile surface for a marginal gain. Inside an agent-deck-launched session
+// the env_file has already been sourced, so this reads the live credential
+// exactly where the user runs it. Widening it is a documented follow-up.
+//
+// os.Environ() is lint-banned outside an allowlist this package is not on;
+// os.Getenv is the supported reader and is all that is needed.
+func FetchZai(ctx context.Context, client *http.Client) (Snapshot, error) {
+	endpoint, err := zaiQuotaEndpoint(os.Getenv("ANTHROPIC_BASE_URL"))
+	if err != nil {
+		return Snapshot{}, err
+	}
+	token := strings.TrimSpace(os.Getenv("ANTHROPIC_AUTH_TOKEN"))
+	if token == "" {
+		return Snapshot{}, fmt.Errorf("ANTHROPIC_AUTH_TOKEN is not set: %w", ErrNotConfigured)
+	}
+
+	// #nosec G704 -- the destination is not attacker-controlled: endpoint is
+	// built by zaiQuotaEndpoint from the user's own ANTHROPIC_BASE_URL, which
+	// must parse as http/https AND resolve to a host on zaiHostSuffixes before
+	// any request is built. There is deliberately no default host, so an
+	// unconfigured machine reaches nothing at all.
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("building quota request: %w", err)
+	}
+	// The vendor's own plugin sends the bare token with no "Bearer" prefix. The
+	// endpoint accepted both when tested, so the vendor's shape is used: it is
+	// the one guaranteed to keep working.
+	request.Header.Set("Authorization", token)
+	request.Header.Set("Accept", "application/json")
+
+	// #nosec G704 -- same constrained destination as the request above.
+	response, err := client.Do(request)
+	if err != nil {
+		// url.Error stringifies the request URL, which carries no credential
+		// (the token is a header), but the message is still reduced to the
+		// bare cause so nothing from the transport layer is passed through
+		// into a field that gets persisted and printed.
+		return Snapshot{}, errors.New("quota request failed: " + zaiTransportReason(err))
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	if response.StatusCode != http.StatusOK {
+		// Status only. The response body is NOT included: a server that echoes
+		// the Authorization header back would otherwise push the user's token
+		// into an error string that is cached on disk and printed.
+		return Snapshot{}, fmt.Errorf("quota endpoint returned %d %s",
+			response.StatusCode, http.StatusText(response.StatusCode))
+	}
+
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxZaiBodyBytes+1))
+	if err != nil {
+		return Snapshot{}, errors.New("reading quota response: " + zaiTransportReason(err))
+	}
+	if int64(len(body)) > maxZaiBodyBytes {
+		return Snapshot{}, errors.New("quota response exceeds size cap")
+	}
+
+	var decoded zaiResponse
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return Snapshot{}, fmt.Errorf("decoding quota response: %w", err)
+	}
+
+	snapshot := Snapshot{
+		ID:        ProviderZai,
+		Label:     "Z.ai",
+		Plan:      decoded.Data.Level,
+		UpdatedAt: time.Now().Unix(),
+	}
+	for _, limit := range decoded.Data.Limits {
+		snapshot.Windows = append(snapshot.Windows, limit.toWindow())
+	}
+	return snapshot, nil
+}
+
+// zaiTransportReason reduces a transport error to its innermost cause. A
+// *url.Error prints the method and URL, which is noise in a one-line status
+// rendering and is the only place a caller-supplied string could reach the
+// message at all.
+func zaiTransportReason(err error) string {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) && urlErr.Err != nil {
+		if urlErr.Timeout() {
+			return "timeout"
+		}
+		return urlErr.Err.Error()
+	}
+	return err.Error()
+}
+
+// toWindow maps one monitor limit onto the shared model.
+func (l zaiLimit) toWindow() Window {
+	window := Window{Kind: WindowOther, Label: fmt.Sprintf("unit%dx%d", l.Unit, l.Number)}
+	switch {
+	case l.Unit == 3 && l.Number == 5:
+		window.Kind, window.Label = WindowFiveHour, "5h"
+	case l.Unit == 6 && l.Number == 1:
+		window.Kind, window.Label = WindowSevenDay, "7d"
+	}
+
+	switch {
+	case l.Percentage != nil:
+		// Preferred: the provider's own arithmetic, so a plan whose windows are
+		// not a simple ratio still reports what the vendor dashboard reports.
+		window.UsedPercentage = *l.Percentage
+	case l.Usage > 0:
+		window.UsedPercentage = l.CurrentValue / l.Usage * 100
+	}
+
+	if l.NextResetTime != nil {
+		// Milliseconds here, seconds in the model. Nothing is synthesised when
+		// the field is absent: a window with no consumption has no open window
+		// to reset, and inventing "now + 5h" would be a promise.
+		seconds := *l.NextResetTime / 1000
+		window.ResetsAt = &seconds
+	}
+	return window
+}
+
+// zaiQuotaEndpoint derives the monitor URL from the user-configured
+// Anthropic-compat base URL, mirroring what the vendor's plugin does.
+//
+// There is deliberately NO default host. The repo's security lens requires that
+// an outbound destination in non-test code be user-configured rather than
+// hardcoded, and a fallback host would also mean a user who never set up Z.ai
+// still generates traffic to it.
+func zaiQuotaEndpoint(baseURL string) (string, error) {
+	trimmed := strings.TrimSpace(baseURL)
+	if trimmed == "" {
+		return "", fmt.Errorf("ANTHROPIC_BASE_URL is not set: %w", ErrNotConfigured)
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return "", fmt.Errorf("ANTHROPIC_BASE_URL %q is not a usable URL: %w", trimmed, ErrNotConfigured)
+	}
+	if !isZaiHost(parsed.Hostname()) {
+		return "", fmt.Errorf("ANTHROPIC_BASE_URL host %q is not a Z.ai endpoint: %w",
+			parsed.Hostname(), ErrNotConfigured)
+	}
+
+	path := strings.TrimSuffix(strings.TrimSuffix(parsed.Path, "/"), zaiAnthropicPathSuffix)
+	endpoint := url.URL{Scheme: parsed.Scheme, Host: parsed.Host, Path: path + zaiMonitorPath}
+	return endpoint.String(), nil
+}
+
+// isZaiHost matches on a dot-boundary so a lookalike host ("notz.ai") does not
+// satisfy a plain suffix check.
+func isZaiHost(host string) bool {
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+	for _, suffix := range zaiHostSuffixes {
+		if host == suffix || strings.HasSuffix(host, "."+suffix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/quota/zai_test.go
+++ b/internal/quota/zai_test.go
@@ -1,0 +1,270 @@
+package quota
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// serveZai starts a stub monitor endpoint, points the process environment at it,
+// and widens the host allowlist to cover httptest's loopback address for the
+// duration of the test. The allowlist is the production guard that the
+// destination is a z.ai-family host the user configured; it is relaxed here
+// only so a stub can stand in for that host, never in production code.
+func serveZai(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	parsed, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	previous := zaiHostSuffixes
+	zaiHostSuffixes = append(append([]string(nil), previous...), parsed.Hostname())
+	t.Cleanup(func() { zaiHostSuffixes = previous })
+
+	t.Setenv("ANTHROPIC_BASE_URL", server.URL+"/api/anthropic")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", sentinelToken)
+	return server
+}
+
+// verifiedPayload is the body observed live from a Pro plan on 2026-09-07,
+// anonymised with magnitudes kept. Both windows carry type=CREDIT_LIMIT and the
+// weekly one is listed FIRST, so a parser keyed on `type` or on array order
+// fails this fixture.
+const verifiedPayload = `{
+  "code": 200, "msg": "Operation successful", "success": true,
+  "data": {
+    "level": "pro",
+    "limits": [
+      {"type":"CREDIT_LIMIT","unit":6,"number":1,"usage":60000,"currentValue":13295,
+       "remaining":46704,"percentage":22,"nextResetTime":1789135610964},
+      {"type":"CREDIT_LIMIT","unit":3,"number":5,"usage":12000,"currentValue":0,
+       "remaining":12000,"percentage":0}
+    ]
+  }
+}`
+
+func TestFetchZaiVerifiedPayload(t *testing.T) {
+	var requests atomic.Int32
+	var gotPath, gotAuth string
+	serveZai(t, func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(verifiedPayload))
+	})
+
+	snapshot, err := FetchZai(context.Background(), http.DefaultClient)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), requests.Load())
+	// The Anthropic-compat path suffix is stripped and the monitor path
+	// appended; the host is whatever the user configured.
+	assert.Equal(t, "/api/monitor/usage/quota/limit", gotPath)
+	// The vendor's own plugin sends the bare token, not "Bearer <token>".
+	assert.Equal(t, sentinelToken, gotAuth)
+
+	assert.Equal(t, ProviderZai, snapshot.ID)
+	assert.Equal(t, "pro", snapshot.Plan)
+	require.Len(t, snapshot.Windows, 2)
+
+	fiveHour := windowByKind(t, snapshot, WindowFiveHour)
+	assert.Equal(t, float64(0), fiveHour.UsedPercentage)
+	sevenDay := windowByKind(t, snapshot, WindowSevenDay)
+	assert.Equal(t, float64(22), sevenDay.UsedPercentage)
+}
+
+func TestFetchZaiPercentageIsConsumptionNotBudget(t *testing.T) {
+	// `usage` is the BUDGET and `currentValue` the consumption. The field names
+	// invite exactly the wrong reading, so pin it: 13295 of 60000 is 22%
+	// consumed, and 60000 must never surface as a percentage.
+	serveZai(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(verifiedPayload))
+	})
+
+	snapshot, err := FetchZai(context.Background(), http.DefaultClient)
+	require.NoError(t, err)
+	sevenDay := windowByKind(t, snapshot, WindowSevenDay)
+	assert.Equal(t, float64(22), sevenDay.UsedPercentage)
+	assert.NotEqual(t, float64(60000), sevenDay.UsedPercentage)
+}
+
+func TestFetchZaiPercentageDerivedWhenAbsent(t *testing.T) {
+	serveZai(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"level":"pro","limits":[
+		  {"unit":6,"number":1,"usage":1000,"currentValue":250}]}}`))
+	})
+
+	snapshot, err := FetchZai(context.Background(), http.DefaultClient)
+	require.NoError(t, err)
+	require.Len(t, snapshot.Windows, 1)
+	assert.Equal(t, float64(25), snapshot.Windows[0].UsedPercentage)
+}
+
+func TestFetchZaiResetTime(t *testing.T) {
+	serveZai(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(verifiedPayload))
+	})
+
+	snapshot, err := FetchZai(context.Background(), http.DefaultClient)
+	require.NoError(t, err)
+
+	sevenDay := windowByKind(t, snapshot, WindowSevenDay)
+	require.NotNil(t, sevenDay.ResetsAt)
+	// nextResetTime is epoch MILLISECONDS.
+	assert.Equal(t, int64(1789135610), *sevenDay.ResetsAt)
+
+	// The 5h window carried no nextResetTime. Nothing may be synthesised for it.
+	fiveHour := windowByKind(t, snapshot, WindowFiveHour)
+	assert.Nil(t, fiveHour.ResetsAt)
+}
+
+func TestFetchZaiUnknownWindowKept(t *testing.T) {
+	// Evidence exists for unit=3 (hour) and unit=6 (week) only. An unknown
+	// pair is kept and labelled from the provider's own numbers rather than
+	// dropped or given a duration it may not have.
+	serveZai(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"level":"pro","limits":[
+		  {"unit":9,"number":2,"usage":100,"currentValue":50,"percentage":50}]}}`))
+	})
+
+	snapshot, err := FetchZai(context.Background(), http.DefaultClient)
+	require.NoError(t, err)
+	require.Len(t, snapshot.Windows, 1)
+	assert.Equal(t, WindowOther, snapshot.Windows[0].Kind)
+	assert.Equal(t, "unit9x2", snapshot.Windows[0].Label)
+	assert.Equal(t, float64(50), snapshot.Windows[0].UsedPercentage)
+}
+
+func TestFetchZaiEmptyLimits(t *testing.T) {
+	serveZai(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"level":"pro","limits":[]}}`))
+	})
+
+	snapshot, err := FetchZai(context.Background(), http.DefaultClient)
+	require.NoError(t, err)
+	assert.Empty(t, snapshot.Windows)
+	assert.Empty(t, snapshot.Error)
+}
+
+func TestFetchZaiHTTPErrorsNeverLeakToken(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusTooManyRequests, http.StatusInternalServerError} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			serveZai(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+				// A server that echoes the credential back must not be able to
+				// push it into an error string agent-deck persists and prints.
+				_, _ = w.Write([]byte(`{"msg":"` + sentinelToken + `"}`))
+			})
+
+			_, err := FetchZai(context.Background(), http.DefaultClient)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), http.StatusText(status))
+			assert.NotContains(t, err.Error(), sentinelToken)
+		})
+	}
+}
+
+func TestFetchZaiTimeout(t *testing.T) {
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	serveZai(t, func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	})
+
+	client := &http.Client{Timeout: 100 * time.Millisecond}
+	start := time.Now()
+	_, err := FetchZai(context.Background(), client)
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), 5*time.Second)
+	assert.NotContains(t, err.Error(), sentinelToken)
+}
+
+func TestFetchZaiNotConfiguredMakesNoRequest(t *testing.T) {
+	var requests atomic.Int32
+	serveZai(t, func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		_, _ = w.Write([]byte(verifiedPayload))
+	})
+
+	tests := []struct {
+		name    string
+		baseURL string
+		token   string
+	}{
+		{"base url unset", "", sentinelToken},
+		{"token unset", "https://api.z.ai/api/anthropic", ""},
+		{"host not z.ai family", "https://evil.example.com/api/anthropic", sentinelToken},
+		{"base url unparseable", "://nonsense", sentinelToken},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("ANTHROPIC_BASE_URL", tt.baseURL)
+			t.Setenv("ANTHROPIC_AUTH_TOKEN", tt.token)
+
+			_, err := FetchZai(context.Background(), http.DefaultClient)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, ErrNotConfigured), "want ErrNotConfigured, got %v", err)
+			assert.NotContains(t, err.Error(), sentinelToken)
+		})
+	}
+	// The point of the assertion: an unconfigured provider reaches no network
+	// at all, rather than making a request that happens to fail.
+	assert.Equal(t, int32(0), requests.Load())
+}
+
+func TestFetchZaiCapsResponseBody(t *testing.T) {
+	previous := maxZaiBodyBytes
+	maxZaiBodyBytes = 512
+	t.Cleanup(func() { maxZaiBodyBytes = previous })
+
+	serveZai(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"level":"` + strings.Repeat("x", 4096) + `","limits":[]}}`))
+	})
+
+	_, err := FetchZai(context.Background(), http.DefaultClient)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), sentinelToken)
+}
+
+func TestZaiQuotaEndpoint(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		want    string
+		wantErr bool
+	}{
+		{"anthropic compat suffix stripped", "https://api.z.ai/api/anthropic", "https://api.z.ai/api/monitor/usage/quota/limit", false},
+		{"trailing slash", "https://api.z.ai/api/anthropic/", "https://api.z.ai/api/monitor/usage/quota/limit", false},
+		{"bare host", "https://api.z.ai", "https://api.z.ai/api/monitor/usage/quota/limit", false},
+		{"regional subdomain", "https://open.bigmodel.z.ai/api/anthropic", "https://open.bigmodel.z.ai/api/monitor/usage/quota/limit", false},
+		{"empty", "", "", true},
+		{"unrelated host", "https://api.anthropic.com", "", true},
+		{"host suffix lookalike", "https://notz.ai/api/anthropic", "", true},
+		{"unparseable", "://nonsense", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := zaiQuotaEndpoint(tt.baseURL)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, ErrNotConfigured))
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

#2192 (`feat(quota): report Claude subscription quota via agent-deck usage`) added
`internal/quota` and the `agent-deck usage` command for Claude, whose quota is
push-only and needs no network. This PR adds the second provider I actually run
alongside Claude — the Z.ai / GLM Coding Plan — and the `--refresh` flag that
only means something once a pull-based provider exists.

**Stacked on #2192 — please read that one first.** This branch is based on it,
so GitHub shows both commits here; only the second one, `feat(quota): add the
Z.ai/GLM provider and --refresh`, belongs to this PR. The first is #2192
verbatim, unchanged. A cross-fork PR cannot take a base branch that lives only
in my fork, which is why the diff is not already narrowed for you; once #2192
lands I will rebase and this PR collapses to that single commit. Reviewing
commit-by-commit, or ignoring the first commit, gives the honest ~669-line diff.

It changes no contract from #2192: the store is already one-file-per-provider
and the report is already a list, so a provider is a new file plus a fetch
path.

Related to Discussion #2082, which does not cover Z.ai at all.

## Why this change

Z.ai/GLM quota comes from the monitor endpoint the vendor's own coding plugin
calls, against the host the user themselves put in `ANTHROPIC_BASE_URL`, using
`ANTHROPIC_AUTH_TOKEN`. It is not a documented public API — which is exactly the
open question @hfreire put first in #2082 and which is still unanswered:

> None of these three endpoints is a documented public API. [...] I would rather
> agree the shape here than open a PR and find out the maintainers do not want
> undocumented endpoints in the tree at all.

Splitting it out this way makes that a decision you can take on its own: if the
answer is "no undocumented endpoints", close this and #2192 still stands.

How the outbound surface is constrained:

- **No hardcoded destination.** The host is derived from `ANTHROPIC_BASE_URL` and
  validated against a z.ai suffix on a dot boundary, so a lookalike (`notz.ai`)
  does not pass. If the variable is unset, unparseable, or points elsewhere, the
  provider reports "not configured", is omitted from the output, and **no request
  is made at all** — there is a test asserting the stub server's request counter
  stays at 0. A machine that never configured Z.ai generates no traffic ever.
- **User-triggered only.** The fetch happens on `agent-deck usage`, never on a
  TUI render path, never on a timer.
- **Bounded.** Explicit client timeout plus a request context, and a capped
  response body so a hostile or broken endpoint cannot make agent-deck allocate.
- **Cached, and a failure is never persisted.** Overwriting a good snapshot with
  a transient timeout would turn one bad minute into a permanently blank
  provider. The last known numbers are kept and shown with the failure attached,
  attributed to the provider that failed. One provider erroring never suppresses
  another, and `usage` still exits 0.
- **The token never reaches an error string, the cache, or stdout.** Every error
  path in the package is asserted against a sentinel credential, including the
  case where the endpoint echoes the token back in its own error body.
- **No estimation, no synthesised resets** — same rules as #2192. A window with no
  consumption yet reports no reset because Z.ai sends none, rather than being
  given one derived from its nominal duration.

Two additions to the model, both driven by what Z.ai actually returns:
`Snapshot.Plan` for the tier the provider names itself (`data.level`), and
`WindowOther` for a window discriminated by a (unit, number) pair this build
cannot name in advance — only two values have been observed, so anything else has
to stay representable without being given a name it may not deserve.

Still out of scope, as in #2192: the TUI status-bar segment, `/api/quota`, the
cost dashboard section, the session badge, and rewiring `usagelimit.go`.

## User impact

```
$ agent-deck usage
Claude  updated 2m ago
  5h       23.5%  resets in 2h13m
  7d       41.2%  resets in 3d5h
Z.ai (pro)  updated 1m ago
  5h        0.0%
  7d       22.0%  resets in 4d3h
```

`--refresh` forces a fetch for pull-based providers, ignoring the cache. Z.ai
requires `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` in the environment (an
agent-deck-launched session has already sourced its profile's env file);
otherwise the provider is skipped silently.

## Evidence

Run against the real endpoint with a live GLM Coding Plan account, in an
isolated HOME:

    $ agent-deck usage --refresh
    Z.ai (pro)  updated 0s ago
      5h        0.0%
      7d       23.0%  resets in 3d19h

That run found the case the design argues about, and found it in the real
payload rather than in a stub: the 5-hour window came back as
`"used_percentage": 0` with **no `resets_at` key at all**, because nothing has
been consumed in it yet. That is why `ResetsAt` is a `*int64` — a non-pointer
would render a window that reset in 1970, and synthesising "now + 5h" would be a
promise agent-deck cannot make. `data.level` supplied the `pro` tier.

The written cache file is 326 bytes in a `0700` directory, and grepping the
account's actual auth token against it finds nothing.

The rest below uses a synthetic statusLine payload; no live account is involved.

    # ANTHROPIC_BASE_URL unset
    $ agent-deck usage
    Claude  updated 0s ago
      5h       23.5%  resets in 2h13m
    $ echo $?
    0

    # a non-z.ai host, and --refresh, which is the case that matters:
    $ ANTHROPIC_BASE_URL=https://evil.example.com ANTHROPIC_AUTH_TOKEN=... \
        agent-deck usage --refresh
    Claude  updated 0s ago
      5h       23.5%  resets in 2h13m
    $ echo $?
    0

No Z.ai line, and no request: the token is not sent to a host the user did not
name as Z.ai.

Sandboxed suite: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
→ every package passes except `internal/tmux`, and the bootstrap-leak sentinel in
`internal/testutil` that watches it, which fail under the full parallel run and
pass on re-run in isolation (`go test ./internal/tmux/ ./internal/testutil/` →
ok, 60s / 24s). They fail the same way on a clean `upstream/main` worktree, and
nothing in this branch touches the tmux layer.

One more thing worth knowing if you run the suite from inside an agent-deck
session: `cmd/agent-deck` fails unless `AGENTDECK_INSTANCE_ID` is unset, because
a test spawns `main()`, which then tries to resolve the inherited id as a parent
session. `env -u AGENTDECK_INSTANCE_ID go test ./cmd/agent-deck/` → ok. Also
pre-existing on `upstream/main`.

`golangci-lint run` (v2.13.2, whole repo) → 0 issues. `gofmt -l`, `go vet ./...`,
`go build ./...` clean.

Revert-check note: the tests do not compile against `upstream/main`, so the
whole-diff revert cannot run; reverted per-hunk instead. Removing the
`isZaiHost` check in `zaiQuotaEndpoint`:

    --- FAIL: TestFetchZaiNotConfiguredMakesNoRequest/host_not_z.ai_family
        zai_test.go:219: want ErrNotConfigured, got quota request failed:
            dial tcp: lookup evil.example.com: no such host

That is the hunk worth reading: with the host check gone, an
`ANTHROPIC_BASE_URL` pointing anywhere at all would receive the auth token. The
test fails because the request went out.

**Pre-justified WARN from `self-check.sh`:** *new outbound network call in
production path* — `internal/quota/zai.go`, constrained as listed above.

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-5

**Prompt / session log (optional):** —

## What actually bothered you

My human asked (in French; translated):

"I run several Claude Code and Z.ai/GLM agents at once through Agent Deck. What
actually stops me is the provider's 5-hour and weekly subscription quota, not the
dollar cost. I want to see the real subscription limits in Agent Deck — not an
estimate derived from token counts — instead of opening provider dashboards or
running separate tools."

The Claude half alone does not answer that: half my agents run on GLM.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

**On diff size:** 669 added lines against #2192, of which ~270 are tests. All of
the outbound-network surface in the feature is in this PR and nowhere else.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiXDy2qqQ6aLr7HV2jye1t

<!-- gate:ai=authored model=claude-opus-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an `agent-deck usage` command to view provider subscription quotas in human-readable or JSON format.
  - Added cached quota reporting with profile-specific data, stale-status indicators, reset times, and provider error handling.
  - Added Claude status-line ingestion and optional forwarding to wrapped commands.
  - Added Z.ai quota retrieval with support for usage windows and percentage limits.
- **Security & Reliability**
  - Credentials and sensitive command data are excluded from stored and displayed quota information.
  - Provider failures and malformed cache data are isolated without hiding other results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->