### PR TITLE
fix(session): exclude archived sessions from group capacity

### DIFF
--- a/internal/session/group_concurrency.go
+++ b/internal/session/group_concurrency.go
@@ -24,16 +24,16 @@ func IsAtCap(running, max int) bool {
 	return running >= max
 }
 
-// CountRunningInGroup returns the number of instances in the given group whose
-// status is StatusRunning. Queued, stopped, and other-group instances are not
-// counted.
+// CountRunningInGroup returns the number of active instances in the given
+// group whose status is StatusRunning. Queued, stopped, archived, and
+// other-group instances are not counted.
 func CountRunningInGroup(instances []*Instance, groupPath string) int {
 	n := 0
 	for _, inst := range instances {
 		if inst == nil {
 			continue
 		}
-		if inst.GroupPath == groupPath && inst.Status == StatusRunning {
+		if inst.GroupPath == groupPath && inst.Status == StatusRunning && !inst.IsArchived() {
 			n++
 		}
 	}

--- a/internal/session/group_concurrency_test.go
+++ b/internal/session/group_concurrency_test.go
@@ -157,12 +157,13 @@ func TestGroup_NewGroupDefault_ConfigN(t *testing.T) {
 	}
 }
 
-// TestGroup_CountRunningInGroup verifies the count helper only includes
-// running sessions in the target group (not queued, not other groups).
+// TestGroup_CountRunningInGroup verifies the count helper only includes active
+// running sessions in the target group (not queued, archived, or other groups).
 func TestGroup_CountRunningInGroup(t *testing.T) {
 	instances := []*Instance{
 		{GroupPath: "g", Status: StatusRunning},
 		{GroupPath: "g", Status: StatusRunning},
+		{GroupPath: "g", Status: StatusRunning, ArchivedAt: time.Now()},
 		{GroupPath: "g", Status: StatusQueued},
 		{GroupPath: "g", Status: StatusStopped},
 		{GroupPath: "other", Status: StatusRunning},


### PR DESCRIPTION
## What problem does this solve?

Archived sessions whose stored status is still `running` consume a group's concurrency capacity, so new active work can be queued even when the group has no active running session.

## Why this change

Group admission already counts exact-group `running` sessions. Adding the existing `IsArchived` predicate at that counting chokepoint preserves exact-group and configured-cap behavior while excluding retained history.

## User impact

Archived session history remains available, but no longer blocks new work from starting. Active running sessions still enforce the configured group cap.

## Evidence

- Regression: `go test ./internal/session -run '^(TestGroup_CountRunningInGroup|TestGroup_LaunchOverCap_Queues|TestGroup_UnlimitedLegacy)$' -count=1` passes.
- TDD mutation evidence: without the archived predicate, `TestGroup_CountRunningInGroup` fails with `expected 2, got 3`.
- `make lint` passes with `0 issues`.
- `make build` passes.
- `git diff --check` passes.
- Local full-suite disclosure: the mandatory repository wrapper completed on clean base and head checkouts. Both remain red on 13 common pre-existing environment/platform failures; five differing timing-sensitive failures all passed a focused repaired-head rerun, and one head-only failure reproduced on base. This draft PR is being opened to obtain authoritative CI rather than claiming the local full suite is green.
- Isolated CLI proof with group cap `1`: an archived persisted `running` row did not queue a newly added same-group session; no live registry or cap was changed.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-5-codex

**Prompt / session log (optional):** Not included.

## What actually bothered you

My human asked: "Fix Agent Deck admission counting archived sessions" because retained archived-running history was blocking BaBa workers despite no active load.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included (not applicable; admission predicate only)
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=gpt-5-codex intent=yes -->
