### PR TITLE
fix(ui): only show the account badge when account slots are configured

### DIFF
--- a/internal/ui/account_slot_gate_test.go
+++ b/internal/ui/account_slot_gate_test.go
@@ -1,0 +1,101 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/stretchr/testify/require"
+)
+
+// #2122 shipped the stored-slot badge ungated, so a machine with no
+// [profiles.<name>.claude].config_dir block got "[account:inherited]" on every
+// session row while the New/Edit Session dialogs correctly hid their account
+// rows (#2152 gates those on ConfiguredAccountNames). The badge must use the
+// same gate: no configured slots means the inherited badge carries no
+// information and costs title width on every row.
+func TestInheritedBadgeHiddenWithoutConfiguredSlots(t *testing.T) {
+	inst := &session.Instance{ID: "gate-inherited", Title: "no-slot-session", Tool: "shell", Status: session.StatusIdle}
+
+	for _, refreshed := range []bool{false, true} {
+		name := "fallback"
+		if refreshed {
+			name = "snapshot"
+		}
+		t.Run(name, func(t *testing.T) {
+			h := NewHome()
+			h.width, h.height = 240, 40
+			h.accountSlotsConfigured.Store(false)
+			if refreshed {
+				h.refreshSessionRenderSnapshot([]*session.Instance{inst})
+			}
+			for _, selected := range []bool{false, true} {
+				var b strings.Builder
+				h.renderSessionItem(&b, session.Item{Type: session.ItemTypeSession, Session: inst, Level: 1, Path: "work", IsLastInGroup: true}, selected, h.getSessionRenderSnapshot(), 240)
+				row := b.String()
+				require.NotContains(t, row, "[account:", "no configured slots means no account badge")
+				require.NotContains(t, row, "inherited")
+				require.Contains(t, row, "no-slot-session", "suppressing the badge must not disturb the title")
+				require.Equal(t, 1, strings.Count(row, "\n"))
+			}
+
+			card := h.renderSessionInfoCard(inst, 240, 40)
+			require.NotContains(t, card, "Account slot:", "the card drops the line rather than printing an empty value")
+			require.NotContains(t, card, "inherited")
+		})
+	}
+}
+
+// The gate is about the inherited label only. A session carrying an explicit
+// slot still reports it even when config.toml no longer declares that profile,
+// because the session really does run against that slot's config dir.
+func TestExplicitSlotStillRendersWithoutConfiguredSlots(t *testing.T) {
+	inst := &session.Instance{ID: "gate-explicit", Title: "slotted", Tool: "shell", Status: session.StatusIdle, Account: "work"}
+
+	h := NewHome()
+	h.width, h.height = 240, 40
+	h.accountSlotsConfigured.Store(false)
+	h.refreshSessionRenderSnapshot([]*session.Instance{inst})
+
+	var b strings.Builder
+	h.renderSessionItem(&b, session.Item{Type: session.ItemTypeSession, Session: inst, Level: 1, Path: "work", IsLastInGroup: true}, false, h.getSessionRenderSnapshot(), 240)
+	require.Contains(t, b.String(), `[account:"work"]`)
+	require.Contains(t, h.renderSessionInfoCard(inst, 240, 40), "Account slot:")
+}
+
+// With at least one slot configured the badge is meaningful again: "inherited"
+// then distinguishes a session following the conductor/group/env chain from one
+// pinned to a named slot, so it must come back for both.
+func TestBadgeReturnsWhenSlotsAreConfigured(t *testing.T) {
+	inherited := &session.Instance{ID: "gate-on-inherited", Title: "follows-chain", Tool: "shell", Status: session.StatusIdle}
+	pinned := &session.Instance{ID: "gate-on-pinned", Title: "pinned", Tool: "shell", Status: session.StatusIdle, Account: "personal"}
+
+	h := NewHome()
+	h.width, h.height = 240, 40
+	h.accountSlotsConfigured.Store(true)
+	h.refreshSessionRenderSnapshot([]*session.Instance{inherited, pinned})
+
+	for inst, want := range map[*session.Instance]string{
+		inherited: "[account:inherited]",
+		pinned:    `[account:"personal"]`,
+	} {
+		var b strings.Builder
+		h.renderSessionItem(&b, session.Item{Type: session.ItemTypeSession, Session: inst, Level: 1, Path: "work", IsLastInGroup: true}, false, h.getSessionRenderSnapshot(), 240)
+		require.Contains(t, b.String(), want)
+	}
+}
+
+// The gate is a pure function of the stored slot and the configured-slot flag;
+// pin it directly so a future refactor of the render path cannot quietly
+// reintroduce a zero-width badge that still reserves prefix width.
+func TestAccountPresentationGate(t *testing.T) {
+	hidden := newAccountPresentation("", false)
+	require.Equal(t, accountPresentation{}, hidden, "suppressed badge must be the zero value, not an empty-labelled one")
+	badge, width := hidden.fit(0)
+	require.Empty(t, badge)
+	require.Zero(t, width)
+
+	shown := newAccountPresentation("", true)
+	require.Equal(t, "inherited", shown.label)
+	require.Equal(t, " [account:inherited]", shown.badge)
+}

--- a/internal/ui/account_slot_label.go
+++ b/internal/ui/account_slot_label.go
@@ -21,7 +21,16 @@ type accountPresentation struct {
 	quoted bool
 }
 
-func newAccountPresentation(account string) accountPresentation {
+// slotsConfigured reports whether this machine has any named account slot. An
+// empty stored slot only carries information when it could have been something
+// else, so on a single-login machine the inherited badge is suppressed entirely
+// (zero value: no badge, no width). An explicit slot always renders — a session
+// can hold a slot whose profile was since removed from config.toml, and hiding
+// that would misreport which config dir the session actually runs on.
+func newAccountPresentation(account string, slotsConfigured bool) accountPresentation {
+	if account == "" && !slotsConfigured {
+		return accountPresentation{}
+	}
 	label := storedAccountLabel(account)
 	return accountPresentation{
 		label:  label,

--- a/internal/ui/account_slot_render_test.go
+++ b/internal/ui/account_slot_render_test.go
@@ -11,6 +11,8 @@ import (
 
 // These controls intentionally use only pre-existing rendering entry points.
 // They must reproduce missing stored-slot output on the unmodified baseline.
+// Slots are configured here so the inherited case stays covered; the
+// no-slots-configured gate lives in account_slot_gate_test.go.
 func TestStoredAccountRenderBaseline(t *testing.T) {
 	slots := []string{"personal", "work", "", "inherited", " 日本 e\u0301 🚀 ", "quote\"slash\\", "\x1b]0;injected\a\r\n\u0085\u202e"}
 	for _, account := range slots {
@@ -28,6 +30,7 @@ func TestStoredAccountRenderBaseline(t *testing.T) {
 				t.Run(name, func(t *testing.T) {
 					h := NewHome()
 					h.width, h.height = 240, 40
+					h.accountSlotsConfigured.Store(true)
 					if refreshed {
 						h.refreshSessionRenderSnapshot([]*session.Instance{inst})
 					}
@@ -43,6 +46,7 @@ func TestStoredAccountRenderBaseline(t *testing.T) {
 				})
 				t.Run(name+"_card", func(t *testing.T) {
 					h := NewHome()
+					h.accountSlotsConfigured.Store(true)
 					if refreshed {
 						h.refreshSessionRenderSnapshot([]*session.Instance{inst})
 					}

--- a/internal/ui/account_slot_width_test.go
+++ b/internal/ui/account_slot_width_test.go
@@ -18,7 +18,7 @@ func TestStoredAccountWidthMatrix(t *testing.T) {
 					h := NewHome()
 					h.width, h.height = width, 40
 					inst := &session.Instance{ID: "width", Title: strings.Repeat("Title日本e\u0301", 8), Tool: "shell", Status: session.StatusIdle, Account: slot}
-					state := sessionRenderState{status: session.StatusIdle, tool: "shell", title: inst.Title, account: slot, accountDisplay: newAccountPresentation(slot), autoName: auto, paneTitle: "pane subtitle", autoNameDesc: "description"}
+					state := sessionRenderState{status: session.StatusIdle, tool: "shell", title: inst.Title, account: slot, accountDisplay: newAccountPresentation(slot, true), autoName: auto, paneTitle: "pane subtitle", autoNameDesc: "description"}
 					for _, selected := range []bool{false, true} {
 						var b strings.Builder
 						h.renderSessionItem(&b, session.Item{Type: session.ItemTypeSession, Session: inst, Level: 1, Path: "work", IsLastInGroup: true}, selected, map[string]sessionRenderState{inst.ID: state}, width)

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -555,6 +555,16 @@ type Home struct {
 	// one. Cached here so all rows of a frame agree; reloaded after panel save.
 	showPaneTitles bool
 
+	// accountSlotsConfigured mirrors len(session.ConfiguredAccountNames(cfg)) > 0,
+	// the same gate the New/Edit Session dialogs use to hide their account rows
+	// (#2152). A machine with no [profiles.<name>.claude].config_dir block has
+	// one login, so "which slot is this session on" is not a question that can
+	// have two answers — the inherited badge would be dead width on every row.
+	// Atomic because refreshSessionRenderSnapshot reads it from the background
+	// refresher goroutine while the settings panel writes it from the Bubble Tea
+	// event loop. Explicit slots ignore this gate; see newAccountPresentation.
+	accountSlotsConfigured atomic.Bool
+
 	// Sessions/Preview split (issue #1092): percentage of width allocated to
 	// preview pane. Loaded from config.toml [ui] preview_pct, adjustable
 	// live via < and > keybindings, persisted back to config on adjustment.
@@ -1914,6 +1924,9 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 
 	// Hook-based status detection (Claude Code lifecycle hooks)
 	userConfig, _ := session.LoadUserConfig()
+	// Seed the account-badge gate from the same config read; the settings panel
+	// refreshes it on save so adding a slot lights the badges without a restart.
+	h.accountSlotsConfigured.Store(len(session.ConfiguredAccountNames(userConfig)) > 0)
 	hooksEnabled := userConfig == nil || userConfig.Claude.GetHooksEnabled()
 	if homeBackgroundWorkersEnabled && hooksEnabled {
 		configDir := session.GetClaudeConfigDir()
@@ -5216,6 +5229,7 @@ func (h *Home) refreshSessionRenderSnapshot(instances []*session.Instance) {
 
 	snap := make(map[string]sessionRenderState, len(instances))
 	accounts := make(map[string]accountPresentation)
+	slotsConfigured := h.accountSlotsConfigured.Load()
 	for _, inst := range instances {
 		if inst == nil {
 			continue
@@ -5236,7 +5250,7 @@ func (h *Home) refreshSessionRenderSnapshot(instances []*session.Instance) {
 		}
 		display, ok := accounts[state.account]
 		if !ok {
-			display = newAccountPresentation(state.account)
+			display = newAccountPresentation(state.account, slotsConfigured)
 			accounts[state.account] = display
 		}
 		state.accountDisplay = display
@@ -5284,7 +5298,7 @@ func (h *Home) getSessionRenderState(inst *session.Instance) sessionRenderState 
 		status:         inst.GetStatusThreadSafe(),
 		tool:           inst.GetToolThreadSafe(),
 		account:        account,
-		accountDisplay: newAccountPresentation(account),
+		accountDisplay: newAccountPresentation(account, h.accountSlotsConfigured.Load()),
 		title:          inst.GetTitleThreadSafe(),
 		autoName:       inst.GetAutoName(),
 		autoNameDesc:   inst.GetAutoNameDescription(),
@@ -8691,6 +8705,9 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 				h.reloadHotkeysFromConfig()
 				h.showSessionTimestamps = config.Display.ShowSessionTimestamps
 				h.showPaneTitles = config.Display.ShowPaneTitles
+				// A slot added here must light the badges now; the next snapshot
+				// refresh reads this flag.
+				h.accountSlotsConfigured.Store(len(session.ConfiguredAccountNames(config)) > 0)
 
 				// Apply theme changes live
 				h.stopThemeWatcher()
@@ -19991,9 +20008,12 @@ func (h *Home) renderSessionInfoCard(inst *session.Instance, width, height int) 
 	b.WriteString(fmt.Sprintf("%s %s\n", labelStyle.Render("Tool:"), valueStyle.Render(cardTool)))
 
 	// Use the same cached metadata as the row; no account/config resolution.
-	account := h.getSessionRenderState(inst).accountDisplay.label
-	account = cellTruncate(account, max(0, width-cellWidth("Account slot: ")), "…")
-	b.WriteString(fmt.Sprintf("%s %s\n", labelStyle.Render("Account slot:"), valueStyle.Render(account)))
+	// An empty label means the row suppressed the badge (single-login machine,
+	// inherited slot) — drop the whole line rather than print an empty value.
+	if account := h.getSessionRenderState(inst).accountDisplay.label; account != "" {
+		account = cellTruncate(account, max(0, width-cellWidth("Account slot: ")), "…")
+		b.WriteString(fmt.Sprintf("%s %s\n", labelStyle.Render("Account slot:"), valueStyle.Render(account)))
+	}
 
 	// Session ID (if available) - Claude, Gemini, OpenCode, or generic (Hermes/custom tools)
 	sessionID := inst.ClaudeSessionID


### PR DESCRIPTION
## What problem does this solve?

Fixes #2197. On a machine with no account slots configured, every session row renders `[account:inherited]`. With a single login there is no other slot a session could be on, so the badge carries no information, and it costs title width on every row of the deck.

## Why this change

#2152 already set the rule for this feature: it hides the New Session and Edit Session account rows when `session.ConfiguredAccountNames()` is empty, in its own words "so a single-login machine sees no dead controls". The row badge from #2122 simply did not get that gate. This applies the same one, through the same helper, so the badge and the dialogs agree about when accounts are a thing on this machine.

An explicit slot is deliberately **not** gated. A session can carry a slot whose profile was since removed from `config.toml`, and it still runs against that slot's config dir — suppressing it would misreport where the session actually lives.

The gate is cached on `Home` as an `atomic.Bool` rather than read per row: `refreshSessionRenderSnapshot` runs on the background refresher goroutine, so a `LoadUserConfig()` there would put file I/O and a data race on the render path. It is seeded from the config read the constructor already does, and refreshed in the settings-panel save path next to `showSessionTimestamps`/`showPaneTitles`, so adding a slot lights the badges without a restart.

The info card drops its `Account slot:` line when the badge is suppressed, rather than printing the label with an empty value.

## User impact

Single-login machines (no `[profiles.<name>.claude].config_dir` in `config.toml`) no longer see `[account:inherited]` on every session row, and get that width back for titles. Machines with at least one configured slot are unchanged: both `inherited` and named slots render exactly as before. Sessions carrying an explicit slot always show it either way.

## Evidence

Reproduced on a sandboxed `HOME` with two shell sessions and no configured slots, built from `main` at 5235e160.

Before (`main`) — badge on every row:

```
SESSIONS
──────────────────────────────────────────
  ▾ tmp.XXXXXXXX (2)
   ├─ ✕ alpha shell [account:inherited]
   └─ ✕ beta shell [account:inherited]
```

while the CLI agrees there are no slots:

```
$ agent-deck accounts
No named account slots configured.
Add one as [profiles.<name>.claude].config_dir in <sandbox>/.config/agent-deck/config.toml.
```

After (this branch), same deck, same sandbox:

```
SESSIONS
──────────────────────────────────────────
  ▾ tmp.XXXXXXXX (2)
   ├─ ✕ alpha shell
   └─ ✕ beta shell
```

Then adding one slot to the sandbox config:

```
$ cat >> <sandbox>/.config/agent-deck/config.toml <<'EOF'
[profiles.personal.claude]
config_dir = "<sandbox>/claude-personal"
EOF
$ agent-deck accounts
personal             <sandbox>/claude-personal   ok
```

brings the badge back, confirming the gate is not a one-way removal:

```
   ├─ ✕ alpha shell [account:inherited]
   └─ ✕ beta shell [account:inherited]
```

Revert-check — `self-check.sh` reports `WARN revert-check: tests do not compile on base (new symbols)`, because reverting the whole diff also reverts the `slotsConfigured` parameter the new tests call. So I ran the check the meaningful way instead: revert **only** the two-line guard in `newAccountPresentation`, keep the tests, re-run them:

```
--- FAIL: TestInheritedBadgeHiddenWithoutConfiguredSlots/fallback
    Error: "   └─ ○ no-slot-session shell [account:inherited]\n" should not contain "[account:"
    Messages: no configured slots means no account badge
--- FAIL: TestInheritedBadgeHiddenWithoutConfiguredSlots/snapshot
    Error: "   └─ ○ no-slot-session shell [account:inherited]\n" should not contain "[account:"
--- FAIL: TestAccountPresentationGate
    Messages: suppressed badge must be the zero value, not an empty-labelled one
FAIL	github.com/asheshgoplani/agent-deck/internal/ui
```

Sandboxed suite, the package this touches:

```
$ HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...
ok  	github.com/asheshgoplani/agent-deck/internal/ui	53.103s
```

`gofmt -l ./cmd ./internal` prints nothing; `go vet ./...` is clean.

Honest note on the full-suite run: 29 tests fail on this machine (macOS, tmux 3.6a) in `cmd/agent-deck`, `internal/session`, `internal/tmux`, `internal/agents`, `internal/testutil`. I checked every one of them against a clean `main` with the same command and they fail identically there, so they are pre-existing and environmental, not from this diff. Examples: `TestCLIStoredAccountVisibility` fails parsing `--json` output because the tmux 3.6a heads-up banner lands in `CombinedOutput`; the `TestIsLiveTmuxClientOrServer_*` family and `TestPipeManager_ConnectPreservesLiveSibling` fail the same way on `main` in isolation. `internal/ui`, the only package this PR changes, is green.

Not a hot path: this removes work from the row render (a suppressed badge is the zero value, so `fit` returns immediately) and adds one atomic load per snapshot refresh. No `list`/`status`/`session output`/startup/tmux behavior changes.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-5

## What actually bothered you

My human asked: "could you check what did agent-deck updated (first git pull) that all of my sessions now have [account:inherited]". They run a 44-session deck with a single Claude login, so after updating they had the same meaningless badge on all 44 rows, taking width away from the titles they actually navigate by.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=claude-opus-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Account badges are now hidden when no account slots are configured.
  * Session details no longer show an empty account-slot row.
  * Explicitly assigned accounts and configured slots continue to display correctly.
  * Account badges update appropriately after account-slot settings change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->