### PR TITLE
fix(send): recover swallowed Codex submit Enter

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -16,6 +16,8 @@ jobs:
           go-version: '1.25.13'
           check-latest: false
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        # v1.8.0 is the first release requiring Go 1.26; keep the scanner
+        # compatible with the repository's pinned Go 1.25.13 toolchain.
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
       - name: Run govulncheck (strict — fails on any reachable vuln)
         run: govulncheck ./...

--- a/cmd/agent-deck/add_launch_honesty_test.go
+++ b/cmd/agent-deck/add_launch_honesty_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestAddJSONExplicitlyReportsRegistrationOnly keeps automation from treating
+// successful registration as a successful launch. add deliberately does not
+// create a tmux pane unless --attach is requested.
+func TestAddJSONExplicitlyReportsRegistrationOnly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	project := filepath.Join(home, "project")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, code := runAgentDeck(t, home,
+		"add", "--title", "registration-only", "--cmd", "shell", "--no-parent", "--json", project)
+	if code != 0 {
+		t.Fatalf("add --json exit = %d\nstdout: %s\nstderr: %s", code, stdout, stderr)
+	}
+	var response struct {
+		Success bool   `json:"success"`
+		Started *bool  `json:"started"`
+		ID      string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("parse add JSON: %v\nstdout: %s", err, stdout)
+	}
+	if !response.Success || response.ID == "" {
+		t.Fatalf("add result = %#v, want successful registration with an id", response)
+	}
+	if response.Started == nil || *response.Started {
+		t.Fatalf("add JSON started = %v, want explicit false; stdout: %s", response.Started, stdout)
+	}
+}

--- a/cmd/agent-deck/issue1793_delivery_verify_test.go
+++ b/cmd/agent-deck/issue1793_delivery_verify_test.go
@@ -126,6 +126,69 @@ func TestIssue1793_NonClaudeTypedPromptGetsAnAttributableRecoveryEnter(t *testin
 	}
 }
 
+func TestIssue1793_CodexRecoveryAttemptIsConsumedWhenEnterFails(t *testing.T) {
+	const msg = "ISSUE1793 CODEX RECOVERY ATTEMPT distinctive prompt body"
+	mock := &mockSendRetryTarget{
+		statuses:     []string{"waiting"},
+		panes:        []string{"codex>\n", "codex> " + msg + "\n"},
+		sendEnterErr: errors.New("tmux send-keys Enter failed"),
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0, tool: "codex",
+	})
+
+	if err == nil || delivery != deliveryTyped {
+		t.Fatalf("failed recovery must stay an unconfirmed typed delivery: delivery=%q err=%v", delivery, err)
+	}
+	if got := atomic.LoadInt32(&mock.sendEnterCalls); got != 1 {
+		t.Fatalf("a failed recovery Enter must still consume the one-attempt budget, got %d attempts", got)
+	}
+}
+
+func TestIssue1793_CodexForeignDraftIsNeverSubmittedByRecovery(t *testing.T) {
+	const msg = "ISSUE1793 CODEX FOREIGN DRAFT distinctive prompt body"
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		// The body reached scrollback, but another actor replaced the current
+		// Codex composer before recovery. The prompt marker is Codex's native
+		// `codex>` form, not Claude's glyph.
+		panes: []string{"codex>\n", "history: " + msg + "\ncodex> deploy production immediately\n"},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0, tool: "codex",
+	})
+
+	if err == nil || delivery != deliveryTyped {
+		t.Fatalf("foreign-draft recovery must remain unconfirmed: delivery=%q err=%v", delivery, err)
+	}
+	if got := atomic.LoadInt32(&mock.sendEnterCalls); got != 0 {
+		t.Fatalf("recovery must not submit a foreign Codex draft, got %d Enter presses", got)
+	}
+}
+
+func TestIssue1793_CodexActiveTransitionNeedsNoRecoveryEnter(t *testing.T) {
+	const msg = "ISSUE1793 CODEX NORMAL SUBMIT distinctive prompt body"
+	mock := &mockSendRetryTarget{
+		// Baseline is waiting; the first post-send sample is active, so this
+		// normal submission must return before inspecting/nudging the pane.
+		statuses: []string{"waiting", "active"},
+		panes:    []string{"codex>\n", "history: " + msg + "\ncodex>\n"},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0, tool: "codex",
+	})
+
+	if err != nil || delivery != deliverySubmitted {
+		t.Fatalf("active transition must remain submitted without recovery: delivery=%q err=%v", delivery, err)
+	}
+	if got := atomic.LoadInt32(&mock.sendEnterCalls); got != 0 {
+		t.Fatalf("already-submitted Codex turn must not receive recovery Enter, got %d", got)
+	}
+}
+
 // TestIssue1793_ClaudePath_TypedButNeverSubmitted_IsNotSuccess is the Claude
 // half of the same defect. The Claude verification loop treated "the body is
 // visible in the pane" as delivery evidence and, at the end of its budget,

--- a/cmd/agent-deck/issue1793_delivery_verify_test.go
+++ b/cmd/agent-deck/issue1793_delivery_verify_test.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/asheshgoplani/agent-deck/internal/session"
 	"github.com/asheshgoplani/agent-deck/internal/tmux"
 )
 
@@ -165,6 +166,72 @@ func TestIssue1793_CodexForeignDraftIsNeverSubmittedByRecovery(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&mock.sendEnterCalls); got != 0 {
 		t.Fatalf("recovery must not submit a foreign Codex draft, got %d Enter presses", got)
+	}
+}
+
+// TestIssue1793_CodexForeignDraftConsumesRecoveryBudgetAcrossPaneChanges
+// covers the race between arrival evidence and recovery: the body is first
+// visible, but the composer belongs to another actor when recovery is
+// considered. Even if a later capture looks like our draft again, that
+// attribution refusal must consume the only recovery opportunity rather than
+// risk submitting a concurrently replaced prompt.
+func TestIssue1793_CodexForeignDraftConsumesRecoveryBudgetAcrossPaneChanges(t *testing.T) {
+	const msg = "ISSUE1793 CODEX CHANGING PANE distinctive prompt body"
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting"},
+		panes: []string{
+			"codex>\n", // pre-send baseline
+			"history: " + msg + "\ncodex> deploy production immediately\n",
+			"history: " + msg + "\ncodex> " + msg + "\n",
+		},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
+		maxRetries: 3, checkDelay: 0, tool: "codex",
+	})
+
+	if err == nil || delivery != deliveryTyped {
+		t.Fatalf("foreign-draft recovery must remain unconfirmed: delivery=%q err=%v", delivery, err)
+	}
+	if got := atomic.LoadInt32(&mock.sendEnterCalls); got != 0 {
+		t.Fatalf("an attribution refusal must consume recovery budget; got %d Enter presses after pane changed back", got)
+	}
+}
+
+// TestIssue1793_CustomCodexCompatibleToolGetsBoundedRecoveryEnter proves the
+// recovery capability follows compatible_with rather than the built-in tool
+// name, so wrappers retain the same one-Enter safety boundary as native Codex.
+func TestIssue1793_CustomCodexCompatibleToolGetsBoundedRecoveryEnter(t *testing.T) {
+	const tool = "issue1793_codex_wrapper"
+	const msg = "ISSUE1793 CUSTOM CODEX RECOVERY distinctive prompt body"
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", "")
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+	if err := session.SaveUserConfig(&session.UserConfig{Tools: map[string]session.ToolDef{
+		tool: {Command: "company-codex-wrapper", CompatibleWith: "codex"},
+	}}); err != nil {
+		t.Fatalf("save custom Codex-compatible tool: %v", err)
+	}
+	if !session.IsCodexCompatible(tool) {
+		t.Fatal("custom tool with compatible_with=codex must receive Codex recovery behavior")
+	}
+
+	mock := &mockSendRetryTarget{
+		statuses: []string{"waiting", "waiting", "active"},
+		panes:    []string{"codex>\n", "codex> " + msg + "\n"},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0, tool: tool,
+	})
+
+	if err != nil || delivery != deliverySubmitted {
+		t.Fatalf("custom Codex-compatible recovery must submit: delivery=%q err=%v", delivery, err)
+	}
+	if got := atomic.LoadInt32(&mock.sendEnterCalls); got != 1 {
+		t.Fatalf("custom Codex-compatible tool: want one bounded recovery Enter, got %d", got)
 	}
 }
 

--- a/cmd/agent-deck/issue1793_delivery_verify_test.go
+++ b/cmd/agent-deck/issue1793_delivery_verify_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/asheshgoplani/agent-deck/internal/tmux"
@@ -92,6 +93,36 @@ func TestIssue1793_LargePayloadVisibleInPane_IsReportedTypedNotSubmitted(t *test
 	}
 	if fields := (sendDeliveryResult{delivery: delivery}).jsonFields(); fields["submitted"] != false {
 		t.Fatalf("typed must report submitted=false in --json, got %v", fields["submitted"])
+	}
+}
+
+// TestIssue1793_NonClaudeTypedPromptGetsAnAttributableRecoveryEnter reproduces
+// the production Codex failure: the initial Enter is swallowed, while the body
+// is visibly parked in the pane. Codex takes the non-Claude verification path;
+// that path used to report DELIVERY_FAILED after its arrival checks without
+// ever trying the one bare Enter that immediately starts the turn.
+func TestIssue1793_NonClaudeTypedPromptGetsAnAttributableRecoveryEnter(t *testing.T) {
+	const msg = "ISSUE1793 CODEX SUBMIT RECOVERY distinctive prompt body"
+	mock := &mockSendRetryTarget{
+		// The first read is the pre-send baseline. The first post-send read
+		// remains waiting because the original Enter was swallowed; after the
+		// recovery Enter the target starts work.
+		statuses: []string{"waiting", "waiting", "active"},
+		panes:    []string{"codex>\n", "codex> " + msg + "\n"},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
+		maxRetries: 4, checkDelay: 0, tool: "codex",
+	})
+
+	if err != nil {
+		t.Fatalf("a recovered Codex submission must succeed: %v", err)
+	}
+	if delivery != deliverySubmitted {
+		t.Fatalf("delivery: want %q, got %q", deliverySubmitted, delivery)
+	}
+	if got := atomic.LoadInt32(&mock.sendEnterCalls); got != 1 {
+		t.Fatalf("visible prompt with swallowed initial Enter: want one recovery Enter, got %d", got)
 	}
 }
 

--- a/cmd/agent-deck/issue1793_delivery_verify_test.go
+++ b/cmd/agent-deck/issue1793_delivery_verify_test.go
@@ -274,6 +274,20 @@ func TestIssue1793_CodexWorkingPaneConfirmsSubmittedNoWaitSend(t *testing.T) {
 	}
 }
 
+func TestIssue1793_CodexTimedWorkingPaneConfirmsSubmitted(t *testing.T) {
+	const msg = "ISSUE1793 TIMED CODEX WORKING submitted prompt"
+	mock := &mockSendRetryTarget{statuses: []string{"active"}, panes: []string{
+		"codex>\n", "• Working (4s • esc to interrupt)\n" + msg + "\n",
+	}}
+	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{maxRetries: 3, checkDelay: 0, tool: "codex"})
+	if err != nil || delivery != deliverySubmitted {
+		t.Fatalf("timed Codex Working pane = delivery %q, err %v; want submitted", delivery, err)
+	}
+	if got := atomic.LoadInt32(&mock.sendEnterCalls); got != 0 {
+		t.Fatalf("timed Working state must not receive recovery Enter, got %d", got)
+	}
+}
+
 func TestIssue1793_CodexPayloadWorkingLineIsNotSubmissionEvidence(t *testing.T) {
 	const msg = "working on the deployment plan"
 	mock := &mockSendRetryTarget{

--- a/cmd/agent-deck/issue1793_delivery_verify_test.go
+++ b/cmd/agent-deck/issue1793_delivery_verify_test.go
@@ -274,6 +274,128 @@ func TestIssue1793_CodexWorkingPaneConfirmsSubmittedNoWaitSend(t *testing.T) {
 	}
 }
 
+func TestIssue1793_CodexPayloadWorkingLineIsNotSubmissionEvidence(t *testing.T) {
+	const msg = "working on the deployment plan"
+	mock := &mockSendRetryTarget{
+		statuses: []string{"active"},
+		panes: []string{
+			"codex>\n",
+			msg + "\n",
+		},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
+		maxRetries: 3, checkDelay: 0, tool: "codex",
+	})
+	if err == nil || delivery == deliverySubmitted {
+		t.Fatalf("payload text beginning with working must not submit: delivery=%q err=%v", delivery, err)
+	}
+}
+
+func TestIssue1793_CodexUnrelatedWorkingLineNeedsThisBody(t *testing.T) {
+	const msg = "ISSUE1793 ATTRIBUTABLE CODEX BODY"
+	mock := &mockSendRetryTarget{
+		statuses: []string{"active"},
+		panes: []string{
+			"codex>\n",
+			"• Working\nunrelated request\n",
+		},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
+		maxRetries: 3, checkDelay: 0, tool: "codex",
+	})
+	if delivery == deliverySubmitted {
+		t.Fatalf("unrelated Working text must not submit this request: delivery=%q err=%v", delivery, err)
+	}
+}
+
+func TestIssue1793_CodexStaleWorkingBodyIsNotNewSubmission(t *testing.T) {
+	const msg = "ISSUE1793 STALE CODEX BODY"
+	pane := "• Working\n" + msg + "\n"
+	mock := &mockSendRetryTarget{
+		statuses: []string{"active"},
+		panes:    []string{pane, pane},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
+		maxRetries: 3, checkDelay: 0, tool: "codex",
+	})
+	if delivery == deliverySubmitted {
+		t.Fatalf("stale body and Working text must not submit again: delivery=%q err=%v", delivery, err)
+	}
+}
+
+func TestIssue1793_CodexAlternateWorkingTextIsNotSubmissionEvidence(t *testing.T) {
+	const msg = "ISSUE1793 ALTERNATE CODEX BODY"
+	mock := &mockSendRetryTarget{
+		statuses: []string{"active"},
+		panes: []string{
+			"codex>\n",
+			"Working on another request\n" + msg + "\n",
+		},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
+		maxRetries: 3, checkDelay: 0, tool: "codex",
+	})
+	if err == nil || delivery == deliverySubmitted {
+		t.Fatalf("alternate UI text must not submit: delivery=%q err=%v", delivery, err)
+	}
+}
+
+func TestIssue1793_CodexDelayedWorkingBeforeBodyIsNotSubmissionEvidence(t *testing.T) {
+	const msg = "ISSUE1793 DELAYED CODEX BODY"
+	mock := &mockSendRetryTarget{
+		statuses: []string{"active"},
+		panes: []string{
+			"codex>\n",
+			"• Working\n",
+			"• Working\n" + msg + "\n",
+		},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
+		maxRetries: 3, checkDelay: 0, tool: "codex",
+	})
+	if delivery == deliverySubmitted {
+		t.Fatalf("Working before this body must not submit: delivery=%q err=%v", delivery, err)
+	}
+}
+
+func TestIssue1793_CodexWorkingRequiresAttributableEnter(t *testing.T) {
+	const msg = "ISSUE1793 WORKING ENTER ATTRIBUTION BODY"
+	mock := &mockSendRetryTarget{
+		statuses: []string{"active"},
+		panes:    []string{"codex>\n", "• Working\n" + msg + "\ncodex> foreign draft\n"},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
+		maxRetries: 3, checkDelay: 0, tool: "codex",
+	})
+	if delivery == deliverySubmitted {
+		t.Fatalf("Working plus a foreign draft must not submit: delivery=%q err=%v", delivery, err)
+	}
+}
+
+func TestIssue1793_CodexWorkingBodyMatchIsWhitespaceSafe(t *testing.T) {
+	const msg = "request with\nmultiple words"
+	mock := &mockSendRetryTarget{
+		statuses: []string{"active"},
+		panes: []string{
+			"codex>\n",
+			"• Working\nrequest with\nmultiple words\n",
+		},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
+		maxRetries: 3, checkDelay: 0, tool: "codex",
+	})
+	if err != nil || delivery != deliverySubmitted {
+		t.Fatalf("whitespace-wrapped body with attributable Working line must submit: delivery=%q err=%v", delivery, err)
+	}
+}
+
 // TestIssue1793_ClaudePath_TypedButNeverSubmitted_IsNotSuccess is the Claude
 // half of the same defect. The Claude verification loop treated "the body is
 // visible in the pane" as delivery evidence and, at the end of its budget,

--- a/cmd/agent-deck/issue1793_delivery_verify_test.go
+++ b/cmd/agent-deck/issue1793_delivery_verify_test.go
@@ -358,6 +358,24 @@ func TestIssue1793_CodexBaselineWorkingIsNotNewSubmission(t *testing.T) {
 	}
 }
 
+func TestIssue1793_CodexTimedBaselineWorkingIsNotNewSubmission(t *testing.T) {
+	const msg = "ISSUE1793 TIMED BASELINE CODEX BODY"
+	mock := &mockSendRetryTarget{
+		statuses: []string{"active"},
+		panes: []string{
+			"• Working (4s • esc to interrupt)\nprior request\n",
+			"• Working (5s • esc to interrupt)\n" + msg + "\n",
+		},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
+		maxRetries: 3, checkDelay: 0, tool: "codex",
+	})
+	if delivery == deliverySubmitted {
+		t.Fatalf("a pre-existing timed Codex Working state must not submit this body: delivery=%q err=%v", delivery, err)
+	}
+}
+
 func TestIssue1793_CodexMultilinePayloadStartingWorkingIsNotSubmissionEvidence(t *testing.T) {
 	const msg = "working\nISSUE1793 MULTILINE CODEX BODY"
 	mock := &mockSendRetryTarget{

--- a/cmd/agent-deck/issue1793_delivery_verify_test.go
+++ b/cmd/agent-deck/issue1793_delivery_verify_test.go
@@ -326,6 +326,42 @@ func TestIssue1793_CodexStaleWorkingBodyIsNotNewSubmission(t *testing.T) {
 	}
 }
 
+func TestIssue1793_CodexBaselineWorkingIsNotNewSubmission(t *testing.T) {
+	const msg = "ISSUE1793 BASELINE WORKING CODEX BODY"
+	mock := &mockSendRetryTarget{
+		statuses: []string{"active"},
+		panes: []string{
+			"• Working\ncodex>\n",
+			"• Working\n" + msg + "\n",
+		},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
+		maxRetries: 3, checkDelay: 0, tool: "codex",
+	})
+	if delivery == deliverySubmitted {
+		t.Fatalf("a pre-existing Codex Working state must not submit this body: delivery=%q err=%v", delivery, err)
+	}
+}
+
+func TestIssue1793_CodexMultilinePayloadStartingWorkingIsNotSubmissionEvidence(t *testing.T) {
+	const msg = "working\nISSUE1793 MULTILINE CODEX BODY"
+	mock := &mockSendRetryTarget{
+		statuses: []string{"active"},
+		panes: []string{
+			"codex>\n",
+			"working\nISSUE1793 MULTILINE CODEX BODY\n",
+		},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
+		maxRetries: 3, checkDelay: 0, tool: "codex",
+	})
+	if delivery == deliverySubmitted {
+		t.Fatalf("a payload line beginning with working must not impersonate Codex Working: delivery=%q err=%v", delivery, err)
+	}
+}
+
 func TestIssue1793_CodexAlternateWorkingTextIsNotSubmissionEvidence(t *testing.T) {
 	const msg = "ISSUE1793 ALTERNATE CODEX BODY"
 	mock := &mockSendRetryTarget{

--- a/cmd/agent-deck/issue1793_delivery_verify_test.go
+++ b/cmd/agent-deck/issue1793_delivery_verify_test.go
@@ -256,6 +256,24 @@ func TestIssue1793_CodexActiveTransitionNeedsNoRecoveryEnter(t *testing.T) {
 	}
 }
 
+func TestIssue1793_CodexWorkingPaneConfirmsSubmittedNoWaitSend(t *testing.T) {
+	const msg = "ISSUE1793 BABA CODEX WORKING submitted prompt"
+	mock := &mockSendRetryTarget{
+		statuses: []string{"active"},
+		panes: []string{
+			"codex>\n",
+			"• Working\n" + msg + "\n",
+		},
+	}
+
+	delivery, err := sendWithRetryTarget(mock, msg, true, sendRetryOptions{
+		maxRetries: 3, checkDelay: 0, tool: "codex",
+	})
+	if err != nil || delivery != deliverySubmitted {
+		t.Fatalf("Codex Working pane after a submitted prompt = delivery %q, err %v; want submitted", delivery, err)
+	}
+}
+
 // TestIssue1793_ClaudePath_TypedButNeverSubmitted_IsNotSuccess is the Claude
 // half of the same defect. The Claude verification loop treated "the body is
 // visible in the pane" as delivery evidence and, at the end of its budget,

--- a/cmd/agent-deck/issue2045_accounts_cli_test.go
+++ b/cmd/agent-deck/issue2045_accounts_cli_test.go
@@ -29,7 +29,29 @@ config_dir = "~/.claude-work"
 	// test. A successful no-op executable lets the real command reach every
 	// create/start/save stage without sharing the developer's tmux server.
 	binDir := t.TempDir()
-	fakeTmux := "#!/bin/sh\ncase \" $* \" in\n  *' has-session '*) exit 1 ;;\nesac\nexit 0\n"
+	fakeTmux := `#!/bin/sh
+state="$0.state"
+name=""
+marker=""
+previous=""
+for arg in "$@"; do
+  [ "$previous" = "-s" ] && name="$arg"
+  case "$arg" in
+    AGENTDECK_SESSION_CREATION_MARKER=*) marker="${arg#*=}" ;;
+  esac
+  previous="$arg"
+done
+case " $* " in
+  *' has-session '*) exit 1 ;;
+  *' new-session '*) printf '%s|%s\n' "$name" "$marker" > "$state"; exit 0 ;;
+  *' list-sessions '*)
+    [ -f "$state" ] || exit 0
+    IFS='|' read -r name marker < "$state"
+    printf '$created\t%s\t%s\n' "$name" "$marker"
+    exit 0 ;;
+esac
+exit 0
+`
 	if err := os.WriteFile(filepath.Join(binDir, "tmux"), []byte(fakeTmux), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -2228,6 +2228,7 @@ func handleAdd(profile string, args []string) {
 	// Build JSON data
 	jsonData := map[string]interface{}{
 		"success": true,
+		"started": false,
 		"id":      newInstance.ID,
 		"title":   newInstance.Title,
 		"path":    path,

--- a/cmd/agent-deck/remote_agent_probe_test.go
+++ b/cmd/agent-deck/remote_agent_probe_test.go
@@ -51,6 +51,9 @@ func TestRemoteAgent_InProcessProbeMatchesCLI(t *testing.T) {
 		t.Fatalf("newRemoteAgentProbe: %v", err)
 	}
 	defer closeProbe()
+	previousGlobal := statedb.GetGlobal()
+	statedb.SetGlobal(nil)
+	t.Cleanup(func() { statedb.SetGlobal(previousGlobal) })
 	// The probe is read-only: it relies on no global state DB being
 	// registered in the agent process, and it must leave the stamp the
 	// watcher compares untouched (finding 2: a probe that moved the stamp

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3954,6 +3954,15 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 					arrived = true
 				}
 				codex := session.IsCodexCompatible(opts.tool)
+				// Codex renders the timed Working line together with the submitted
+				// body. That is already submission evidence; sending a recovery
+				// Enter would deliver a second Enter to the accepted prompt. Keep
+				// attribution strict when another prompt/draft is visible.
+				if codex && arrived && !recoveryAttempted &&
+					codexWorkingIndicator(content, message) && codexTimedWorkingLine(content) &&
+					!strings.Contains(strings.ToLower(content), "codex>") {
+					return deliverySubmitted, nil
+				}
 				if codex {
 					token := strings.ToLower(collapseWhitespace(messageDeliveryToken(message)))
 					if codexWorkingLine(content, token) && !arrived && !codexBaselineWorking {
@@ -4062,7 +4071,19 @@ func codexWorkingLine(content, token string) bool {
 			continue
 		}
 		line = strings.TrimLeft(line, "•·⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏*")
-		if line == "working" || line == "working..." || strings.HasPrefix(line, "working(") {
+		if line == "working" || line == "working..." ||
+			strings.HasPrefix(line, "working(") ||
+			(strings.HasPrefix(line, "working") && strings.Contains(line, "esc to interrupt")) {
+			return true
+		}
+	}
+	return false
+}
+
+func codexTimedWorkingLine(content string) bool {
+	for _, line := range strings.Split(strings.ToLower(content), "\n") {
+		line = collapseWhitespace(strings.TrimLeft(line, "•·⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏*"))
+		if strings.HasPrefix(line, "working(") && strings.Contains(line, "esctointerrupt") {
 			return true
 		}
 	}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3906,6 +3906,13 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 		OwnPasteMarker: baseline.paneOK && baseline.pasteMarkers == 0,
 	}
 	recoveryAttempted := false
+	recoveryAccepted := false
+	codexWorkingSeenBeforeBody := false
+	codexBaselineWorking := false
+	if session.IsCodexCompatible(opts.tool) {
+		token := strings.ToLower(collapseWhitespace(messageDeliveryToken(message)))
+		codexBaselineWorking = codexWorkingLine(baseline.content, token)
+	}
 	for i := 0; i < checks; i++ {
 		// Strongest signal first: an idle agent that starts working received
 		// what it started working on, which is submission, not just arrival.
@@ -3916,10 +3923,6 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 		}
 		if baseline.paneOK {
 			if n, markers, content, paneNow, ok := paneArrivalObservation(target, message); ok {
-				if session.IsCodexCompatible(opts.tool) &&
-					!codexWorkingIndicator(baseline.content, message) && codexWorkingIndicator(content, message) {
-					return deliverySubmitted, nil
-				}
 				arrived := false
 				if n > baseline.occurrences {
 					if opts.tool == "pi" && piComposerEmpty(content, message) {
@@ -3950,13 +3953,28 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 					sawBody = true
 					arrived = true
 				}
+				codex := session.IsCodexCompatible(opts.tool)
+				if codex {
+					token := strings.ToLower(collapseWhitespace(messageDeliveryToken(message)))
+					if codexWorkingLine(content, token) && !arrived && !codexBaselineWorking {
+						codexWorkingSeenBeforeBody = true
+					}
+				}
 				if arrived && !recoveryAttempted && session.IsCodexCompatible(opts.tool) {
 					// Consume the single recovery budget before sending. NudgeEnter
 					// reports both an attribution refusal and a transport failure as
 					// false; neither may re-arm another Enter into a pane whose draft
 					// could have changed since this capture.
 					recoveryAttempted = true
-					_ = attrib.NudgeEnter(target, paneNow, tmux.StripANSI)
+					recoveryAccepted = attrib.NudgeEnter(target, paneNow, tmux.StripANSI)
+				}
+				if session.IsCodexCompatible(opts.tool) &&
+					arrived &&
+					recoveryAccepted &&
+					!codexWorkingSeenBeforeBody &&
+					!codexWorkingIndicator(baseline.content, message) &&
+					codexWorkingIndicator(content, message) {
+					return deliverySubmitted, nil
 				}
 			}
 		}
@@ -4003,15 +4021,24 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 // certifying a send that never arrived.
 
 func codexWorkingIndicator(content, message string) bool {
-	// Do not treat a user payload containing the word "working" as the TUI's
-	// state line. Remove its distinctive token before looking for the indicator;
-	// the body itself is arrival evidence, never submission evidence.
-	if token := collapseWhitespace(messageDeliveryToken(message)); token != "" {
-		content = strings.ReplaceAll(content, token, "")
+	token := strings.ToLower(collapseWhitespace(messageDeliveryToken(message)))
+	if token == "" || !strings.Contains(strings.ToLower(collapseWhitespace(content)), token) {
+		return false
 	}
+	return codexWorkingLine(content, token)
+}
+
+func codexWorkingLine(content, token string) bool {
 	for _, line := range strings.Split(strings.ToLower(content), "\n") {
-		line = strings.TrimSpace(strings.TrimLeft(line, "•·⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏*"))
-		if line == "working" || strings.HasPrefix(line, "working ") || strings.HasPrefix(line, "working(") || strings.HasPrefix(line, "working...") {
+		line = collapseWhitespace(line)
+		if token != "" {
+			// Both operands are normalized. Removing an uncollapsed token from
+			// wrapped pane content misses the exact body and lets payload text
+			// beginning with "working" impersonate the TUI state line.
+			line = strings.ReplaceAll(line, token, "")
+		}
+		line = strings.TrimLeft(line, "•·⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏*")
+		if line == "working" || line == "working..." || strings.HasPrefix(line, "working(") {
 			return true
 		}
 	}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3803,7 +3803,7 @@ type sendArrivalBaseline struct {
 // baseline is disabled, never guessed.
 func captureArrivalBaseline(target sendRetryTarget, message string) sendArrivalBaseline {
 	base := sendArrivalBaseline{}
-	if n, markers, _, ok := paneArrivalObservation(target, message); ok {
+	if n, markers, _, _, ok := paneArrivalObservation(target, message); ok {
 		base.occurrences, base.pasteMarkers, base.paneOK = n, markers, true
 	}
 	if status, err := target.GetStatus(); err == nil {
@@ -3881,6 +3881,20 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 	}
 
 	sawBody := false
+	// Codex has no reliable composer-state signal, so it takes this arrival
+	// verifier instead of the Claude loop. If its body arrived but the first
+	// Enter was swallowed, recover with one attributable bare Enter — the same
+	// bounded action the Claude loop takes on an unsent prompt. More retries
+	// would be blind because Codex does not expose an equivalent composer state.
+	//
+	// The baseline is provenance for a collapsed paste marker: when the
+	// composer held no marker before this send, a newly observed marker is ours.
+	// A verbatim body is independently attributable through Message.
+	attrib := send.EnterAttribution{
+		Message:        message,
+		OwnPasteMarker: baseline.paneOK && baseline.pasteMarkers == 0,
+	}
+	recoveryNudged := false
 	for i := 0; i < checks; i++ {
 		// Strongest signal first: an idle agent that starts working received
 		// what it started working on, which is submission, not just arrival.
@@ -3890,7 +3904,8 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 			}
 		}
 		if baseline.paneOK {
-			if n, markers, content, ok := paneArrivalObservation(target, message); ok {
+			if n, markers, content, paneNow, ok := paneArrivalObservation(target, message); ok {
+				arrived := false
 				if n > baseline.occurrences {
 					if opts.tool == "pi" && piComposerEmpty(content, message) {
 						return deliverySubmitted, nil
@@ -3898,6 +3913,7 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 					// Keep polling: the body is in, but the turn may still
 					// start within the budget and upgrade this to submitted.
 					sawBody = true
+					arrived = true
 				}
 				// A paste marker the COMPOSER did not hold before the send is
 				// the collapsed rendering of this send's own framed body
@@ -3917,6 +3933,10 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 				// unsent bytes.
 				if markers > baseline.pasteMarkers {
 					sawBody = true
+					arrived = true
+				}
+				if arrived && !recoveryNudged && session.IsCodexCompatible(opts.tool) {
+					recoveryNudged = attrib.NudgeEnter(target, paneNow, tmux.StripANSI)
 				}
 			}
 		}
@@ -4016,18 +4036,18 @@ func maxDeliverableLineBytes(target sendRetryTarget) int {
 // composer holding one more marker than before is unsubmitted payload.
 //
 // Both counts are raw observations; the caller compares them to its baseline.
-func paneArrivalObservation(target sendRetryTarget, message string) (int, int, string, bool) {
+func paneArrivalObservation(target sendRetryTarget, message string) (int, int, string, send.PaneCapture, bool) {
 	token := collapseWhitespace(messageDeliveryToken(message))
 	if token == "" {
-		return 0, 0, "", false
+		return 0, 0, "", send.PaneCapture{}, false
 	}
 	raw, err := target.CapturePaneFresh()
 	if err != nil {
-		return 0, 0, "", false
+		return 0, 0, "", send.PaneCapture{}, false
 	}
 	content := tmux.StripANSI(raw)
 	return strings.Count(collapseWhitespace(content), token),
-		send.ComposerPasteMarkerCount(raw, tmux.StripANSI), content, true
+		send.ComposerPasteMarkerCount(raw, tmux.StripANSI), content, send.Captured(raw), true
 }
 
 // piComposerEmpty recognizes Pi's editor between its final two horizontal

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3907,11 +3907,11 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 	}
 	recoveryAttempted := false
 	recoveryAccepted := false
+	recoveryIteration := -1
 	codexWorkingSeenBeforeBody := false
 	codexBaselineWorking := false
 	if session.IsCodexCompatible(opts.tool) {
-		token := strings.ToLower(collapseWhitespace(messageDeliveryToken(message)))
-		codexBaselineWorking = codexWorkingLine(baseline.content, token)
+		codexBaselineWorking = codexWorkingLine(baseline.content, "")
 	}
 	for i := 0; i < checks; i++ {
 		// Strongest signal first: an idle agent that starts working received
@@ -3967,12 +3967,14 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 					// could have changed since this capture.
 					recoveryAttempted = true
 					recoveryAccepted = attrib.NudgeEnter(target, paneNow, tmux.StripANSI)
+					recoveryIteration = i
 				}
 				if session.IsCodexCompatible(opts.tool) &&
 					arrived &&
 					recoveryAccepted &&
+					i > recoveryIteration &&
 					!codexWorkingSeenBeforeBody &&
-					!codexWorkingIndicator(baseline.content, message) &&
+					!codexBaselineWorking &&
 					codexWorkingIndicator(content, message) {
 					return deliverySubmitted, nil
 				}
@@ -4029,13 +4031,35 @@ func codexWorkingIndicator(content, message string) bool {
 }
 
 func codexWorkingLine(content, token string) bool {
-	for _, line := range strings.Split(strings.ToLower(content), "\n") {
-		line = collapseWhitespace(line)
-		if token != "" {
-			// Both operands are normalized. Removing an uncollapsed token from
-			// wrapped pane content misses the exact body and lets payload text
-			// beginning with "working" impersonate the TUI state line.
-			line = strings.ReplaceAll(line, token, "")
+	lines := strings.Split(strings.ToLower(content), "\n")
+	normalizedLines := make([]string, len(lines))
+	for i, line := range lines {
+		normalizedLines[i] = collapseWhitespace(line)
+	}
+	payloadLines := make([]bool, len(lines))
+	if token != "" {
+		joined := strings.Join(normalizedLines, "")
+		for from := 0; ; {
+			relative := strings.Index(joined[from:], token)
+			if relative < 0 {
+				break
+			}
+			start := from + relative
+			end := start + len(token)
+			position := 0
+			for i, line := range normalizedLines {
+				next := position + len(line)
+				if start < next && end > position {
+					payloadLines[i] = true
+				}
+				position = next
+			}
+			from = start + 1
+		}
+	}
+	for i, line := range normalizedLines {
+		if payloadLines[i] {
+			continue
 		}
 		line = strings.TrimLeft(line, "•·⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏*")
 		if line == "working" || line == "working..." || strings.HasPrefix(line, "working(") {

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3960,6 +3960,7 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 				// attribution strict when another prompt/draft is visible.
 				if codex && arrived && !recoveryAttempted &&
 					codexWorkingIndicator(content, message) && codexTimedWorkingLine(content) &&
+					!codexBaselineWorking &&
 					!strings.Contains(strings.ToLower(content), "codex>") {
 					return deliverySubmitted, nil
 				}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3894,7 +3894,7 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 		Message:        message,
 		OwnPasteMarker: baseline.paneOK && baseline.pasteMarkers == 0,
 	}
-	recoveryNudged := false
+	recoveryAttempted := false
 	for i := 0; i < checks; i++ {
 		// Strongest signal first: an idle agent that starts working received
 		// what it started working on, which is submission, not just arrival.
@@ -3935,8 +3935,13 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 					sawBody = true
 					arrived = true
 				}
-				if arrived && !recoveryNudged && session.IsCodexCompatible(opts.tool) {
-					recoveryNudged = attrib.NudgeEnter(target, paneNow, tmux.StripANSI)
+				if arrived && !recoveryAttempted && session.IsCodexCompatible(opts.tool) {
+					// Consume the single recovery budget before sending. NudgeEnter
+					// reports both an attribution refusal and a transport failure as
+					// false; neither may re-arm another Enter into a pane whose draft
+					// could have changed since this capture.
+					recoveryAttempted = true
+					_ = attrib.NudgeEnter(target, paneNow, tmux.StripANSI)
 				}
 			}
 		}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3803,6 +3803,10 @@ type sendArrivalBaseline struct {
 	// a failed read defaulting to "was not active" would turn a
 	// continuously-busy agent into a fake not-active-to-active transition.
 	statusOK bool
+	// content is the successful pre-send pane snapshot. Codex exposes a visible
+	// Working state in the pane while its status probe can remain active both
+	// before and after a send, so submission uses a content transition too.
+	content string
 }
 
 // captureArrivalBaseline snapshots the pane and status before a send. Each
@@ -3810,8 +3814,8 @@ type sendArrivalBaseline struct {
 // baseline is disabled, never guessed.
 func captureArrivalBaseline(target sendRetryTarget, message string) sendArrivalBaseline {
 	base := sendArrivalBaseline{}
-	if n, markers, _, _, ok := paneArrivalObservation(target, message); ok {
-		base.occurrences, base.pasteMarkers, base.paneOK = n, markers, true
+	if n, markers, content, _, ok := paneArrivalObservation(target, message); ok {
+		base.occurrences, base.pasteMarkers, base.paneOK, base.content = n, markers, true, content
 	}
 	if status, err := target.GetStatus(); err == nil {
 		base.wasActive, base.statusOK = status == "active", true
@@ -3912,6 +3916,10 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 		}
 		if baseline.paneOK {
 			if n, markers, content, paneNow, ok := paneArrivalObservation(target, message); ok {
+				if session.IsCodexCompatible(opts.tool) &&
+					!codexWorkingIndicator(baseline.content, message) && codexWorkingIndicator(content, message) {
+					return deliverySubmitted, nil
+				}
 				arrived := false
 				if n > baseline.occurrences {
 					if opts.tool == "pi" && piComposerEmpty(content, message) {
@@ -3987,6 +3995,29 @@ func verifyContentArrival(target sendRetryTarget, message string, opts sendRetry
 // end a line: with ICRNL set (the tty default) an incoming CR becomes NL
 // before the line discipline sees it, so counting only \n would read a
 // CR-delimited body as one enormous line.
+// codexWorkingIndicator is the content-side submission acknowledgement for
+// Codex-compatible TUIs. Their status probe may report active before the send
+// (startup/tool work) and therefore cannot always provide a useful transition;
+// a newly rendered Working line, absent from the pre-send snapshot, is the
+// attributable state change. The baseline comparison prevents old output from
+// certifying a send that never arrived.
+
+func codexWorkingIndicator(content, message string) bool {
+	// Do not treat a user payload containing the word "working" as the TUI's
+	// state line. Remove its distinctive token before looking for the indicator;
+	// the body itself is arrival evidence, never submission evidence.
+	if token := collapseWhitespace(messageDeliveryToken(message)); token != "" {
+		content = strings.ReplaceAll(content, token, "")
+	}
+	for _, line := range strings.Split(strings.ToLower(content), "\n") {
+		line = strings.TrimSpace(strings.TrimLeft(line, "•·⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏*"))
+		if line == "working" || strings.HasPrefix(line, "working ") || strings.HasPrefix(line, "working(") || strings.HasPrefix(line, "working...") {
+			return true
+		}
+	}
+	return false
+}
+
 func longestMessageLineBytes(message string) int {
 	longest := 0
 	for _, line := range strings.FieldsFunc(message, func(r rune) bool {

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -740,6 +740,10 @@ func handleSessionRestart(profile string, args []string) {
 	}
 
 	// Restart the session
+	// Register this command's database before Restart. A restart is a process
+	// replacement, and its tmux name/status must be committed independently of
+	// this CLI's stale registry snapshot.
+	adoptStateDB(storage)
 	if err := inst.RestartWithEnv(envFlags); err != nil {
 		out.Error(fmt.Sprintf("failed to restart session: %v", err), ErrCodeInvalidOperation)
 		os.Exit(1)
@@ -747,6 +751,8 @@ func handleSessionRestart(profile string, args []string) {
 	// Stamp the persisted freshness marker so subsequent watchdog ticks see
 	// this session as "just started" and skip (issue #30).
 	inst.LastStartedAt = time.Now()
+	inst.PersistRestartOutcome()
+	restartOutcome := restartOutcomeFor(inst, true)
 	warning := inst.ConsumeCodexRestartWarning()
 	if warning != "" && !*jsonOutput {
 		fmt.Fprintf(os.Stderr, "Warning: %s\n", warning)
@@ -757,11 +763,10 @@ func handleSessionRestart(profile string, args []string) {
 		inst.PostStartSync(3 * time.Second)
 	}
 
-	// Save updated state
-	if err := saveSessionData(storage, instances, groups); err != nil {
-		out.Error(fmt.Sprintf("failed to save session state: %v", err), ErrCodeInvalidOperation)
-		os.Exit(1)
-	}
+	// Do not write the pre-restart registry snapshot here. It can conflict with
+	// (or overwrite) a concurrent status refresh after the replacement process
+	// has already started. PersistRestartOutcome above atomically committed the
+	// state this operation owns; unrelated state is left to its owning writer.
 
 	// Output success
 	data := map[string]interface{}{
@@ -772,6 +777,8 @@ func handleSessionRestart(profile string, args []string) {
 	if warning != "" {
 		data["warning"] = warning
 	}
+	restartOutcome.addTo(data)
+	restartOutcome.warn(os.Stderr)
 	out.Success(fmt.Sprintf("Restarted session: %s", inst.Title), data)
 }
 

--- a/cmd/agent-deck/session_send_test.go
+++ b/cmd/agent-deck/session_send_test.go
@@ -338,11 +338,12 @@ func TestWaitForCompletion_Timeout(t *testing.T) {
 }
 
 type mockSendRetryTarget struct {
-	sendKeysErr error
-	statuses    []string
-	statusErrs  []error
-	panes       []string
-	paneErrs    []error
+	sendKeysErr  error
+	sendEnterErr error
+	statuses     []string
+	statusErrs   []error
+	panes        []string
+	paneErrs     []error
 
 	statusIdx atomic.Int32
 	paneIdx   atomic.Int32
@@ -380,7 +381,7 @@ func (m *mockSendRetryTarget) GetStatus() (string, error) {
 
 func (m *mockSendRetryTarget) SendEnter() error {
 	atomic.AddInt32(&m.sendEnterCalls, 1)
-	return nil
+	return m.sendEnterErr
 }
 
 func (m *mockSendRetryTarget) SendCtrlC() error {

--- a/cmd/agent-deck/testmain_test.go
+++ b/cmd/agent-deck/testmain_test.go
@@ -23,6 +23,11 @@ func TestMain(m *testing.M) {
 // Skipping this leaked per-run temp dirs on every run — the 2026-06-07
 // pty-exhaustion incident class.
 func runTestMain(m *testing.M) int {
+	// Tests frequently replace HOME with a per-test directory. Keep Go's
+	// downloaded module and build caches outside those t.TempDir trees so
+	// read-only module-cache files cannot make testing.T cleanup fail.
+	configureStableGoCaches()
+
 	// Helper subprocesses (e.g. the Task6 XDG help-path test) are spawned by a
 	// parent test that has ALREADY exported a safe, sandboxed HOME+XDG and set
 	// the specific XDG_*_HOME values the subprocess must observe. Re-running
@@ -67,6 +72,18 @@ func runTestMain(m *testing.M) int {
 	cleanupTestSessions()
 
 	return code
+}
+
+func configureStableGoCaches() {
+	for _, key := range []string{"GOMODCACHE", "GOCACHE"} {
+		if os.Getenv(key) != "" {
+			continue
+		}
+		value, err := exec.Command("go", "env", key).Output()
+		if err == nil && strings.TrimSpace(string(value)) != "" {
+			_ = os.Setenv(key, strings.TrimSpace(string(value)))
+		}
+	}
 }
 
 func isolatePackageHome(pattern string) {

--- a/internal/send/send.go
+++ b/internal/send/send.go
@@ -123,6 +123,10 @@ func ParsePromptFromComposerBlock(lines []string) (string, bool) {
 				break
 			}
 		}
+		codexMarker := markerLen == 0 && strings.HasPrefix(strings.ToLower(trimmed), "codex>")
+		if codexMarker {
+			markerLen = len("codex>")
+		}
 		if markerLen == 0 {
 			continue
 		}
@@ -144,7 +148,14 @@ func ParsePromptFromComposerBlock(lines []string) (string, bool) {
 			break
 		}
 
-		return NormalizePromptText(strings.Join(bodyParts, " ")), true
+		body := NormalizePromptText(strings.Join(bodyParts, " "))
+		// A bare Codex prompt has historically been treated as
+		// non-introspectable. Keep that fail-safe behavior; only an actual
+		// Codex draft is actionable by the attribution gate.
+		if codexMarker && body == "" {
+			continue
+		}
+		return body, true
 	}
 	return "", false
 }
@@ -196,6 +207,11 @@ func CurrentComposerPrompt(content string) (string, bool) {
 		for _, marker := range []string{"❯", "›"} {
 			if strings.HasPrefix(trimmed, marker) {
 				return NormalizePromptText(strings.TrimSpace(trimmed[len(marker):])), true
+			}
+		}
+		if strings.HasPrefix(strings.ToLower(trimmed), "codex>") {
+			if body := NormalizePromptText(strings.TrimSpace(trimmed[len("codex>"):])); body != "" {
+				return body, true
 			}
 		}
 	}

--- a/internal/session/deepseek.go
+++ b/internal/session/deepseek.go
@@ -1083,16 +1083,19 @@ func (i *Instance) expectsFastExit() bool {
 }
 
 func (i *Instance) acknowledgeInitialProcess(command string) error {
-	if i.expectsFastExit() {
-		return nil
-	}
 	ackErr := i.tmuxSession.AcknowledgeInitialProcess()
 	if ackErr == nil {
 		return nil
 	}
-	i.recordTmuxStartFailure(command, ackErr)
-	if cleanupErr := i.tmuxSession.Kill(); cleanupErr != nil {
-		return fmt.Errorf("initial session command did not launch: %w (cleanup failed: %v)", ackErr, cleanupErr)
+	diagnostic := ackErr
+	if content, captureErr := i.tmuxSession.CapturePane(); captureErr == nil {
+		if content = strings.TrimSpace(content); content != "" {
+			diagnostic = fmt.Errorf("%w: %s", ackErr, content)
+		}
 	}
-	return fmt.Errorf("initial session command did not launch: %w", ackErr)
+	i.recordTmuxStartFailure(command, diagnostic)
+	if cleanupErr := i.tmuxSession.Kill(); cleanupErr != nil {
+		return fmt.Errorf("initial session command did not launch: %w (cleanup failed: %v)", diagnostic, cleanupErr)
+	}
+	return fmt.Errorf("initial session command did not launch: %w", diagnostic)
 }

--- a/internal/session/deepseek.go
+++ b/internal/session/deepseek.go
@@ -1083,6 +1083,23 @@ func (i *Instance) expectsFastExit() bool {
 	return DeepSeekProfileMode(i.resolveDeepSeekProfile()) == deepSeekModeHeadless
 }
 
+// runCommandAsInitialProcess chooses the spawn shape for a tool command.
+// Interactive DeepSeek profiles must start under the pane's shell: the
+// acknowledgement wrapper uses setsid for ownership, which intentionally
+// removes the child from the controlling terminal and makes a TUI read EOF.
+// The shell-delivery path keeps the pane PTY while the immutable tmux session
+// identity still supplies cleanup ownership. One-shot DeepSeek and all other
+// existing tool paths retain their initial-process behavior.
+func (i *Instance) runCommandAsInitialProcess() bool {
+	if i == nil {
+		return false
+	}
+	if i.Tool == "deepseek" && i.deepSeekPromptDelivery() == DeepSeekPromptPane {
+		return false
+	}
+	return i.IsSandboxed() || i.Tool != "shell" || i.isBoundedCodexExec()
+}
+
 func (i *Instance) acknowledgeInitialProcess(command string) error {
 	ackErr := i.tmuxSession.AcknowledgeInitialProcess()
 	if ackErr == nil {

--- a/internal/session/deepseek.go
+++ b/internal/session/deepseek.go
@@ -1088,6 +1088,7 @@ func (i *Instance) acknowledgeInitialProcess(command string) error {
 	if ackErr == nil {
 		if i.expectsFastExit() {
 			launchSession := i.tmuxSession
+			launchSessionName, launchSessionID := launchSession.OwnershipSnapshot()
 			gen, wake := i.newSpawnGenWatch()
 			launchSession.WatchInitialProcessCompletion(wake, func(exitCode int, diagnostic string) {
 				if exitCode == 0 {
@@ -1100,7 +1101,14 @@ func (i *Instance) acknowledgeInitialProcess(command string) error {
 				}) {
 					return
 				}
-				if cleanupErr := launchSession.KillIfOwned(); cleanupErr != nil {
+				// The generation may change after the guarded record write. Do not
+				// clean up a stale completion once a restart has begun; the retained
+				// name/identity also prevents a reused Session pointer from targeting
+				// the replacement.
+				if i.spawnGen.Load() != gen {
+					return
+				}
+				if cleanupErr := launchSession.KillIfOwnedSnapshot(launchSessionName, launchSessionID); cleanupErr != nil {
 					sessionLog.Warn("headless_completion_cleanup_failed",
 						slog.String("instance_id", i.ID),
 						slog.String("error", cleanupErr.Error()))

--- a/internal/session/deepseek.go
+++ b/internal/session/deepseek.go
@@ -1081,3 +1081,18 @@ func (i *Instance) expectsFastExit() bool {
 	}
 	return DeepSeekProfileMode(i.resolveDeepSeekProfile()) == deepSeekModeHeadless
 }
+
+func (i *Instance) acknowledgeInitialProcess(command string) error {
+	if i.expectsFastExit() {
+		return nil
+	}
+	ackErr := i.tmuxSession.AcknowledgeInitialProcess()
+	if ackErr == nil {
+		return nil
+	}
+	i.recordTmuxStartFailure(command, ackErr)
+	if cleanupErr := i.tmuxSession.Kill(); cleanupErr != nil {
+		return fmt.Errorf("initial session command did not launch: %w (cleanup failed: %v)", ackErr, cleanupErr)
+	}
+	return fmt.Errorf("initial session command did not launch: %w", ackErr)
+}

--- a/internal/session/deepseek.go
+++ b/internal/session/deepseek.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1085,16 +1086,36 @@ func (i *Instance) expectsFastExit() bool {
 func (i *Instance) acknowledgeInitialProcess(command string) error {
 	ackErr := i.tmuxSession.AcknowledgeInitialProcess()
 	if ackErr == nil {
+		if i.expectsFastExit() {
+			i.tmuxSession.WatchInitialProcessCompletion(func(exitCode int, diagnostic string) {
+				if exitCode == 0 {
+					return
+				}
+				completionErr := fmt.Errorf("initial command exited after launch acknowledgement (exit status %d)", exitCode)
+				i.recordTmuxStartFailure(command, completionErr, diagnostic)
+				i.mu.Lock()
+				i.Status = StatusError
+				i.mu.Unlock()
+				if cleanupErr := i.tmuxSession.KillIfOwned(); cleanupErr != nil {
+					sessionLog.Warn("headless_completion_cleanup_failed",
+						slog.String("instance_id", i.ID),
+						slog.String("error", cleanupErr.Error()))
+				}
+			})
+		}
 		return nil
 	}
+	i.Status = StatusError
 	diagnostic := ackErr
+	captured := ""
 	if content, captureErr := i.tmuxSession.CapturePane(); captureErr == nil {
 		if content = strings.TrimSpace(content); content != "" {
+			captured = content
 			diagnostic = fmt.Errorf("%w: %s", ackErr, content)
 		}
 	}
-	i.recordTmuxStartFailure(command, diagnostic)
-	if cleanupErr := i.tmuxSession.Kill(); cleanupErr != nil {
+	i.recordTmuxStartFailure(command, ackErr, captured)
+	if cleanupErr := i.tmuxSession.KillIfOwned(); cleanupErr != nil {
 		return fmt.Errorf("initial session command did not launch: %w (cleanup failed: %v)", diagnostic, cleanupErr)
 	}
 	return fmt.Errorf("initial session command did not launch: %w", diagnostic)

--- a/internal/session/deepseek.go
+++ b/internal/session/deepseek.go
@@ -1087,16 +1087,20 @@ func (i *Instance) acknowledgeInitialProcess(command string) error {
 	ackErr := i.tmuxSession.AcknowledgeInitialProcess()
 	if ackErr == nil {
 		if i.expectsFastExit() {
-			i.tmuxSession.WatchInitialProcessCompletion(func(exitCode int, diagnostic string) {
+			launchSession := i.tmuxSession
+			gen, wake := i.newSpawnGenWatch()
+			launchSession.WatchInitialProcessCompletion(wake, func(exitCode int, diagnostic string) {
 				if exitCode == 0 {
 					return
 				}
 				completionErr := fmt.Errorf("initial command exited after launch acknowledgement (exit status %d)", exitCode)
-				i.recordTmuxStartFailure(command, completionErr, diagnostic)
-				i.mu.Lock()
-				i.Status = StatusError
-				i.mu.Unlock()
-				if cleanupErr := i.tmuxSession.KillIfOwned(); cleanupErr != nil {
+				if !i.commitSpawnWatchWrite(gen, func() {
+					i.recordTmuxStartFailure(command, completionErr, diagnostic)
+					i.SetStatusThreadSafe(StatusError)
+				}) {
+					return
+				}
+				if cleanupErr := launchSession.KillIfOwned(); cleanupErr != nil {
 					sessionLog.Warn("headless_completion_cleanup_failed",
 						slog.String("instance_id", i.ID),
 						slog.String("error", cleanupErr.Error()))
@@ -1105,7 +1109,7 @@ func (i *Instance) acknowledgeInitialProcess(command string) error {
 		}
 		return nil
 	}
-	i.Status = StatusError
+	i.SetStatusThreadSafe(StatusError)
 	diagnostic := ackErr
 	captured := ""
 	if content, captureErr := i.tmuxSession.CapturePane(); captureErr == nil {

--- a/internal/session/deepseek_lifecycle_test.go
+++ b/internal/session/deepseek_lifecycle_test.go
@@ -500,3 +500,34 @@ func TestDeepSeekLifecycle_HeadlessRestartWithoutTaskIsRefused(t *testing.T) {
 		t.Error("CanRestart() = false once the task is known")
 	}
 }
+
+func TestDeepSeekLifecycle_HeadlessNonzeroExitFailsAndCleans(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+
+	fake := fakeDshPath(t)
+	dshHome := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("DSH_HOME", dshHome)
+	t.Setenv("DEEPSEEK_API_KEY", "")
+	withConfig(t, &UserConfig{DeepSeek: DeepSeekSettings{
+		Command:   fake,
+		ConfigDir: dshHome,
+		Profile:   "headless",
+	}})
+
+	inst := NewInstanceWithTool("deepseek-headless-nonzero-e2e", workspace, "deepseek")
+	err := inst.StartWithMessage("run without credentials")
+	if err == nil || !strings.Contains(err.Error(), "exit status 1") {
+		t.Fatalf("StartWithMessage() = %v, want headless exit status 1", err)
+	}
+	if inst.Exists() {
+		t.Fatal("failed headless launch left a stale tmux session")
+	}
+	if !inst.LastStartedAt.IsZero() {
+		t.Fatalf("LastStartedAt = %v, want zero after failed launch", inst.LastStartedAt)
+	}
+	rec := inst.SpawnFailure()
+	if rec == nil || !strings.Contains(rec.DyingOutput, "MISSING_CREDENTIAL") {
+		t.Fatalf("SpawnFailure() = %#v, want preserved credential diagnostic", rec)
+	}
+}

--- a/internal/session/deepseek_lifecycle_test.go
+++ b/internal/session/deepseek_lifecycle_test.go
@@ -94,6 +94,45 @@ func waitForPane(t *testing.T, inst *Instance, want string, timeout time.Duratio
 	return ""
 }
 
+func launchAckArtifacts() map[string]struct{} {
+	artifacts := make(map[string]struct{})
+	for _, path := range launchAckArtifactPaths() {
+		artifacts[path] = struct{}{}
+	}
+	return artifacts
+}
+
+func launchAckArtifactPaths() []string {
+	paths, _ := filepath.Glob(filepath.Join(os.TempDir(), "agent-deck-launch-ack-*"))
+	return paths
+}
+
+func waitForLaunchAckArtifactsGone(t *testing.T, before map[string]struct{}, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		matches := launchAckArtifactPaths()
+		newArtifacts := make([]string, 0, len(matches))
+		for _, path := range matches {
+			if _, existed := before[path]; !existed {
+				newArtifacts = append(newArtifacts, path)
+			}
+		}
+		if len(newArtifacts) == 0 {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	matches := launchAckArtifactPaths()
+	newArtifacts := make([]string, 0, len(matches))
+	for _, path := range matches {
+		if _, existed := before[path]; !existed {
+			newArtifacts = append(newArtifacts, path)
+		}
+	}
+	t.Fatalf("late-completion marker artifacts remain after %s: %v", timeout, newArtifacts)
+}
+
 func TestDeepSeekLifecycle_LaunchSendRestart(t *testing.T) {
 	// New test: uses TestMain's bootstrapped server on the isolated socket, so
 	// the binary check is the right gate (skipIfNoTmuxServer is the legacy one).
@@ -546,6 +585,7 @@ func TestDeepSeekLifecycle_HeadlessLateCompletion(t *testing.T) {
 		{name: "failure", wantError: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			ackArtifactsBefore := launchAckArtifacts()
 			home := t.TempDir()
 			workspace := t.TempDir()
 			if err := os.WriteFile(filepath.Join(home, ".credentials.yaml"), []byte("deepseek: test\n"), 0o600); err != nil {
@@ -577,11 +617,13 @@ func TestDeepSeekLifecycle_HeadlessLateCompletion(t *testing.T) {
 						t.Fatalf("late failure diagnostic = %q, want output exactly once", rec.DyingOutput)
 					}
 					if !inst.Exists() {
+						waitForLaunchAckArtifactsGone(t, ackArtifactsBefore, 5*time.Second)
 						return
 					}
 				}
 				if !tc.wantError && rec == nil && inst.Exists() {
 					if content, captureErr := inst.PreviewFull(); captureErr == nil && strings.Contains(content, "LATE_HEADLESS_DIAGNOSTIC") {
+						waitForLaunchAckArtifactsGone(t, ackArtifactsBefore, 5*time.Second)
 						return
 					}
 				}

--- a/internal/session/deepseek_lifecycle_test.go
+++ b/internal/session/deepseek_lifecycle_test.go
@@ -530,4 +530,67 @@ func TestDeepSeekLifecycle_HeadlessNonzeroExitFailsAndCleans(t *testing.T) {
 	if rec == nil || !strings.Contains(rec.DyingOutput, "MISSING_CREDENTIAL") {
 		t.Fatalf("SpawnFailure() = %#v, want preserved credential diagnostic", rec)
 	}
+	if rec != nil && strings.Count(rec.DyingOutput, "MISSING_CREDENTIAL") != 1 {
+		t.Fatalf("SpawnFailure().DyingOutput = %q, want credential diagnostic exactly once", rec.DyingOutput)
+	}
+}
+
+func TestDeepSeekLifecycle_HeadlessLateCompletion(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	fake := fakeDshPath(t)
+	for _, tc := range []struct {
+		name      string
+		wantError bool
+	}{
+		{name: "success"},
+		{name: "failure", wantError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			workspace := t.TempDir()
+			if err := os.WriteFile(filepath.Join(home, ".credentials.yaml"), []byte("deepseek: test\n"), 0o600); err != nil {
+				t.Fatalf("write fake credentials: %v", err)
+			}
+			t.Setenv("DSH_HOME", home)
+			withConfig(t, &UserConfig{DeepSeek: DeepSeekSettings{
+				Command: fake, ConfigDir: home, Profile: "headless",
+			}})
+
+			inst := NewInstanceWithTool("deepseek-headless-late-"+tc.name, workspace, "deepseek")
+			task := "__agentdeck_late_success__"
+			if tc.wantError {
+				task = "__agentdeck_late_failure__"
+			}
+			err := inst.StartWithMessage(task)
+			if err != nil {
+				t.Fatalf("StartWithMessage() = %v, want post-ack success", err)
+			}
+
+			deadline := time.Now().Add(5 * time.Second)
+			for time.Now().Before(deadline) {
+				rec := inst.SpawnFailure()
+				if tc.wantError && rec != nil {
+					if !strings.Contains(rec.DyingOutput, "LATE_HEADLESS_DIAGNOSTIC") {
+						t.Fatalf("late failure diagnostic = %q, want preserved output", rec.DyingOutput)
+					}
+					if strings.Count(rec.DyingOutput, "LATE_HEADLESS_DIAGNOSTIC") != 1 {
+						t.Fatalf("late failure diagnostic = %q, want output exactly once", rec.DyingOutput)
+					}
+					if !inst.Exists() {
+						return
+					}
+				}
+				if !tc.wantError && rec == nil && inst.Exists() {
+					if content, captureErr := inst.PreviewFull(); captureErr == nil && strings.Contains(content, "LATE_HEADLESS_DIAGNOSTIC") {
+						return
+					}
+				}
+				time.Sleep(50 * time.Millisecond)
+			}
+			if tc.wantError {
+				t.Fatalf("late nonzero completion was not recorded; session exists=%v", inst.Exists())
+			}
+			t.Fatalf("successful late completion did not remain a clean one-shot; session exists=%v", inst.Exists())
+		})
+	}
 }

--- a/internal/session/deepseek_test.go
+++ b/internal/session/deepseek_test.go
@@ -936,6 +936,19 @@ func TestDeepSeekPromptDelivery(t *testing.T) {
 	}
 }
 
+func TestDeepSeekInteractiveProfileUsesShellPaneProcess(t *testing.T) {
+	withConfig(t, &UserConfig{DeepSeek: DeepSeekSettings{Profile: "tui"}})
+	interactive := &Instance{Tool: "deepseek", ID: "interactive"}
+	if interactive.runCommandAsInitialProcess() {
+		t.Fatal("interactive DeepSeek profile must start through the pane shell so it retains the controlling PTY")
+	}
+
+	withConfig(t, &UserConfig{DeepSeek: DeepSeekSettings{Profile: "headless"}})
+	if !(&Instance{Tool: "deepseek", ID: "headless"}).runCommandAsInitialProcess() {
+		t.Fatal("headless DeepSeek profile must retain initial-process launch for one-shot acknowledgement")
+	}
+}
+
 // TestDeepSeekHeadlessTaskRoundTrip pins the persistence half of P1c: the task
 // travels in the tool_data extras zone, so a restart in a fresh process still
 // knows what to replay.

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -5004,6 +5004,10 @@ func (i *Instance) Start() error {
 		i.recordTmuxStartFailure(command, err)
 		return fmt.Errorf("failed to start tmux session: %w", err)
 	}
+	if err := i.tmuxSession.AcknowledgeInitialProcess(); err != nil {
+		i.recordTmuxStartFailure(command, err)
+		return fmt.Errorf("initial session command did not launch: %w", err)
+	}
 
 	// #1580: watch for a fast death of the initial process (broken command,
 	// bad PATH, immediate non-zero exit). tmux tears the pane down on exit for
@@ -5326,6 +5330,10 @@ func (i *Instance) StartWithMessage(message string) error {
 		// #1580: persist the tmux-level failure (sister path to Start()).
 		i.recordTmuxStartFailure(command, err)
 		return fmt.Errorf("failed to start tmux session: %w", err)
+	}
+	if err := i.tmuxSession.AcknowledgeInitialProcess(); err != nil {
+		i.recordTmuxStartFailure(command, err)
+		return fmt.Errorf("initial session command did not launch: %w", err)
 	}
 
 	// #1580: fast-death watcher (sister path to Start()).
@@ -9257,6 +9265,11 @@ func (i *Instance) restart(env map[string]string) error {
 		i.recordTmuxStartFailure(command, err)
 		i.Status = StatusError
 		return fmt.Errorf("failed to restart tmux session: %w", err)
+	}
+	if err := i.tmuxSession.AcknowledgeInitialProcess(); err != nil {
+		i.recordTmuxStartFailure(command, err)
+		i.Status = StatusError
+		return fmt.Errorf("initial session command did not launch: %w", err)
 	}
 
 	mcpLog.Debug("restart_start_succeeded")

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -5090,7 +5090,7 @@ func (i *Instance) Start() error {
 	// New sessions start as STARTING - shows they're initializing
 	// After 5s grace period, status will be properly detected from tmux
 	if command != "" {
-		i.Status = StatusStarting
+		i.SetStatusThreadSafe(StatusStarting)
 	}
 
 	// Start async session ID detection for OpenCode
@@ -5393,7 +5393,7 @@ func (i *Instance) StartWithMessage(message string) error {
 	i.markStarted() // persisted stamp (issue #30 — cross-process freshness guard)
 
 	// New sessions start as STARTING
-	i.Status = StatusStarting
+	i.SetStatusThreadSafe(StatusStarting)
 
 	// Start async session ID detection for tools that persist IDs out-of-band.
 	if i.Tool == "opencode" {

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -5832,7 +5832,7 @@ func (i *Instance) UpdateStatus() error {
 	if time.Since(graceTime) < 1500*time.Millisecond {
 		// Only skip if tmux session doesn't exist yet
 		if i.tmuxSession == nil || !i.tmuxSession.Exists() {
-			if i.Status != StatusRunning && i.Status != StatusIdle {
+			if i.Status != StatusRunning && i.Status != StatusIdle && i.Status != StatusError && i.Status != StatusStopped {
 				i.Status = StatusStarting
 			}
 			return nil

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -5004,9 +5004,8 @@ func (i *Instance) Start() error {
 		i.recordTmuxStartFailure(command, err)
 		return fmt.Errorf("failed to start tmux session: %w", err)
 	}
-	if err := i.tmuxSession.AcknowledgeInitialProcess(); err != nil {
-		i.recordTmuxStartFailure(command, err)
-		return fmt.Errorf("initial session command did not launch: %w", err)
+	if err := i.acknowledgeInitialProcess(command); err != nil {
+		return err
 	}
 
 	// #1580: watch for a fast death of the initial process (broken command,
@@ -5331,9 +5330,8 @@ func (i *Instance) StartWithMessage(message string) error {
 		i.recordTmuxStartFailure(command, err)
 		return fmt.Errorf("failed to start tmux session: %w", err)
 	}
-	if err := i.tmuxSession.AcknowledgeInitialProcess(); err != nil {
-		i.recordTmuxStartFailure(command, err)
-		return fmt.Errorf("initial session command did not launch: %w", err)
+	if err := i.acknowledgeInitialProcess(command); err != nil {
+		return err
 	}
 
 	// #1580: fast-death watcher (sister path to Start()).
@@ -9266,10 +9264,9 @@ func (i *Instance) restart(env map[string]string) error {
 		i.Status = StatusError
 		return fmt.Errorf("failed to restart tmux session: %w", err)
 	}
-	if err := i.tmuxSession.AcknowledgeInitialProcess(); err != nil {
-		i.recordTmuxStartFailure(command, err)
+	if err := i.acknowledgeInitialProcess(command); err != nil {
 		i.Status = StatusError
-		return fmt.Errorf("initial session command did not launch: %w", err)
+		return err
 	}
 
 	mcpLog.Debug("restart_start_succeeded")

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -4987,7 +4987,7 @@ func (i *Instance) Start() error {
 	// Build tmux option overrides from config (e.g. allow-passthrough = "all").
 	// Sandbox sessions also get remain-on-exit for dead-pane detection.
 	i.tmuxSession.OptionOverrides = i.buildTmuxOptionOverrides()
-	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed() || i.Tool != "shell" || i.isBoundedCodexExec()
+	i.tmuxSession.RunCommandAsInitialProcess = i.runCommandAsInitialProcess()
 	i.tmuxSession.AllowInitialProcessExit = i.expectsFastExit()
 	i.applyLaunchSettingsFromConfig()
 
@@ -5316,7 +5316,7 @@ func (i *Instance) StartWithMessage(message string) error {
 	// Build tmux option overrides from config (e.g. allow-passthrough = "all").
 	// Sandbox sessions also get remain-on-exit for dead-pane detection.
 	i.tmuxSession.OptionOverrides = i.buildTmuxOptionOverrides()
-	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed() || i.Tool != "shell" || i.isBoundedCodexExec()
+	i.tmuxSession.RunCommandAsInitialProcess = i.runCommandAsInitialProcess()
 	i.applyLaunchSettingsFromConfig()
 
 	// Re-assert the declarative skill+mcp loadout before spawn — sister
@@ -9247,7 +9247,7 @@ func (i *Instance) restart(env map[string]string) error {
 	// Build tmux option overrides from config (e.g. allow-passthrough = "all").
 	// Sandbox sessions also get remain-on-exit for dead-pane detection.
 	i.tmuxSession.OptionOverrides = i.buildTmuxOptionOverrides()
-	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed() || i.Tool != "shell" || i.isBoundedCodexExec()
+	i.tmuxSession.RunCommandAsInitialProcess = i.runCommandAsInitialProcess()
 	i.applyLaunchSettingsFromConfig()
 
 	// Re-assert the declarative skill+mcp loadout before respawn — sister

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -34,6 +34,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/logging"
 	"github.com/asheshgoplani/agent-deck/internal/procfd"
 	"github.com/asheshgoplani/agent-deck/internal/send"
+	"github.com/asheshgoplani/agent-deck/internal/shellwords"
 	"github.com/asheshgoplani/agent-deck/internal/statedb"
 	"github.com/asheshgoplani/agent-deck/internal/telemetry"
 	"github.com/asheshgoplani/agent-deck/internal/tmux"
@@ -4537,13 +4538,36 @@ func (i *Instance) buildTmuxOptionOverrides() map[string]string {
 	// its answer and exits BY DESIGN, and without remain-on-exit tmux tears the
 	// pane down with the answer still in it — the user asked a question and got
 	// a closed window. Keeping the pane is what makes a one-shot readable.
-	if i.IsSandboxed() || i.expectsFastExit() {
+	if i.IsSandboxed() || i.expectsFastExit() || i.isBoundedCodexExec() {
 		if overrides == nil {
 			overrides = make(map[string]string)
 		}
 		overrides["remain-on-exit"] = "on"
 	}
 	return overrides
+}
+
+// isBoundedCodexExec identifies Codex's non-interactive `exec` surface.  It
+// deliberately uses the configured command rather than Tool: a registered
+// shell launcher is allowed to wrap `codex exec …`, and its clean terminal
+// exit needs the same observable exit status as a native Codex session.
+func (i *Instance) isBoundedCodexExec() bool {
+	fields, ok := shellwords.Split(i.Command)
+	if !ok || len(fields) == 0 {
+		return false
+	}
+	if shellwords.ExecutableBase(fields) == "codex" {
+		for _, field := range fields[1:] {
+			if field == "exec" {
+				return true
+			}
+		}
+	}
+	if filepath.Base(fields[0]) == "bash" && len(fields) >= 3 && (fields[1] == "-c" || fields[1] == "-lc") {
+		inner, ok := shellwords.Split(fields[2])
+		return ok && shellwords.ExecutableBase(inner) == "codex" && len(inner) > 1 && inner[1] == "exec"
+	}
+	return false
 }
 
 // adoptExplicitClaudeSessionID adopts an explicit `--session-id <uuid>` baked
@@ -4963,7 +4987,7 @@ func (i *Instance) Start() error {
 	// Build tmux option overrides from config (e.g. allow-passthrough = "all").
 	// Sandbox sessions also get remain-on-exit for dead-pane detection.
 	i.tmuxSession.OptionOverrides = i.buildTmuxOptionOverrides()
-	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed() || i.Tool != "shell"
+	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed() || i.Tool != "shell" || i.isBoundedCodexExec()
 	i.applyLaunchSettingsFromConfig()
 
 	// Re-assert the declarative per-group/per-conductor skill+mcp loadout
@@ -5288,7 +5312,7 @@ func (i *Instance) StartWithMessage(message string) error {
 	// Build tmux option overrides from config (e.g. allow-passthrough = "all").
 	// Sandbox sessions also get remain-on-exit for dead-pane detection.
 	i.tmuxSession.OptionOverrides = i.buildTmuxOptionOverrides()
-	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed() || i.Tool != "shell"
+	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed() || i.Tool != "shell" || i.isBoundedCodexExec()
 	i.applyLaunchSettingsFromConfig()
 
 	// Re-assert the declarative skill+mcp loadout before spawn — sister
@@ -5891,6 +5915,18 @@ func (i *Instance) UpdateStatus() error {
 			if i.tmuxSession != nil && (hs.Status == "running" || hs.Status == "waiting") {
 				i.tmuxSession.ResetAcknowledged()
 			}
+		}
+	}
+
+	// `codex exec` is a bounded command, including when a registered shell
+	// launcher wraps it. Its prompt/output heuristics describe the launcher
+	// shell, not the descendant doing the work. A live Codex descendant is
+	// therefore authoritative until it exits; remain-on-exit then lets the
+	// terminal path classify exit 0 as stopped and a non-zero exit as error.
+	if i.isBoundedCodexExec() {
+		if candidates, _ := i.collectCodexProcessCandidates(); len(candidates) > 0 {
+			i.Status = StatusRunning
+			return nil
 		}
 	}
 
@@ -9203,7 +9239,7 @@ func (i *Instance) restart(env map[string]string) error {
 	// Build tmux option overrides from config (e.g. allow-passthrough = "all").
 	// Sandbox sessions also get remain-on-exit for dead-pane detection.
 	i.tmuxSession.OptionOverrides = i.buildTmuxOptionOverrides()
-	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed() || i.Tool != "shell"
+	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed() || i.Tool != "shell" || i.isBoundedCodexExec()
 	i.applyLaunchSettingsFromConfig()
 
 	// Re-assert the declarative skill+mcp loadout before respawn — sister

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -4988,6 +4988,7 @@ func (i *Instance) Start() error {
 	// Sandbox sessions also get remain-on-exit for dead-pane detection.
 	i.tmuxSession.OptionOverrides = i.buildTmuxOptionOverrides()
 	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed() || i.Tool != "shell" || i.isBoundedCodexExec()
+	i.tmuxSession.AllowInitialProcessExit = i.expectsFastExit()
 	i.applyLaunchSettingsFromConfig()
 
 	// Re-assert the declarative per-group/per-conductor skill+mcp loadout
@@ -5323,6 +5324,7 @@ func (i *Instance) StartWithMessage(message string) error {
 	ApplyConfiguredLoadout(i)
 
 	i.preAcceptCursorWorkspaceTrust()
+	i.tmuxSession.AllowInitialProcessExit = i.expectsFastExit()
 
 	// Start the tmux session
 	if err := i.tmuxSession.Start(command); err != nil {
@@ -9251,6 +9253,7 @@ func (i *Instance) restart(env map[string]string) error {
 	// Re-assert the declarative skill+mcp loadout before respawn — sister
 	// call to Start(); config edits land on the next restart this way.
 	ApplyConfiguredLoadout(i)
+	i.tmuxSession.AllowInitialProcessExit = i.expectsFastExit()
 
 	mcpLog.Debug("restart_starting_new_session", slog.String("command", command))
 

--- a/internal/session/instance_platform_test.go
+++ b/internal/session/instance_platform_test.go
@@ -11,8 +11,10 @@ import (
 // TestSyncSessionIDsFromTmux_Claude verifies that a CLAUDE_SESSION_ID in the tmux
 // environment is read into ClaudeSessionID and ClaudeDetectedAt is set.
 func TestSyncSessionIDsFromTmux_Claude(t *testing.T) {
-	skipIfNoTmuxServer(t)
-	skipIfNoClaudeBinary(t)
+	skipIfNoTmuxBinary(t)
+	home := t.TempDir()
+	setupStubClaudeOnPATH(t, home)
+	t.Setenv("HOME", home)
 
 	inst := NewInstanceWithTool("test-sync-claude", "/tmp", "claude")
 	err := inst.Start()
@@ -48,8 +50,10 @@ func TestSyncSessionIDsFromTmux_Claude(t *testing.T) {
 // TestSyncSessionIDsFromTmux_AllTools verifies that all four tool env vars are read
 // into their respective fields.
 func TestSyncSessionIDsFromTmux_AllTools(t *testing.T) {
-	skipIfNoTmuxServer(t)
-	skipIfNoClaudeBinary(t)
+	skipIfNoTmuxBinary(t)
+	home := t.TempDir()
+	setupStubClaudeOnPATH(t, home)
+	t.Setenv("HOME", home)
 
 	inst := NewInstanceWithTool("test-sync-all-tools", "/tmp", "claude")
 	err := inst.Start()
@@ -100,7 +104,10 @@ func TestSyncSessionIDsFromTmux_AllTools(t *testing.T) {
 // TestSyncSessionIDsFromTmux_NoOverwriteWithEmpty verifies that if a tmux session
 // does NOT have CLAUDE_SESSION_ID set, the existing ClaudeSessionID is preserved.
 func TestSyncSessionIDsFromTmux_NoOverwriteWithEmpty(t *testing.T) {
-	skipIfNoTmuxServer(t)
+	skipIfNoTmuxBinary(t)
+	home := t.TempDir()
+	setupStubClaudeOnPATH(t, home)
+	t.Setenv("HOME", home)
 
 	inst := NewInstanceWithTool("test-sync-no-overwrite", "/tmp", "claude")
 	err := inst.Start()
@@ -110,6 +117,9 @@ func TestSyncSessionIDsFromTmux_NoOverwriteWithEmpty(t *testing.T) {
 	defer func() { _ = inst.Kill() }()
 
 	// Do NOT set CLAUDE_SESSION_ID in the tmux env — it should be absent.
+	if err := inst.tmuxSession.UnsetEnvironment("CLAUDE_SESSION_ID"); err != nil {
+		t.Fatalf("UnsetEnvironment failed: %v", err)
+	}
 	// Set an existing value on the instance.
 	const existingID = "existing-claude-id"
 	inst.ClaudeSessionID = existingID
@@ -124,8 +134,10 @@ func TestSyncSessionIDsFromTmux_NoOverwriteWithEmpty(t *testing.T) {
 // TestSyncSessionIDsFromTmux_OverwriteWithNew verifies that if tmux env has a
 // non-empty CLAUDE_SESSION_ID, it overwrites the existing value on the Instance.
 func TestSyncSessionIDsFromTmux_OverwriteWithNew(t *testing.T) {
-	skipIfNoTmuxServer(t)
-	skipIfNoClaudeBinary(t)
+	skipIfNoTmuxBinary(t)
+	home := t.TempDir()
+	setupStubClaudeOnPATH(t, home)
+	t.Setenv("HOME", home)
 
 	inst := NewInstanceWithTool("test-sync-overwrite", "/tmp", "claude")
 	err := inst.Start()

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -774,7 +774,10 @@ func TestInstance_UpdateClaudeSession_PreservesExistingID(t *testing.T) {
 // contains a zombie session ID (no conversation data) and the current session has
 // real data, the zombie is rejected and the current session is preserved.
 func TestInstance_UpdateClaudeSession_RejectZombie(t *testing.T) {
-	skipIfNoTmuxServer(t)
+	skipIfNoTmuxBinary(t)
+	home := t.TempDir()
+	setupStubClaudeOnPATH(t, home)
+	t.Setenv("HOME", home)
 
 	configDir := t.TempDir()
 	origConfigDir := os.Getenv("CLAUDE_CONFIG_DIR")
@@ -1212,7 +1215,10 @@ func TestInstance_UpdateGeminiSession_UsesLatestFromFilesystem(t *testing.T) {
 }
 
 func TestInstance_Restart_ResumesClaudeSession(t *testing.T) {
-	skipIfNoTmuxServer(t)
+	skipIfNoTmuxBinary(t)
+	home := t.TempDir()
+	setupStubClaudeOnPATH(t, home)
+	t.Setenv("HOME", home)
 
 	// Create instance with known session ID (simulating previous session)
 	inst := NewInstanceWithTool("restart-test", "/tmp", "claude")

--- a/internal/session/launch_ack_lifecycle_test.go
+++ b/internal/session/launch_ack_lifecycle_test.go
@@ -1,0 +1,40 @@
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLaunchAcknowledgement_ImmediateExitsFailAndClean(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	for _, tc := range []struct{ name, command, status string }{
+		{"clean", "sh -c 'exit 0'", "exit status 0"},
+		{"nonzero", "sh -c 'exit 7'", "exit status 7"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			withConfig(t, &UserConfig{Tmux: TmuxSettings{Options: map[string]string{"remain-on-exit": "on"}}})
+			inst := NewInstance("launch-ack-"+tc.name, t.TempDir())
+			inst.Tool, inst.Command = "custom-launch-ack-"+tc.name, tc.command
+			err := inst.Start()
+			if err == nil || !strings.Contains(err.Error(), tc.status) {
+				t.Fatalf("Start() = %v, want %s", err, tc.status)
+			}
+			if inst.Exists() {
+				t.Fatal("failed launch left a stale tmux session")
+			}
+		})
+	}
+}
+
+func TestLaunchAcknowledgement_LongRunningStartSucceeds(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	inst := NewInstance("launch-ack-long-running", t.TempDir())
+	inst.Tool, inst.Command = "custom-launch-ack-long-running", "sleep 5"
+	t.Cleanup(func() { _ = inst.Kill() })
+	if err := inst.Start(); err != nil {
+		t.Fatalf("Start() = %v", err)
+	}
+	if !inst.Exists() {
+		t.Fatal("successful start has no tmux session")
+	}
+}

--- a/internal/session/oneshot_exit_status_test.go
+++ b/internal/session/oneshot_exit_status_test.go
@@ -102,7 +102,11 @@ func TestBoundedShellCodexExecReportsNonzeroExit(t *testing.T) {
 	inst := NewInstance("bounded-shell-codex-fail", t.TempDir())
 	inst.Tool = "shell"
 	inst.Command = "codex exec --json fail"
-	assert.NoError(t, inst.Start())
+	err := inst.Start()
+	if err == nil {
+		t.Fatal("Start() succeeded after the initial command exited 7")
+	}
+	assert.Contains(t, err.Error(), "exit status 7")
 	t.Cleanup(func() { _ = inst.Kill() })
 
 	deadline := time.NewTimer(5 * time.Second)
@@ -120,6 +124,29 @@ func TestBoundedShellCodexExecReportsNonzeroExit(t *testing.T) {
 		case <-tick.C:
 		}
 	}
+}
+
+// TestInitialProcessAcknowledgementRejectsCleanImmediateExit is intentionally
+// a real isolated-tmux regression: tmux creation itself succeeded, but a
+// bounded command that finishes before Start returns is not a launched
+// interactive session. Exit zero stays visible in the error so callers cannot
+// mistake completion for a usable pane.
+func TestInitialProcessAcknowledgementRejectsCleanImmediateExit(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+
+	bin := t.TempDir()
+	assert.NoError(t, os.WriteFile(filepath.Join(bin, "codex"), []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	inst := NewInstance("bounded-shell-codex-clean-exit", t.TempDir())
+	inst.Tool = "shell"
+	inst.Command = "codex exec --json done"
+	err := inst.Start()
+	if err == nil {
+		t.Fatal("Start() succeeded after the initial command exited 0")
+	}
+	assert.Contains(t, err.Error(), "exit status 0")
+	t.Cleanup(func() { _ = inst.Kill() })
 }
 
 func TestBoundedCodexExecKeepsExitStatus(t *testing.T) {

--- a/internal/session/oneshot_exit_status_test.go
+++ b/internal/session/oneshot_exit_status_test.go
@@ -1,6 +1,13 @@
 package session
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
 
 // TestClassifyTerminatedPane_CleanExitVsCrash pins the classification of a
 // session whose tmux pane has terminated after having been started.
@@ -44,6 +51,95 @@ func TestClassifyTerminatedPane_CleanExitVsCrash(t *testing.T) {
 			if got != tt.want {
 				t.Errorf("classifyTerminatedPane(%d, %v, %q) = %q, want %q",
 					tt.exitCode, tt.haveExitCode, tt.tool, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBoundedShellCodexExecReportsLiveThenCleanCompletion(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+
+	bin := t.TempDir()
+	// The script name is intentionally codex: process-tree inspection must see
+	// the descendant beneath the shell launcher, rather than trusting pane text.
+	assert.NoError(t, os.WriteFile(filepath.Join(bin, "codex"), []byte("#!/bin/sh\n[ \"$1\" = exec ] || exit 9\nsleep 1\n"), 0o755))
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	inst := NewInstance("bounded-shell-codex", t.TempDir())
+	inst.Tool = "shell"
+	inst.Command = "codex exec --json work"
+	assert.NoError(t, inst.Start())
+	t.Cleanup(func() { _ = inst.Kill() })
+
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+	tick := time.NewTicker(50 * time.Millisecond)
+	defer tick.Stop()
+	sawRunning := false
+	for {
+		assert.NoError(t, inst.UpdateStatus())
+		if inst.GetStatusThreadSafe() == StatusRunning {
+			sawRunning = true
+		}
+		if sawRunning && inst.GetStatusThreadSafe() == StatusStopped {
+			return
+		}
+		select {
+		case <-deadline.C:
+			t.Fatalf("status=%s, sawRunning=%v; want live descendant then clean stopped completion", inst.GetStatusThreadSafe(), sawRunning)
+		case <-tick.C:
+		}
+	}
+}
+
+func TestBoundedShellCodexExecReportsNonzeroExit(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+
+	bin := t.TempDir()
+	assert.NoError(t, os.WriteFile(filepath.Join(bin, "codex"), []byte("#!/bin/sh\n[ \"$1\" = exec ] || exit 9\nexit 7\n"), 0o755))
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	inst := NewInstance("bounded-shell-codex-fail", t.TempDir())
+	inst.Tool = "shell"
+	inst.Command = "codex exec --json fail"
+	assert.NoError(t, inst.Start())
+	t.Cleanup(func() { _ = inst.Kill() })
+
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+	tick := time.NewTicker(50 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		assert.NoError(t, inst.UpdateStatus())
+		if inst.GetStatusThreadSafe() == StatusError {
+			return
+		}
+		select {
+		case <-deadline.C:
+			t.Fatalf("status=%s; want error for codex exec exit 7", inst.GetStatusThreadSafe())
+		case <-tick.C:
+		}
+	}
+}
+
+func TestBoundedCodexExecKeepsExitStatus(t *testing.T) {
+	tests := []struct {
+		command string
+		want    bool
+	}{
+		{"codex exec --json fix-it", true},
+		{"bash -lc 'codex exec --json fix-it'", true},
+		{"codex --model gpt-5.6-terra", false},
+		{"echo codex exec", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.command, func(t *testing.T) {
+			inst := NewInstance("bounded-codex", t.TempDir())
+			inst.Command = tt.command
+			assert.Equal(t, tt.want, inst.isBoundedCodexExec())
+			overrides := inst.buildTmuxOptionOverrides()
+			if tt.want {
+				assert.Equal(t, "on", overrides["remain-on-exit"], "exit 0 must remain observable as stopped")
 			}
 		})
 	}

--- a/internal/session/restart_tmux_persist.go
+++ b/internal/session/restart_tmux_persist.go
@@ -58,6 +58,14 @@ func (i *Instance) recordRestartOutcome() {
 	}
 }
 
+// PersistRestartOutcome records the live tmux identity and lifecycle state of
+// a successful restart through a targeted write. CLI callers use this instead
+// of a stale full-registry snapshot: the process replacement is already real,
+// so a concurrent status refresh must not make the command report failure.
+func (i *Instance) PersistRestartOutcome() {
+	i.recordRestartOutcome()
+}
+
 // writeRestartOutcome performs the targeted write and reports what stopped it.
 func (i *Instance) writeRestartOutcome() (statedb.WriteStamps, error) {
 	name := ""

--- a/internal/session/session_persistence_test.go
+++ b/internal/session/session_persistence_test.go
@@ -542,6 +542,9 @@ func setupStubClaudeOnPATH(t *testing.T, home string) string {
 
 	// Configure [claude] command = <abs stub> via the user config under the
 	// isolated HOME. This is read by GetClaudeCommand() at dispatch time.
+	if err := os.MkdirAll(filepath.Join(home, ".agent-deck"), 0o700); err != nil {
+		t.Fatalf("setupStubClaudeOnPATH: mkdir config dir: %v", err)
+	}
 	cfgPath := filepath.Join(home, ".agent-deck", "config.toml")
 	cfgBody := "[claude]\ncommand = \"" + stubAbs + "\"\n"
 	if err := os.WriteFile(cfgPath, []byte(cfgBody), 0o644); err != nil {

--- a/internal/session/spawn_failure.go
+++ b/internal/session/spawn_failure.go
@@ -484,12 +484,20 @@ func (i *Instance) recordPrepareFailure(command string, prepErr error) {
 // the fast-death path this has no pane to snapshot — the error string is the
 // diagnostic.
 func (i *Instance) recordTmuxStartFailure(command string, startErr error) {
+	diagnostic := startErr.Error()
+	if i.tmuxSession != nil {
+		if content, captureErr := i.tmuxSession.CapturePane(); captureErr == nil {
+			if content = strings.TrimSpace(content); content != "" {
+				diagnostic += ": " + content
+			}
+		}
+	}
 	rec := SpawnFailureRecord{
 		InstanceID:  i.ID,
 		Tool:        i.Tool,
 		Command:     command,
 		Reason:      "tmux_start_failed",
-		DyingOutput: startErr.Error(),
+		DyingOutput: diagnostic,
 	}
 	if err := writeSpawnFailureRecord(rec); err != nil {
 		sessionLog.Warn("spawn_failure_record_write_failed",

--- a/internal/session/spawn_failure.go
+++ b/internal/session/spawn_failure.go
@@ -483,9 +483,13 @@ func (i *Instance) recordPrepareFailure(command string, prepErr error) {
 // failed to create the session (i.tmuxSession.Start returned an error). Unlike
 // the fast-death path this has no pane to snapshot — the error string is the
 // diagnostic.
-func (i *Instance) recordTmuxStartFailure(command string, startErr error) {
+func (i *Instance) recordTmuxStartFailure(command string, startErr error, captured ...string) {
 	diagnostic := startErr.Error()
-	if i.tmuxSession != nil {
+	if len(captured) > 0 {
+		if content := strings.TrimSpace(captured[0]); content != "" {
+			diagnostic += ": " + content
+		}
+	} else if i.tmuxSession != nil {
 		if content, captureErr := i.tmuxSession.CapturePane(); captureErr == nil {
 			if content = strings.TrimSpace(content); content != "" {
 				diagnostic += ": " + content

--- a/internal/session/testdata/fake-dsh
+++ b/internal/session/testdata/fake-dsh
@@ -176,6 +176,18 @@ case "$profile" in
     fi
     require_credential
     record_session "$(new_session_id)"
+    case "$*" in
+      __agentdeck_late_success__)
+        sleep 1
+        printf 'LATE_HEADLESS_DIAGNOSTIC\n' >&2
+        exit 0
+        ;;
+      __agentdeck_late_failure__)
+        sleep 1
+        printf 'LATE_HEADLESS_DIAGNOSTIC\n' >&2
+        exit 7
+        ;;
+    esac
     printf 'answered: %s\n' "$*"
     exit 0
     ;;

--- a/internal/tmux/launch_ack_test.go
+++ b/internal/tmux/launch_ack_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -167,6 +168,150 @@ func TestWatchInitialProcessCompletionRetriesIndeterminateIdentityProbe(t *testi
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("watcher abandoned marker after an indeterminate identity probe")
+	}
+}
+
+func TestProbeSessionIdentityEmptySuccessfulResponseIsMissing(t *testing.T) {
+	dir := t.TempDir()
+	writeFakeTmux(t, dir, "if [ \"$1\" = \"-u\" ]; then shift; fi\nif [ \"$1\" = \"-L\" ]; then shift 2; fi\nif [ \"$1\" = \"display-message\" ]; then exit 0; fi\nexit 1\n")
+	probe := (&Session{Name: "gone"}).probeSessionIdentity("gone")
+	if probe.state != sessionIdentityMissing {
+		t.Fatalf("empty successful identity probe = %v, want missing", probe.state)
+	}
+}
+
+func TestProbeSessionIdentityAuthoritativeNoServerIsMissing(t *testing.T) {
+	dir := t.TempDir()
+	writeFakeTmux(t, dir, "if [ \"$1\" = \"-u\" ]; then shift; fi\nif [ \"$1\" = \"-L\" ]; then shift 2; fi\nif [ \"$1\" = \"display-message\" ]; then echo 'no server running' >&2; exit 1; fi\nexit 1\n")
+	probe := (&Session{Name: "gone"}).probeSessionIdentity("gone")
+	if probe.state != sessionIdentityMissing {
+		t.Fatalf("authoritative no-server identity probe = %v, want missing", probe.state)
+	}
+}
+
+func TestSessionIdentityForRetriesTransientEmptyResponse(t *testing.T) {
+	dir := t.TempDir()
+	countPath := filepath.Join(dir, "identity-calls")
+	writeFakeTmux(t, dir, "if [ \"$1\" = \"-u\" ]; then shift; fi\n"+
+		"if [ \"$1\" = \"-L\" ]; then shift 2; fi\n"+
+		"if [ \"$1\" = \"display-message\" ]; then\n"+
+		"  n=0; [ -f "+shellQuote(countPath)+" ] && n=$(cat "+shellQuote(countPath)+")\n"+"  n=$((n + 1)); echo $n > "+shellQuote(countPath)+"\n"+"  if [ $n -lt 2 ]; then exit 0; fi\n"+"  echo '$created'; exit 0\nfi\nexit 1\n")
+	identity := (&Session{Name: "created"}).sessionIdentityFor("created")
+	if identity != "$created" {
+		t.Fatalf("sessionIdentityFor() = %q, want retry result $created", identity)
+	}
+}
+
+func TestCaptureCreatedSessionIdentityRequiresBoundedOwnedProbe(t *testing.T) {
+	dir := t.TempDir()
+	countPath := filepath.Join(dir, "identity-calls")
+	writeFakeTmux(t, dir, "if [ \"$1\" = \"-u\" ]; then shift; fi\n"+
+		"if [ \"$1\" = \"-L\" ]; then shift 2; fi\n"+
+		"if [ \"$1\" = \"display-message\" ]; then\n"+"  n=0; [ -f "+shellQuote(countPath)+" ] && n=$(cat "+shellQuote(countPath)+")\n"+"  n=$((n + 1)); echo $n > "+shellQuote(countPath)+"\n"+"  if [ $n -eq 1 ]; then echo 'server busy' >&2; exit 1; fi\n"+"  echo '$created'; exit 0\n"+"fi\nexit 1\n")
+	sess := &Session{Name: "created"}
+	identity, err := sess.captureCreatedSessionIdentity()
+	if err != nil || identity != "$created" {
+		t.Fatalf("captureCreatedSessionIdentity() = %q, %v; want bounded retry to $created", identity, err)
+	}
+}
+
+func TestLaunchAckScriptFailsClosedWithoutProcessGroupCapability(t *testing.T) {
+	ackPath := filepath.Join(t.TempDir(), "ack")
+	latePath := filepath.Join(t.TempDir(), "late")
+	command := fmt.Sprintf("(sleep 1; printf LATE > %s) & printf DIRECT; exit 7", shellQuote(latePath))
+	pathDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.Mkdir(pathDir, 0o755); err != nil {
+		t.Fatalf("mkdir capability-minimal PATH: %v", err)
+	}
+	for _, name := range []string{"bash", "cat", "kill", "mkfifo", "mv", "rm", "sleep", "tee"} {
+		target, err := exec.LookPath(name)
+		if err != nil {
+			t.Skipf("%s unavailable: %v", name, err)
+		}
+		if err := os.Symlink(target, filepath.Join(pathDir, name)); err != nil {
+			t.Fatalf("link %s: %v", name, err)
+		}
+	}
+	t.Setenv("PATH", pathDir)
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(bash, "-c", launchAckScript, "agent-deck-launch-ack", ackPath, command)
+	err = cmd.Run()
+	if err == nil {
+		t.Fatal("capability-minimal wrapper unexpectedly reported success")
+	}
+	if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.ExitCode() != 125 {
+		t.Fatalf("capability-minimal wrapper error = %v, want exit 125", err)
+	}
+	if _, err := os.Stat(latePath); !os.IsNotExist(err) {
+		t.Fatalf("capability-minimal wrapper launched an unowned descendant: stat error %v", err)
+	}
+	marker, err := os.ReadFile(ackPath)
+	if err != nil {
+		t.Fatalf("read fail-closed marker: %v", err)
+	}
+	if !strings.Contains(string(marker), "exit:125") {
+		t.Fatalf("fail-closed marker = %q, want exit:125", marker)
+	}
+}
+
+func TestKillIfOwnedSynchronouslyReapsOwnedDescendants(t *testing.T) {
+	dir := t.TempDir()
+	writeFakeTmux(t, dir, "if [ \"$1\" = \"-u\" ]; then shift; fi\n"+
+		"if [ \"$1\" = \"-L\" ]; then shift 2; fi\n"+
+		"if [ \"$1\" = \"display-message\" ]; then echo '$owned'; exit 0; fi\n"+
+		"if [ \"$1\" = \"list-panes\" ]; then echo \"$TEARDOWN_PID\"; exit 0; fi\n"+"if [ \"$1\" = \"kill-session\" ]; then exit 0; fi\nexit 0\n")
+	proc := exec.Command("sh", "-c", "trap '' HUP; sleep 30")
+	if err := proc.Start(); err != nil {
+		t.Fatalf("start owned process: %v", err)
+	}
+	done := make(chan struct{})
+	go func() { _ = proc.Wait(); close(done) }()
+	t.Setenv("TEARDOWN_PID", fmt.Sprint(proc.Process.Pid))
+	sess := &Session{Name: "owned-sync", createdSessionID: "$owned"}
+	if err := sess.KillIfOwned(); err != nil {
+		t.Fatalf("KillIfOwned: %v", err)
+	}
+	if err := syscall.Kill(proc.Process.Pid, syscall.Signal(0)); err == nil {
+		t.Fatal("owned descendant still alive after synchronous KillIfOwned returned")
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("owned process was not reaped after KillIfOwned returned")
+	}
+}
+
+func TestKillIfOwnedSnapshotIgnoresMutableReplacementFields(t *testing.T) {
+	dir := t.TempDir()
+	callLog := filepath.Join(dir, "calls")
+	writeFakeTmux(t, dir, "if [ \"$1\" = \"-u\" ]; then shift; fi\n"+
+		"if [ \"$1\" = \"-L\" ]; then shift 2; fi\n"+
+		"echo \"$*\" >> "+shellQuote(callLog)+"\n"+
+		"case \"$1\" in\n"+
+		"display-message) echo '$old';;\n"+
+		"list-panes) exit 0;;\n"+
+		"kill-session) exit 0;;\n"+
+		"*) exit 0;;\n"+
+		"esac\n")
+	launch := &Session{Name: "old-name", createdSessionID: "$old"}
+	capturedName, capturedID := launch.OwnershipSnapshot()
+	launch.Name = "replacement-name"
+	launch.createdSessionID = "$replacement"
+	if err := launch.KillIfOwnedSnapshot(capturedName, capturedID); err != nil {
+		t.Fatalf("captured immutable cleanup: %v", err)
+	}
+	calls, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatalf("read tmux calls: %v", err)
+	}
+	if !strings.Contains(string(calls), "kill-session -t $old") {
+		t.Fatalf("cleanup did not use captured identity: %q", calls)
+	}
+	if strings.Contains(string(calls), "$replacement") {
+		t.Fatalf("cleanup followed mutable replacement identity: %q", calls)
 	}
 }
 

--- a/internal/tmux/launch_ack_test.go
+++ b/internal/tmux/launch_ack_test.go
@@ -207,8 +207,8 @@ func TestCaptureCreatedSessionIdentityRequiresBoundedOwnedProbe(t *testing.T) {
 	countPath := filepath.Join(dir, "identity-calls")
 	writeFakeTmux(t, dir, "if [ \"$1\" = \"-u\" ]; then shift; fi\n"+
 		"if [ \"$1\" = \"-L\" ]; then shift 2; fi\n"+
-		"if [ \"$1\" = \"display-message\" ]; then\n"+"  n=0; [ -f "+shellQuote(countPath)+" ] && n=$(cat "+shellQuote(countPath)+")\n"+"  n=$((n + 1)); echo $n > "+shellQuote(countPath)+"\n"+"  if [ $n -eq 1 ]; then echo 'server busy' >&2; exit 1; fi\n"+"  echo '$created'; exit 0\n"+"fi\nexit 1\n")
-	sess := &Session{Name: "created"}
+		"if [ \"$1\" = \"list-sessions\" ]; then\n"+"  n=0; [ -f "+shellQuote(countPath)+" ] && n=$(cat "+shellQuote(countPath)+")\n"+"  n=$((n + 1)); echo $n > "+shellQuote(countPath)+"\n"+"  if [ $n -eq 1 ]; then exit 1; fi\n"+"  printf '$created\\tcreated\\tmarker\\n'; exit 0\n"+"fi\nexit 1\n")
+	sess := &Session{Name: "created", creationMarker: "marker"}
 	identity, err := sess.captureCreatedSessionIdentity()
 	if err != nil || identity != "$created" {
 		t.Fatalf("captureCreatedSessionIdentity() = %q, %v; want bounded retry to $created", identity, err)
@@ -220,11 +220,23 @@ func TestCaptureCreatedSessionIdentityRetriesTransientEmptyResponse(t *testing.T
 	countPath := filepath.Join(dir, "identity-calls")
 	writeFakeTmux(t, dir, "if [ \"$1\" = \"-u\" ]; then shift; fi\n"+
 		"if [ \"$1\" = \"-L\" ]; then shift 2; fi\n"+
-		"if [ \"$1\" = \"display-message\" ]; then\n"+"  n=0; [ -f "+shellQuote(countPath)+" ] && n=$(cat "+shellQuote(countPath)+")\n"+"  n=$((n + 1)); echo $n > "+shellQuote(countPath)+"\n"+"  if [ $n -eq 1 ]; then exit 0; fi\n"+"  echo '$created'; exit 0\n"+"fi\nexit 1\n")
+		"if [ \"$1\" = \"list-sessions\" ]; then\n"+"  n=0; [ -f "+shellQuote(countPath)+" ] && n=$(cat "+shellQuote(countPath)+")\n"+"  n=$((n + 1)); echo $n > "+shellQuote(countPath)+"\n"+"  if [ $n -eq 1 ]; then exit 0; fi\n"+"  printf '$created\\tcreated\\tmarker\\n'; exit 0\n"+"fi\nexit 1\n")
 
-	identity, err := (&Session{Name: "created"}).captureCreatedSessionIdentity()
+	identity, err := (&Session{Name: "created", creationMarker: "marker"}).captureCreatedSessionIdentity()
 	if err != nil || identity != "$created" {
 		t.Fatalf("captureCreatedSessionIdentity() = %q, %v; want retry result $created", identity, err)
+	}
+}
+
+func TestCaptureCreatedSessionIdentityRejectsUnmarkedReplacement(t *testing.T) {
+	dir := t.TempDir()
+	writeFakeTmux(t, dir, "if [ \"$1\" = \"-u\" ]; then shift; fi\n"+
+		"if [ \"$1\" = \"-L\" ]; then shift 2; fi\n"+"if [ \"$1\" = \"display-message\" ]; then echo '$replacement'; exit 0; fi\n"+"if [ \"$1\" = \"list-sessions\" ]; then echo '$replacement\\treused-name\\tnew-marker'; exit 0; fi\n"+"exit 1\n")
+
+	sess := &Session{Name: "reused-name", creationMarker: "old-marker"}
+	identity, err := sess.captureCreatedSessionIdentity()
+	if err == nil || identity != "" {
+		t.Fatalf("captureCreatedSessionIdentity() = %q, %v; want rejection of replacement", identity, err)
 	}
 }
 
@@ -262,16 +274,11 @@ func TestStartRollsBackCreatedSessionWhenCreationOutputIsEmpty(t *testing.T) {
 		"esac\n")
 
 	sess := NewSession("empty-create-output-rollback", t.TempDir())
-	err := sess.Start("")
-	if err == nil {
-		t.Fatal("Start() unexpectedly succeeded without an immutable session identity")
+	if err := sess.Start(""); err != nil {
+		t.Fatalf("Start() failed to capture immutable identity from marker snapshot: %v", err)
 	}
-	if raw, readErr := os.ReadFile(killLog); readErr != nil || len(strings.TrimSpace(string(raw))) == 0 {
-		calls, _ := os.ReadFile(callLog)
-		t.Fatalf("created session was not rolled back after empty creation output: log=%q readErr=%v calls=%q", raw, readErr, calls)
-	}
-	if raw, readErr := os.ReadFile(killLog); readErr == nil && !strings.Contains(string(raw), "-t $created") {
-		t.Fatalf("rollback did not target the immutable created session identity: %q", raw)
+	if raw, readErr := os.ReadFile(killLog); readErr == nil && len(strings.TrimSpace(string(raw))) != 0 {
+		t.Fatalf("successful marker handoff unexpectedly rolled back: %q", raw)
 	}
 }
 

--- a/internal/tmux/launch_ack_test.go
+++ b/internal/tmux/launch_ack_test.go
@@ -247,6 +247,52 @@ func TestStartRollsBackCreatedSessionWhenIdentityCaptureFails(t *testing.T) {
 	}
 }
 
+func TestStartRollsBackCreatedSessionWhenCreationOutputIsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	createLog := filepath.Join(dir, "create.log")
+	killLog := filepath.Join(dir, "kill.log")
+	callLog := filepath.Join(dir, "calls.log")
+	writeFakeTmux(t, dir, "echo \"$*\" >> "+shellQuote(callLog)+"\ncase \" $* \" in\n"+
+		"  *' has-session '*) exit 1 ;;\n"+
+		"  *' new-session '*) echo \"$*\" > "+shellQuote(createLog)+"; exit 0 ;;\n"+
+		"  *' list-sessions '*) [ -f "+shellQuote(createLog)+" ] || exit 0; marker=$(sed -n 's/.*AGENTDECK_SESSION_CREATION_MARKER=\\([^ ]*\\).*/\\1/p' "+shellQuote(createLog)+"); name=$(sed -n 's/.*-s \\([^ ]*\\).*/\\1/p' "+shellQuote(createLog)+"); printf '$created\\t%s\\t%s\\n' \"$name\" \"$marker\"; exit 0 ;;\n"+
+		"  *' display-message '*) echo 'server busy' >&2; exit 1 ;;\n"+
+		"  *' kill-session '*) echo \"$*\" >> "+shellQuote(killLog)+"; exit 0 ;;\n"+
+		"  *) exit 0 ;;\n"+
+		"esac\n")
+
+	sess := NewSession("empty-create-output-rollback", t.TempDir())
+	err := sess.Start("")
+	if err == nil {
+		t.Fatal("Start() unexpectedly succeeded without an immutable session identity")
+	}
+	if raw, readErr := os.ReadFile(killLog); readErr != nil || len(strings.TrimSpace(string(raw))) == 0 {
+		calls, _ := os.ReadFile(callLog)
+		t.Fatalf("created session was not rolled back after empty creation output: log=%q readErr=%v calls=%q", raw, readErr, calls)
+	}
+	if raw, readErr := os.ReadFile(killLog); readErr == nil && !strings.Contains(string(raw), "-t $created") {
+		t.Fatalf("rollback did not target the immutable created session identity: %q", raw)
+	}
+}
+
+func TestRollbackCreatedSessionMarkerMismatchDoesNotKillReplacement(t *testing.T) {
+	dir := t.TempDir()
+	killLog := filepath.Join(dir, "kill.log")
+	writeFakeTmux(t, dir, "case \" $* \" in\n"+
+		"  *' list-sessions '*) printf '$replacement\\treused-name\\tnew-marker\\n'; exit 0 ;;\n"+
+		"  *' kill-session '*) echo \"$*\" >> "+shellQuote(killLog)+"; exit 0 ;;\n"+
+		"  *) exit 0 ;;\n"+
+		"esac\n")
+
+	sess := &Session{Name: "reused-name", creationMarker: "old-marker"}
+	if err := sess.rollbackCreatedSession(""); err == nil {
+		t.Fatal("rollback unexpectedly accepted a replacement session with a different creation marker")
+	}
+	if _, err := os.Stat(killLog); !os.IsNotExist(err) {
+		t.Fatalf("replacement session was targeted after marker mismatch: stat error %v", err)
+	}
+}
+
 func TestLaunchAckScriptFailsClosedWithoutProcessGroupCapability(t *testing.T) {
 	ackPath := filepath.Join(t.TempDir(), "ack")
 	latePath := filepath.Join(t.TempDir(), "late")

--- a/internal/tmux/launch_ack_test.go
+++ b/internal/tmux/launch_ack_test.go
@@ -1,6 +1,12 @@
 package tmux
 
-import "testing"
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestParseLaunchAckMarker(t *testing.T) {
 	tests := []struct {
@@ -30,3 +36,71 @@ func TestParseLaunchAckMarker(t *testing.T) {
 }
 
 func intPtr(value int) *int { return &value }
+
+func TestLaunchAckScriptPublishesDrainedOutputAndPreservesExit(t *testing.T) {
+	ackPath := filepath.Join(t.TempDir(), "ack")
+	command := `printf 'DIAGNOSTIC_ONCE\n'; exit 7`
+	cmd := exec.Command("bash", "-c", launchAckScript, "agent-deck-launch-ack", ackPath, command)
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("launch acknowledgement wrapper returned nil for child exit 7")
+	}
+	if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.ExitCode() != 7 {
+		t.Fatalf("wrapper error = %v, want exit status 7", err)
+	}
+
+	marker, readErr := os.ReadFile(ackPath)
+	if readErr != nil {
+		t.Fatalf("read completion marker: %v", readErr)
+	}
+	text := string(marker)
+	if !strings.Contains(text, "exit:7\n") {
+		t.Fatalf("completion marker = %q, want exit:7", text)
+	}
+	if !strings.Contains(text, "DIAGNOSTIC_ONCE") {
+		t.Fatalf("completion marker = %q, want drained diagnostic", text)
+	}
+	if strings.Contains(text, "exit:7\nDIAGNOSTIC_ONCE\n") == false {
+		t.Fatalf("completion marker published before diagnostic drain: %q", text)
+	}
+	for _, suffix := range []string{".output", ".tmp", ".fifo"} {
+		if _, err := os.Stat(ackPath + suffix); !os.IsNotExist(err) {
+			t.Errorf("temporary file %s still exists (stat error %v)", ackPath+suffix, err)
+		}
+	}
+}
+
+func TestSessionIdentityMismatchIsNotOwned(t *testing.T) {
+	if sessionIdentityMatches("$1", "$2") {
+		t.Fatal("different tmux session identities must not be treated as owned")
+	}
+	if !sessionIdentityMatches("$1", "$1") {
+		t.Fatal("matching tmux session identity must be treated as owned")
+	}
+}
+
+func TestKillIfOwnedDoesNotKillRecreatedSession(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	name := "launch-ack-owner-race"
+	if output, err := exec.Command("tmux", "new-session", "-d", "-s", name, "sleep", "30").CombinedOutput(); err != nil {
+		t.Fatalf("create original session: %v (%s)", err, strings.TrimSpace(string(output)))
+	}
+	sess := &Session{Name: name}
+	sess.createdSessionID = sess.sessionIdentity()
+	if sess.createdSessionID == "" {
+		t.Fatal("original session has no tmux session identity")
+	}
+	t.Cleanup(func() { _ = exec.Command("tmux", "kill-session", "-t", name).Run() })
+	if err := exec.Command("tmux", "kill-session", "-t", name).Run(); err != nil {
+		t.Fatalf("delete original session: %v", err)
+	}
+	if output, err := exec.Command("tmux", "new-session", "-d", "-s", name, "sleep", "30").CombinedOutput(); err != nil {
+		t.Fatalf("recreate replacement session: %v (%s)", err, strings.TrimSpace(string(output)))
+	}
+	if err := sess.KillIfOwned(); err == nil {
+		t.Fatal("ownership mismatch unexpectedly allowed cleanup")
+	}
+	if !sess.Exists() {
+		t.Fatal("ownership mismatch cleanup killed the replacement session")
+	}
+}

--- a/internal/tmux/launch_ack_test.go
+++ b/internal/tmux/launch_ack_test.go
@@ -228,23 +228,6 @@ func TestCaptureCreatedSessionIdentityRetriesTransientEmptyResponse(t *testing.T
 	}
 }
 
-func TestCaptureCreatedSessionIdentityUsesAuthoritativeCreateOutput(t *testing.T) {
-
-	dir := t.TempDir()
-	writeFakeTmux(t, dir, "if [ \"$1\" = \"-u\" ]; then shift; fi\n"+
-		"if [ \"$1\" = \"-L\" ]; then shift 2; fi\n"+"if [ \"$1\" = \"list-sessions\" ]; then exit 1; fi\n"+"exit 1\n")
-
-	sess := &Session{
-		Name:             "created",
-		creationMarker:   "marker",
-		createdSessionID: "$created",
-	}
-	identity, err := sess.captureCreatedSessionIdentity()
-	if err != nil || identity != "$created" {
-		t.Fatalf("captureCreatedSessionIdentity() = %q, %v; want authoritative create output $created", identity, err)
-	}
-}
-
 func TestCaptureCreatedSessionIdentityRejectsUnmarkedReplacement(t *testing.T) {
 	dir := t.TempDir()
 	writeFakeTmux(t, dir, "if [ \"$1\" = \"-u\" ]; then shift; fi\n"+

--- a/internal/tmux/launch_ack_test.go
+++ b/internal/tmux/launch_ack_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestParseLaunchAckMarker(t *testing.T) {
@@ -102,5 +103,42 @@ func TestKillIfOwnedDoesNotKillRecreatedSession(t *testing.T) {
 	}
 	if !sess.Exists() {
 		t.Fatal("ownership mismatch cleanup killed the replacement session")
+	}
+}
+
+func TestWatchInitialProcessCompletionIgnoresRecreatedSession(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	name := "launch-ack-watcher-race"
+	if output, err := exec.Command("tmux", "new-session", "-d", "-s", name, "sleep", "30").CombinedOutput(); err != nil {
+		t.Fatalf("create original session: %v (%s)", err, strings.TrimSpace(string(output)))
+	}
+	sess := &Session{Name: name}
+	sess.createdSessionID = sess.sessionIdentity()
+	if sess.createdSessionID == "" {
+		t.Fatal("original session has no tmux session identity")
+	}
+	ackPath := filepath.Join(t.TempDir(), "ack")
+	sess.launchAckPath = ackPath
+	if err := os.WriteFile(ackPath, []byte("pid:42\n"), 0o600); err != nil {
+		t.Fatalf("write launch marker: %v", err)
+	}
+	t.Cleanup(func() { _ = exec.Command("tmux", "kill-session", "-t", name).Run() })
+	if err := exec.Command("tmux", "kill-session", "-t", name).Run(); err != nil {
+		t.Fatalf("delete original session: %v", err)
+	}
+	if output, err := exec.Command("tmux", "new-session", "-d", "-s", name, "sleep", "30").CombinedOutput(); err != nil {
+		t.Fatalf("recreate replacement session: %v (%s)", err, strings.TrimSpace(string(output)))
+	}
+
+	called := make(chan struct{}, 1)
+	sess.WatchInitialProcessCompletion(make(chan struct{}), func(int, string) { called <- struct{}{} })
+	if err := os.WriteFile(ackPath, []byte("exit:7\nSTALE\n"), 0o600); err != nil {
+		t.Fatalf("write stale completion marker: %v", err)
+	}
+
+	select {
+	case <-called:
+		t.Fatal("stale watcher callback ran for the replacement session")
+	case <-time.After(250 * time.Millisecond):
 	}
 }

--- a/internal/tmux/launch_ack_test.go
+++ b/internal/tmux/launch_ack_test.go
@@ -1,0 +1,32 @@
+package tmux
+
+import "testing"
+
+func TestParseLaunchAckMarker(t *testing.T) {
+	tests := []struct {
+		marker   string
+		wantExit *int
+		wantPID  int
+		wantOK   bool
+	}{
+		{marker: "exit:0", wantExit: intPtr(0), wantOK: true},
+		{marker: "exit:17", wantExit: intPtr(17), wantOK: true},
+		{marker: "pid:42", wantPID: 42, wantOK: true},
+		{marker: "exit:nope", wantOK: false},
+		{marker: "pid:0", wantOK: false},
+		{marker: "started", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.marker, func(t *testing.T) {
+			gotExit, gotPID, gotOK := parseLaunchAckMarker(tt.marker)
+			if gotOK != tt.wantOK || gotPID != tt.wantPID {
+				t.Fatalf("parseLaunchAckMarker(%q) = (%v, %d, %v), want (%v, %d, %v)", tt.marker, gotExit, gotPID, gotOK, tt.wantExit, tt.wantPID, tt.wantOK)
+			}
+			if (gotExit == nil) != (tt.wantExit == nil) || gotExit != nil && *gotExit != *tt.wantExit {
+				t.Fatalf("parseLaunchAckMarker(%q) exit = %v, want %v", tt.marker, gotExit, tt.wantExit)
+			}
+		})
+	}
+}
+
+func intPtr(value int) *int { return &value }

--- a/internal/tmux/launch_ack_test.go
+++ b/internal/tmux/launch_ack_test.go
@@ -215,6 +215,38 @@ func TestCaptureCreatedSessionIdentityRequiresBoundedOwnedProbe(t *testing.T) {
 	}
 }
 
+func TestCaptureCreatedSessionIdentityRetriesTransientEmptyResponse(t *testing.T) {
+	dir := t.TempDir()
+	countPath := filepath.Join(dir, "identity-calls")
+	writeFakeTmux(t, dir, "if [ \"$1\" = \"-u\" ]; then shift; fi\n"+
+		"if [ \"$1\" = \"-L\" ]; then shift 2; fi\n"+
+		"if [ \"$1\" = \"display-message\" ]; then\n"+"  n=0; [ -f "+shellQuote(countPath)+" ] && n=$(cat "+shellQuote(countPath)+")\n"+"  n=$((n + 1)); echo $n > "+shellQuote(countPath)+"\n"+"  if [ $n -eq 1 ]; then exit 0; fi\n"+"  echo '$created'; exit 0\n"+"fi\nexit 1\n")
+
+	identity, err := (&Session{Name: "created"}).captureCreatedSessionIdentity()
+	if err != nil || identity != "$created" {
+		t.Fatalf("captureCreatedSessionIdentity() = %q, %v; want retry result $created", identity, err)
+	}
+}
+
+func TestStartRollsBackCreatedSessionWhenIdentityCaptureFails(t *testing.T) {
+	dir := t.TempDir()
+	killLog := filepath.Join(dir, "kill.log")
+	writeFakeTmux(t, dir, "case \" $* \" in\n"+
+		"  *' has-session '*|*' list-sessions '*) exit 1 ;;\n"+
+		"  *' new-session '*) echo '$created'; exit 0 ;;\n"+
+		"  *' display-message '*) exit 0 ;;\n"+
+		"  *' list-panes '*) exit 0 ;;\n"+"  *' kill-session '*) echo \"$*\" >> "+shellQuote(killLog)+"; exit 0 ;;\n"+"  *) exit 0 ;;\n"+"esac\n")
+
+	sess := NewSession("identity-capture-rollback", t.TempDir())
+	err := sess.Start("")
+	if err == nil {
+		t.Fatal("Start() unexpectedly succeeded without an immutable session identity")
+	}
+	if raw, readErr := os.ReadFile(killLog); readErr != nil || len(strings.TrimSpace(string(raw))) == 0 {
+		t.Fatalf("created session was not rolled back: log=%q readErr=%v", raw, readErr)
+	}
+}
+
 func TestLaunchAckScriptFailsClosedWithoutProcessGroupCapability(t *testing.T) {
 	ackPath := filepath.Join(t.TempDir(), "ack")
 	latePath := filepath.Join(t.TempDir(), "late")

--- a/internal/tmux/launch_ack_test.go
+++ b/internal/tmux/launch_ack_test.go
@@ -1,6 +1,8 @@
 package tmux
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -140,5 +142,119 @@ func TestWatchInitialProcessCompletionIgnoresRecreatedSession(t *testing.T) {
 	case <-called:
 		t.Fatal("stale watcher callback ran for the replacement session")
 	case <-time.After(250 * time.Millisecond):
+	}
+}
+
+func TestWatchInitialProcessCompletionRetriesIndeterminateIdentityProbe(t *testing.T) {
+	dir := t.TempDir()
+	countPath := filepath.Join(dir, "identity-calls")
+	writeFakeTmux(t, dir, "if [ \"$1\" = \"-u\" ]; then shift; fi\n"+
+		"if [ \"$1\" = \"-L\" ]; then shift 2; fi\n"+"if [ \"$1\" = \"display-message\" ]; then\n"+"  n=0; [ -f "+shellQuote(countPath)+" ] && n=$(cat "+shellQuote(countPath)+")\n"+"  n=$((n + 1)); echo $n > "+shellQuote(countPath)+"\n"+"  if [ $n -eq 1 ]; then echo 'server busy' >&2; exit 1; fi\n"+"  echo '$owned'\n"+"  exit 0\n"+"fi\nexit 1\n")
+
+	ackPath := filepath.Join(t.TempDir(), "ack")
+	if err := os.WriteFile(ackPath, []byte("exit:7\nTRANSIENT_PROBE_DIAGNOSTIC\n"), 0o600); err != nil {
+		t.Fatalf("write acknowledgement: %v", err)
+	}
+	sess := &Session{Name: "probe-retry", createdSessionID: "$owned", launchAckPath: ackPath}
+	called := make(chan string, 1)
+	sess.WatchInitialProcessCompletion(make(chan struct{}), func(code int, diagnostic string) {
+		called <- fmt.Sprintf("%d:%s", code, diagnostic)
+	})
+	select {
+	case got := <-called:
+		if got != "7:TRANSIENT_PROBE_DIAGNOSTIC" {
+			t.Fatalf("callback = %q, want completion after retry", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher abandoned marker after an indeterminate identity probe")
+	}
+}
+
+func TestKillIfOwnedPerformsOwnedTeardown(t *testing.T) {
+	dir := t.TempDir()
+	callLog := filepath.Join(dir, "calls")
+	writeFakeTmux(t, dir, "if [ \"$1\" = \"-u\" ]; then shift; fi\n"+"if [ \"$1\" = \"-L\" ]; then shift 2; fi\n"+"echo \"$*\" >> "+shellQuote(callLog)+"\n"+"case \"$1\" in\n"+"display-message) echo '$owned' ;;\n"+"list-panes) echo \"$TEARDOWN_PID\" ;;\n"+"kill-session) ;;\n"+"*) exit 0 ;;\n"+"esac\n")
+	proc := exec.Command("sh", "-c", "sleep 30 & wait")
+	if err := proc.Start(); err != nil {
+		t.Fatalf("start owned process: %v", err)
+	}
+	t.Setenv("TEARDOWN_PID", fmt.Sprint(proc.Process.Pid))
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	logPath := filepath.Join(LogDir(), "owned-teardown.log")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o700); err != nil {
+		t.Fatalf("create log directory: %v", err)
+	}
+	if err := os.WriteFile(logPath, []byte("legacy"), 0o600); err != nil {
+		t.Fatalf("create legacy log: %v", err)
+	}
+
+	sess := &Session{Name: "owned-teardown", createdSessionID: "$owned"}
+	if err := sess.KillIfOwned(); err != nil {
+		t.Fatalf("KillIfOwned: %v", err)
+	}
+	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+		t.Fatalf("legacy log remains, stat error %v", err)
+	}
+	_ = proc.Wait()
+	calls, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatalf("read tmux calls: %v", err)
+	}
+	if !strings.Contains(string(calls), "kill-session -t $owned") {
+		t.Fatalf("teardown did not target immutable session id: %q", calls)
+	}
+}
+
+func TestLaunchAckScriptDoesNotWaitForOutlivingDescendant(t *testing.T) {
+	ackPath := filepath.Join(t.TempDir(), "ack")
+	latePath := filepath.Join(t.TempDir(), "late")
+	command := fmt.Sprintf("(sleep 2; printf LATE > %s) & printf DIRECT; exit 7", shellQuote(latePath))
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "bash", "-c", launchAckScript, "agent-deck-launch-ack", ackPath, command)
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("wrapper returned nil for child exit 7")
+	}
+	if ctx.Err() != nil {
+		t.Fatal("wrapper blocked on a descendant-held output descriptor")
+	}
+	marker, err := os.ReadFile(ackPath)
+	if err != nil {
+		t.Fatalf("read completion marker: %v", err)
+	}
+	if !strings.Contains(string(marker), "exit:7\nDIRECT") {
+		t.Fatalf("marker lost direct-child diagnostics: %q", marker)
+	}
+	time.Sleep(2500 * time.Millisecond)
+	if _, err := os.Stat(latePath); !os.IsNotExist(err) {
+		t.Fatalf("outliving descendant survived wrapper cleanup, stat error %v", err)
+	}
+}
+
+func TestAcknowledgeInitialProcessWaitsForSlowCompletionDrain(t *testing.T) {
+	ackPath := filepath.Join(t.TempDir(), "ack")
+	if err := os.WriteFile(ackPath, []byte("pid:999999\n"), 0o600); err != nil {
+		t.Fatalf("write pid marker: %v", err)
+	}
+	if err := os.WriteFile(ackPath+".output", []byte("initial\n"), 0o600); err != nil {
+		t.Fatalf("write initial diagnostic: %v", err)
+	}
+	go func() {
+		for i := 0; i < 5; i++ {
+			time.Sleep(300 * time.Millisecond)
+			f, err := os.OpenFile(ackPath+".output", os.O_APPEND|os.O_WRONLY, 0o600)
+			if err != nil {
+				return
+			}
+			_, _ = fmt.Fprintf(f, "%s-progress-%d\n", strings.Repeat("L", 64*1024), i)
+			_ = f.Close()
+		}
+		_ = os.WriteFile(ackPath, []byte("exit:7\nSLOW_DIAGNOSTIC_COMPLETE\n"), 0o600)
+	}()
+	sess := &Session{Name: "slow-completion", launchAckPath: ackPath}
+	err := sess.AcknowledgeInitialProcess()
+	if err == nil || !strings.Contains(err.Error(), "SLOW_DIAGNOSTIC_COMPLETE") {
+		t.Fatalf("AcknowledgeInitialProcess = %v, want complete slow diagnostic", err)
 	}
 }

--- a/internal/tmux/launch_ack_test.go
+++ b/internal/tmux/launch_ack_test.go
@@ -228,6 +228,23 @@ func TestCaptureCreatedSessionIdentityRetriesTransientEmptyResponse(t *testing.T
 	}
 }
 
+func TestCaptureCreatedSessionIdentityUsesAuthoritativeCreateOutput(t *testing.T) {
+
+	dir := t.TempDir()
+	writeFakeTmux(t, dir, "if [ \"$1\" = \"-u\" ]; then shift; fi\n"+
+		"if [ \"$1\" = \"-L\" ]; then shift 2; fi\n"+"if [ \"$1\" = \"list-sessions\" ]; then exit 1; fi\n"+"exit 1\n")
+
+	sess := &Session{
+		Name:             "created",
+		creationMarker:   "marker",
+		createdSessionID: "$created",
+	}
+	identity, err := sess.captureCreatedSessionIdentity()
+	if err != nil || identity != "$created" {
+		t.Fatalf("captureCreatedSessionIdentity() = %q, %v; want authoritative create output $created", identity, err)
+	}
+}
+
 func TestCaptureCreatedSessionIdentityRejectsUnmarkedReplacement(t *testing.T) {
 	dir := t.TempDir()
 	writeFakeTmux(t, dir, "if [ \"$1\" = \"-u\" ]; then shift; fi\n"+

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1501,7 +1501,7 @@ func (s *Session) startCommandSpec(workDir, command string) (string, []string) {
 		// We DO NOT use --collect here: --collect unloads the unit once
 		// inactive, which would race with Restart= semantics.
 		svcArgs := []string{
-			"--user", "--unit", unitBase + ".service", "--quiet", "--pipe",
+			"--user", "--unit", unitBase + ".service", "--quiet",
 			"--property=Type=forking",
 			"--property=Restart=on-failure",
 			"--property=RestartSec=5s",
@@ -1518,7 +1518,7 @@ func (s *Session) startCommandSpec(workDir, command string) (string, []string) {
 		// Legacy PR #467 shape — unchanged so existing users opting out
 		// of service mode with launch_as="scope" get identical semantics.
 		scopeArgs := []string{
-			"--user", "--scope", "--quiet", "--pipe", "--collect", "--unit", unitBase, "tmux",
+			"--user", "--scope", "--quiet", "--collect", "--unit", unitBase, "tmux",
 		}
 		scopeArgs = append(scopeArgs, tmuxArgs...)
 		return "systemd-run", scopeArgs
@@ -1595,7 +1595,7 @@ exit "$exit_code"`
 // falling all the way back to direct tmux.
 func buildScopeArgsFromTmuxArgs(sessionName string, tmuxArgs []string) []string {
 	unitBase := serviceUnitBase(sessionName)
-	scopeArgs := []string{"--user", "--scope", "--quiet", "--pipe", "--collect", "--unit", unitBase, "tmux"}
+	scopeArgs := []string{"--user", "--scope", "--quiet", "--collect", "--unit", unitBase, "tmux"}
 	return append(scopeArgs, tmuxArgs...)
 }
 
@@ -3846,18 +3846,27 @@ func (s *Session) sessionIdentityFor(name string) string {
 // step. A live session without this fact cannot be safely owned or cleaned up,
 // so Start refuses to report success rather than arming an unowned watcher.
 func (s *Session) captureCreatedSessionIdentity() (string, error) {
+	if strings.TrimSpace(s.creationMarker) == "" || strings.TrimSpace(s.Name) == "" {
+		return "", fmt.Errorf("tmux session creation marker is unavailable")
+	}
 	deadline := time.Now().Add(2 * time.Second)
 	for {
-		out, err := s.runBoundedOutput("display-message", "-t", s.Name, "-p", "#{session_id}")
+		out, err := s.runBoundedOutput("list-sessions", "-F", "#{session_id}\t#{session_name}\t#{E:"+sessionCreationMarkerEnv+"}")
 		if err == nil {
-			if identity := strings.TrimSpace(string(out)); identity != "" {
+			for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+				parts := strings.SplitN(line, "\t", 3)
+				if len(parts) != 3 || parts[1] != s.Name || parts[2] != s.creationMarker {
+					continue
+				}
+				identity := strings.TrimSpace(parts[0])
+				if identity == "" {
+					continue
+				}
 				if s.createdSessionID != "" && !sessionIdentityMatches(s.createdSessionID, identity) {
 					return "", fmt.Errorf("session identity changed during capture: expected %s, found %s", s.createdSessionID, identity)
 				}
 				return identity, nil
 			}
-		} else if tmuxSessionAbsence(err) {
-			return "", fmt.Errorf("session disappeared before identity capture")
 		}
 		if time.Now().After(deadline) {
 			return "", fmt.Errorf("identity probe remained indeterminate")

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1206,6 +1206,10 @@ type Session struct {
 	// created by the current Start call. Cleanup after acknowledgement must use
 	// this identity, not the mutable human-readable name.
 	createdSessionID string
+	// captureSessionIdentityOnCreate asks tmux new-session to print the
+	// immutable identity at creation time. That identity remains a safe cleanup
+	// target even when the later display-message probe is unavailable.
+	captureSessionIdentityOnCreate bool
 
 	// VimMode guarantees the inner agent's input composer is in insert mode
 	// before any text/Enter is delivered. When the inner tool (Claude Code with
@@ -1435,6 +1439,12 @@ func (s *Session) startCommandSpec(workDir, command string) (string, []string) {
 	cols, rows := InitialWindowSize()
 	tmuxArgs := buildInnerTmuxArgs(s.SocketName, "new-session", "-d", "-s", s.Name, "-c", workDir,
 		"-x", strconv.Itoa(cols), "-y", strconv.Itoa(rows))
+	if s.captureSessionIdentityOnCreate {
+		// -P/-F prints the session identity minted by this exact new-session
+		// command. It is an immutable rollback target if the follow-up probe
+		// cannot read the session yet.
+		tmuxArgs = append(tmuxArgs, "-P", "-F", "#{session_id}")
+	}
 	if startWithInitialProcess {
 		// Deliver the pane command as SEPARATE argv tokens (bash, -c, command)
 		// rather than a single shell-quoted string. This is the crux of the
@@ -2453,6 +2463,7 @@ func (s *Session) Start(command string) error {
 	// Commands containing bash-specific syntax are wrapped for fish compatibility.
 	//
 	// workDir was resolved and validated at the top of Start (#1713).
+	s.captureSessionIdentityOnCreate = true
 	launcher, args := s.startCommandSpec(workDir, command)
 	// newSpawnCommand (not bare execCommand) so the spawn — and any tmux server
 	// it starts — runs from SpawnBaseDir and can never inherit a directory that
@@ -2556,11 +2567,19 @@ func (s *Session) Start(command string) error {
 		return fmt.Errorf("failed to create tmux session: %w (output: %s)", err, string(output))
 	}
 	created = true
-	s.createdSessionID = ""
+	s.createdSessionID = createdSessionIdentityFromOutput(output)
 	createdID, identityErr := s.captureCreatedSessionIdentity()
 	if identityErr != nil {
 		cleanupLaunchAckFiles(s.launchAckPath)
 		s.launchAckPath = ""
+		if s.createdSessionID != "" {
+			if rollbackErr := s.rollbackCreatedSession(s.createdSessionID); rollbackErr != nil {
+				statusLog.Warn("created_session_rollback_failed",
+					slog.String("session", logging.SanitizeValue(s.Name)),
+					slog.String("identity", logging.SanitizeValue(s.createdSessionID)),
+					slog.String("error", rollbackErr.Error()))
+			}
+		}
 		return fmt.Errorf("tmux session created but immutable identity was not captured: %w", identityErr)
 	}
 	s.createdSessionID = createdID
@@ -2749,6 +2768,26 @@ func (s *Session) Start(command string) error {
 	// The Stop hook (via Claude settings) handles instant YELLOW detection.
 
 	return nil
+}
+
+func createdSessionIdentityFromOutput(output []byte) string {
+	for _, line := range strings.Split(string(output), "\n") {
+		identity := strings.TrimSpace(line)
+		if strings.HasPrefix(identity, "$") && strings.TrimSpace(strings.TrimPrefix(identity, "$")) != "" {
+			return identity
+		}
+	}
+	return ""
+}
+
+// rollbackCreatedSession addresses the session by the immutable identity
+// returned by the creating new-session command. A name-based kill here would
+// be able to delete a replacement session after a delete-and-recreate race.
+func (s *Session) rollbackCreatedSession(identity string) error {
+	if s == nil || strings.TrimSpace(identity) == "" {
+		return fmt.Errorf("tmux session ownership is unproven")
+	}
+	return s.teardown(identity, true, true)
 }
 
 // AcknowledgeInitialProcess proves the initial command did not die before the
@@ -3780,11 +3819,15 @@ func (s *Session) sessionIdentityFor(name string) string {
 func (s *Session) captureCreatedSessionIdentity() (string, error) {
 	deadline := time.Now().Add(2 * time.Second)
 	for {
-		probe := s.probeSessionIdentity(s.Name)
-		if probe.state == sessionIdentityOwned {
-			return probe.identity, nil
-		}
-		if probe.state == sessionIdentityMissing {
+		out, err := s.runBoundedOutput("display-message", "-t", s.Name, "-p", "#{session_id}")
+		if err == nil {
+			if identity := strings.TrimSpace(string(out)); identity != "" {
+				if s.createdSessionID != "" && !sessionIdentityMatches(s.createdSessionID, identity) {
+					return "", fmt.Errorf("session identity changed during capture: expected %s, found %s", s.createdSessionID, identity)
+				}
+				return identity, nil
+			}
+		} else if tmuxSessionAbsence(err) {
 			return "", fmt.Errorf("session disappeared before identity capture")
 		}
 		if time.Now().After(deadline) {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1509,8 +1509,15 @@ func (s *Session) startCommandSpec(workDir, command string) (string, []string) {
 			"--property=StartLimitIntervalSec=60",
 			"--property=KillMode=control-group",
 			"--property=TimeoutStopSec=15s",
-			"tmux",
 		}
+		// A user service is started by the user manager, not by this
+		// process, so it does not inherit the caller's dynamic environment.
+		// Carry the socket base explicitly or the service creates its tmux
+		// server on the default socket and the creator cannot prove ownership.
+		if tmuxTmp := os.Getenv("TMUX_TMPDIR"); tmuxTmp != "" {
+			svcArgs = append(svcArgs, "--setenv=TMUX_TMPDIR="+tmuxTmp)
+		}
+		svcArgs = append(svcArgs, "tmux")
 		svcArgs = append(svcArgs, tmuxArgs...)
 		return "systemd-run", svcArgs
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -3866,28 +3866,34 @@ func (s *Session) captureCreatedSessionIdentity() (string, error) {
 		if err == nil {
 			for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 				parts := strings.SplitN(line, "\t", 3)
-				if len(parts) != 3 || parts[1] != s.Name || parts[2] != s.creationMarker {
+				if len(parts) != 3 || parts[1] != s.Name {
 					continue
 				}
 				identity := strings.TrimSpace(parts[0])
 				if identity == "" {
 					continue
 				}
+				if parts[2] != s.creationMarker {
+					return "", fmt.Errorf("session identity changed during capture: expected marker %s, found %s", s.creationMarker, parts[2])
+				}
 				if s.createdSessionID != "" && !sessionIdentityMatches(s.createdSessionID, identity) {
 					return "", fmt.Errorf("session identity changed during capture: expected %s, found %s", s.createdSessionID, identity)
 				}
 				return identity, nil
 			}
+		} else if identity := strings.TrimSpace(s.createdSessionID); identity != "" {
+			// The creating new-session command's -P/-F output is authoritative. A
+			// launcher may suppress the later marker listing (for example when a
+			// systemd service owns a separate tmux environment), but the immutable
+			// ID printed by the command that created this session remains a safe
+			// cleanup target when that follow-up probe is unavailable.
+			return identity, nil
 		}
 		if time.Now().After(deadline) {
 			return "", fmt.Errorf("identity probe remained indeterminate")
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-}
-
-func (s *Session) sessionIdentityIs(want string) bool {
-	return sessionIdentityMatches(want, s.sessionIdentity())
 }
 
 // getPaneProcessTree returns the pane's direct PID and all descendant PIDs.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1202,6 +1202,10 @@ type Session struct {
 	// wrapper. It lets Start distinguish a pane that is still usable from an
 	// initial command that exited while tmux setup was still running.
 	launchAckPath string
+	// createdSessionID is the tmux server's immutable identity for the session
+	// created by the current Start call. Cleanup after acknowledgement must use
+	// this identity, not the mutable human-readable name.
+	createdSessionID string
 
 	// VimMode guarantees the inner agent's input composer is in insert mode
 	// before any text/Enter is delivered. When the inner tool (Claude Code with
@@ -1507,17 +1511,33 @@ func (s *Session) startCommandSpec(workDir, command string) (string, []string) {
 
 const launchAckScript = `ack_path="$1"
 command="$2"
-bash -c "$command" > >(tee "${ack_path}.output") 2>&1 &
+output_path="${ack_path}.output"
+fifo_path="${ack_path}.fifo"
+marker_tmp="${ack_path}.tmp"
+cleanup() {
+  rm -f "$output_path" "$fifo_path" "$marker_tmp"
+}
+trap cleanup EXIT
+rm -f "$output_path" "$fifo_path" "$marker_tmp"
+if ! mkfifo "$fifo_path"; then
+  exit 125
+fi
+tee "$output_path" < "$fifo_path" &
+tee_pid=$!
+bash -c "$command" > "$fifo_path" 2>&1 &
 child_pid=$!
-printf 'pid:%s\n' "$child_pid" > "$ack_path"
+printf 'pid:%s\n' "$child_pid" > "$marker_tmp" && mv -f "$marker_tmp" "$ack_path"
 wait "$child_pid"
 exit_code=$?
-printf 'exit:%s\n' "$exit_code" > "$ack_path"
-if [ -s "${ack_path}.output" ]; then
-  cat "${ack_path}.output" >> "$ack_path"
-fi
-rm -f "${ack_path}.output"
-exit 0`
+wait "$tee_pid"
+{
+  printf 'exit:%s\n' "$exit_code"
+  if [ -s "$output_path" ]; then
+    cat "$output_path"
+  fi
+} > "$marker_tmp"
+mv -f "$marker_tmp" "$ack_path"
+exit "$exit_code"`
 
 // buildScopeArgsFromTmuxArgs reconstructs scope-mode systemd-run argv
 // from the bare tmux args. Used by the three-tier fallback in Start()
@@ -2355,6 +2375,14 @@ func (s *Session) Start(command string) error {
 	workDir = resolvedWorkDir
 
 	s.Command = command
+	ackPathForCleanup := ""
+	created := false
+	defer func() {
+		if !created && ackPathForCleanup != "" {
+			cleanupLaunchAckFiles(ackPathForCleanup)
+			s.launchAckPath = ""
+		}
+	}()
 	// An initial-process command can exit between new-session returning and the
 	// caller observing the pane. Give it a private, explicit exit marker so the
 	// caller can reject that false launch success without guessing by sleeping.
@@ -2368,6 +2396,7 @@ func (s *Session) Start(command string) error {
 			return fmt.Errorf("close launch acknowledgement marker: %w", err)
 		}
 		s.launchAckPath = ackFile.Name()
+		ackPathForCleanup = ackFile.Name()
 	} else {
 		s.launchAckPath = ""
 	}
@@ -2495,6 +2524,8 @@ func (s *Session) Start(command string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create tmux session: %w (output: %s)", err, string(output))
 	}
+	created = true
+	s.createdSessionID = s.sessionIdentity()
 
 	// Register session in cache immediately to prevent race condition
 	// where Exists() returns false because cache was refreshed before session creation
@@ -2508,6 +2539,8 @@ func (s *Session) Start(command string) error {
 	// such a session as started is the exact "looked created, never ran the
 	// agent" failure from the report — tear it down and say why instead.
 	if cwdErr := s.verifyPaneWorkDirUnlessPlaceholder(workDir); cwdErr != nil {
+		cleanupLaunchAckFiles(s.launchAckPath)
+		s.launchAckPath = ""
 		if killErr := s.Kill(); killErr != nil {
 			statusLog.Warn("deleted_cwd_session_cleanup_failed",
 				slog.String("session", logging.SanitizeValue(s.Name)),
@@ -2687,17 +2720,23 @@ func (s *Session) Start(command string) error {
 // enough, even before they paint a prompt.
 func (s *Session) AcknowledgeInitialProcess() error {
 	ackPath := s.launchAckPath
-	s.launchAckPath = ""
 	if ackPath == "" {
 		return nil
 	}
-	defer os.Remove(ackPath)
+	retainAck := false
+	defer func() {
+		if !retainAck {
+			cleanupLaunchAckFiles(ackPath)
+			s.launchAckPath = ""
+		}
+	}()
 
 	// The pane is created asynchronously by tmux. Wait for the wrapper's
 	// protocol event (not a guessed process-settle sleep) before sampling it;
 	// otherwise a just-created pane can be reported live before its initial
 	// command has even been scheduled.
 	deadline := time.Now().Add(250 * time.Millisecond)
+	var completionDeadline time.Time
 	var marker string
 	for {
 		if raw, err := os.ReadFile(ackPath); err == nil {
@@ -2723,21 +2762,38 @@ func (s *Session) AcknowledgeInitialProcess() error {
 			}
 			if exitCode, _, ok := parseLaunchAckMarker(marker); ok && exitCode != nil {
 				if *exitCode != 0 || !s.AllowInitialProcessExit {
-					diagnostic := strings.TrimSpace(strings.TrimPrefix(marker, fmt.Sprintf("exit:%d", *exitCode)))
+					diagnostic := launchAckDiagnostic(marker)
 					if diagnostic != "" {
 						return fmt.Errorf("initial command exited before launch acknowledgement (exit status %d): %s", *exitCode, diagnostic)
 					}
 					return fmt.Errorf("initial command exited before launch acknowledgement (exit status %d)", *exitCode)
 				}
+				retainAck = s.AllowInitialProcessExit
 				return nil
 			}
+			childAlive := false
 			if _, pid, ok := parseLaunchAckMarker(marker); ok && pid > 0 {
 				process, findErr := os.FindProcess(pid)
-				if findErr != nil || process.Signal(syscall.Signal(0)) != nil || processIsZombieOrExiting(pid) {
-					return fmt.Errorf("initial command exited before launch acknowledgement")
+				if findErr == nil && process.Signal(syscall.Signal(0)) == nil && !processIsZombieOrExiting(pid) {
+					childAlive = true
+					// The child is still live; a pid marker is enough to accept a
+					// slow interactive process once the acknowledgement window ends.
 				}
 			}
 			if time.Now().After(deadline) {
+				if !childAlive && completionDeadline.IsZero() {
+					// The child has exited, but the wrapper still owns the
+					// authoritative completion publication while tee drains.
+					completionDeadline = time.Now().Add(time.Second)
+				}
+				if !childAlive && time.Now().Before(completionDeadline) {
+					time.Sleep(time.Millisecond)
+					continue
+				}
+				if !childAlive {
+					return fmt.Errorf("initial command exited before launch acknowledgement")
+				}
+				retainAck = s.AllowInitialProcessExit
 				return nil
 			}
 			time.Sleep(time.Millisecond)
@@ -2753,7 +2809,61 @@ func (s *Session) AcknowledgeInitialProcess() error {
 	if err != nil || strings.TrimSpace(string(out)) != "0" {
 		return fmt.Errorf("initial pane exited before launch acknowledgement")
 	}
+	retainAck = s.AllowInitialProcessExit
 	return nil
+}
+
+// WatchInitialProcessCompletion watches the retained acknowledgement marker
+// for a headless one-shot that survived the initial acknowledgement window.
+// The completion marker is published only after output capture has drained, so
+// the callback receives a complete diagnostic and the watcher can then remove
+// every temporary file. A missing session ends the watcher without invoking
+// the callback; explicit Kill() is not a launch failure.
+func (s *Session) WatchInitialProcessCompletion(callback func(exitCode int, diagnostic string)) {
+	ackPath := s.launchAckPath
+	if ackPath == "" {
+		return
+	}
+	s.launchAckPath = ""
+	go func() {
+		defer cleanupLaunchAckFiles(ackPath)
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			if raw, err := os.ReadFile(ackPath); err == nil {
+				marker := strings.TrimSpace(string(raw))
+				if exitCode, _, ok := parseLaunchAckMarker(marker); ok && exitCode != nil {
+					callback(*exitCode, launchAckDiagnostic(marker))
+					return
+				}
+			}
+			if !s.Exists() {
+				return
+			}
+			<-ticker.C
+		}
+	}()
+}
+
+func cleanupLaunchAckFiles(ackPath string) {
+	if ackPath == "" {
+		return
+	}
+	for _, suffix := range []string{"", ".output", ".tmp", ".fifo"} {
+		_ = os.Remove(ackPath + suffix)
+	}
+}
+
+func launchAckDiagnostic(marker string) string {
+	parts := strings.SplitN(marker, "\n", 2)
+	if len(parts) != 2 {
+		return ""
+	}
+	return strings.TrimSpace(parts[1])
+}
+
+func sessionIdentityMatches(expected, actual string) bool {
+	return strings.TrimSpace(expected) != "" && strings.TrimSpace(expected) == strings.TrimSpace(actual)
 }
 
 // parseLaunchAckMarker is deliberately tiny and pure: the on-disk protocol is
@@ -3440,6 +3550,40 @@ func (s *Session) Kill() error {
 	}
 
 	return err
+}
+
+// KillIfOwned terminates only the tmux session created by the current Start
+// call. It proves the mutable name still resolves to the same immutable tmux
+// session id, then addresses kill-session by that id so a delete-and-recreate
+// race cannot kill the replacement.
+func (s *Session) KillIfOwned() error {
+	if s == nil || strings.TrimSpace(s.createdSessionID) == "" {
+		return fmt.Errorf("tmux session ownership is unproven")
+	}
+	actual := s.sessionIdentity()
+	if actual == "" && !s.Exists() {
+		return nil
+	}
+	if !sessionIdentityMatches(s.createdSessionID, actual) {
+		return fmt.Errorf("tmux session ownership changed: expected %s, found %s", s.createdSessionID, actual)
+	}
+	err := s.runBoundedMutation("kill-session", "-t", s.createdSessionID)
+	if err != nil && !s.sessionIdentityIs(s.createdSessionID) {
+		return nil
+	}
+	return err
+}
+
+func (s *Session) sessionIdentity() string {
+	out, err := s.runBoundedOutput("display-message", "-t", s.Name, "-p", "#{session_id}")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func (s *Session) sessionIdentityIs(want string) bool {
+	return sessionIdentityMatches(want, s.sessionIdentity())
 }
 
 // getPaneProcessTree returns the pane's direct PID and all descendant PIDs.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1196,6 +1196,7 @@ type Session struct {
 	// process instead of sending it via SendKeysAndEnter after session creation.
 	// Sandbox sessions enable this so pane-dead detection can restart exited tools.
 	RunCommandAsInitialProcess bool
+	AllowInitialProcessExit    bool
 
 	// launchAckPath is a per-spawn marker written by the initial-process
 	// wrapper. It lets Start distinguish a pane that is still usable from an
@@ -1506,13 +1507,17 @@ func (s *Session) startCommandSpec(workDir, command string) (string, []string) {
 
 const launchAckScript = `ack_path="$1"
 command="$2"
-bash -c "$command" &
+bash -c "$command" > >(tee "${ack_path}.output") 2>&1 &
 child_pid=$!
 printf 'pid:%s\n' "$child_pid" > "$ack_path"
 wait "$child_pid"
 exit_code=$?
 printf 'exit:%s\n' "$exit_code" > "$ack_path"
-exit "$exit_code"`
+if [ -s "${ack_path}.output" ]; then
+  cat "${ack_path}.output" >> "$ack_path"
+fi
+rm -f "${ack_path}.output"
+exit 0`
 
 // buildScopeArgsFromTmuxArgs reconstructs scope-mode systemd-run argv
 // from the bare tmux args. Used by the three-tier fallback in Start()
@@ -2717,7 +2722,14 @@ func (s *Session) AcknowledgeInitialProcess() error {
 				marker = strings.TrimSpace(string(raw))
 			}
 			if exitCode, _, ok := parseLaunchAckMarker(marker); ok && exitCode != nil {
-				return fmt.Errorf("initial command exited before launch acknowledgement (exit status %d)", *exitCode)
+				if *exitCode != 0 || !s.AllowInitialProcessExit {
+					diagnostic := strings.TrimSpace(strings.TrimPrefix(marker, fmt.Sprintf("exit:%d", *exitCode)))
+					if diagnostic != "" {
+						return fmt.Errorf("initial command exited before launch acknowledgement (exit status %d): %s", *exitCode, diagnostic)
+					}
+					return fmt.Errorf("initial command exited before launch acknowledgement (exit status %d)", *exitCode)
+				}
+				return nil
 			}
 			if _, pid, ok := parseLaunchAckMarker(marker); ok && pid > 0 {
 				process, findErr := os.FindProcess(pid)
@@ -2747,6 +2759,7 @@ func (s *Session) AcknowledgeInitialProcess() error {
 // parseLaunchAckMarker is deliberately tiny and pure: the on-disk protocol is
 // the boundary between the pane wrapper and the creator process.
 func parseLaunchAckMarker(marker string) (exitCode *int, pid int, ok bool) {
+	marker = strings.SplitN(marker, "\n", 2)[0]
 	if strings.HasPrefix(marker, "exit:") {
 		code, err := strconv.Atoi(strings.TrimPrefix(marker, "exit:"))
 		if err != nil {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2424,6 +2424,17 @@ func (s *Session) Start(command string) error {
 	}
 	workDir = resolvedWorkDir
 
+	// A Session may be reused after a prior launch. Clear the previous launch's
+	// ownership handoff before spawning the next one so a suppressed create
+	// response cannot be compared with, or rolled back through, stale state.
+	if s.launchAckPath != "" {
+		cleanupLaunchAckFiles(s.launchAckPath)
+	}
+	s.launchAckPath = ""
+	s.createdSessionID = ""
+	s.creationMarker = ""
+	s.captureSessionIdentityOnCreate = false
+
 	s.Command = command
 	ackPathForCleanup := ""
 	created := false

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -39,6 +39,8 @@ var (
 	perfLog    = logging.ForComponent(logging.CompPerf)
 )
 
+const sessionCreationMarkerEnv = "AGENTDECK_SESSION_CREATION_MARKER"
+
 // execCommand is a swappable seam that defaults to exec.Command. Tests
 // override it to inject failure into specific launcher names without
 // mutating host PATH or systemd state. Production callers always read
@@ -1206,6 +1208,10 @@ type Session struct {
 	// created by the current Start call. Cleanup after acknowledgement must use
 	// this identity, not the mutable human-readable name.
 	createdSessionID string
+	// creationMarker is carried in the session environment from the exact
+	// new-session command. It is the safe ownership handoff when a launcher
+	// suppresses the command's -P/-F stdout before identity capture completes.
+	creationMarker string
 	// captureSessionIdentityOnCreate asks tmux new-session to print the
 	// immutable identity at creation time. That identity remains a safe cleanup
 	// target even when the later display-message probe is unavailable.
@@ -1445,6 +1451,9 @@ func (s *Session) startCommandSpec(workDir, command string) (string, []string) {
 		// cannot read the session yet.
 		tmuxArgs = append(tmuxArgs, "-P", "-F", "#{session_id}")
 	}
+	if s.creationMarker != "" {
+		tmuxArgs = append(tmuxArgs, "-e", sessionCreationMarkerEnv+"="+s.creationMarker)
+	}
 	if startWithInitialProcess {
 		// Deliver the pane command as SEPARATE argv tokens (bash, -c, command)
 		// rather than a single shell-quoted string. This is the crux of the
@@ -1492,7 +1501,7 @@ func (s *Session) startCommandSpec(workDir, command string) (string, []string) {
 		// We DO NOT use --collect here: --collect unloads the unit once
 		// inactive, which would race with Restart= semantics.
 		svcArgs := []string{
-			"--user", "--unit", unitBase + ".service", "--quiet",
+			"--user", "--unit", unitBase + ".service", "--quiet", "--pipe",
 			"--property=Type=forking",
 			"--property=Restart=on-failure",
 			"--property=RestartSec=5s",
@@ -1509,7 +1518,7 @@ func (s *Session) startCommandSpec(workDir, command string) (string, []string) {
 		// Legacy PR #467 shape — unchanged so existing users opting out
 		// of service mode with launch_as="scope" get identical semantics.
 		scopeArgs := []string{
-			"--user", "--scope", "--quiet", "--collect", "--unit", unitBase, "tmux",
+			"--user", "--scope", "--quiet", "--pipe", "--collect", "--unit", unitBase, "tmux",
 		}
 		scopeArgs = append(scopeArgs, tmuxArgs...)
 		return "systemd-run", scopeArgs
@@ -1586,7 +1595,7 @@ exit "$exit_code"`
 // falling all the way back to direct tmux.
 func buildScopeArgsFromTmuxArgs(sessionName string, tmuxArgs []string) []string {
 	unitBase := serviceUnitBase(sessionName)
-	scopeArgs := []string{"--user", "--scope", "--quiet", "--collect", "--unit", unitBase, "tmux"}
+	scopeArgs := []string{"--user", "--scope", "--quiet", "--pipe", "--collect", "--unit", unitBase, "tmux"}
 	return append(scopeArgs, tmuxArgs...)
 }
 
@@ -2463,6 +2472,7 @@ func (s *Session) Start(command string) error {
 	// Commands containing bash-specific syntax are wrapped for fish compatibility.
 	//
 	// workDir was resolved and validated at the top of Start (#1713).
+	s.creationMarker = generateShortID()
 	s.captureSessionIdentityOnCreate = true
 	launcher, args := s.startCommandSpec(workDir, command)
 	// newSpawnCommand (not bare execCommand) so the spawn — and any tmux server
@@ -2572,13 +2582,11 @@ func (s *Session) Start(command string) error {
 	if identityErr != nil {
 		cleanupLaunchAckFiles(s.launchAckPath)
 		s.launchAckPath = ""
-		if s.createdSessionID != "" {
-			if rollbackErr := s.rollbackCreatedSession(s.createdSessionID); rollbackErr != nil {
-				statusLog.Warn("created_session_rollback_failed",
-					slog.String("session", logging.SanitizeValue(s.Name)),
-					slog.String("identity", logging.SanitizeValue(s.createdSessionID)),
-					slog.String("error", rollbackErr.Error()))
-			}
+		if rollbackErr := s.rollbackCreatedSession(s.createdSessionID); rollbackErr != nil {
+			statusLog.Warn("created_session_rollback_failed",
+				slog.String("session", logging.SanitizeValue(s.Name)),
+				slog.String("identity", logging.SanitizeValue(s.createdSessionID)),
+				slog.String("error", rollbackErr.Error()))
 		}
 		return fmt.Errorf("tmux session created but immutable identity was not captured: %w", identityErr)
 	}
@@ -2784,10 +2792,31 @@ func createdSessionIdentityFromOutput(output []byte) string {
 // returned by the creating new-session command. A name-based kill here would
 // be able to delete a replacement session after a delete-and-recreate race.
 func (s *Session) rollbackCreatedSession(identity string) error {
-	if s == nil || strings.TrimSpace(identity) == "" {
+	if s == nil {
 		return fmt.Errorf("tmux session ownership is unproven")
 	}
-	return s.teardown(identity, true, true)
+	if strings.TrimSpace(identity) != "" {
+		return s.teardown(identity, true, true)
+	}
+	if strings.TrimSpace(s.creationMarker) == "" || strings.TrimSpace(s.Name) == "" {
+		return fmt.Errorf("tmux session ownership is unproven")
+	}
+	// Read the immutable ID and the creation marker in one server-side
+	// list-sessions snapshot. Checking the marker first and then killing by name
+	// would leave a delete-and-recreate window in which the replacement could
+	// be killed. The ID from this snapshot remains safe even if the name moves
+	// before teardown runs.
+	listing, err := s.runBoundedOutput("list-sessions", "-F", "#{session_id}\t#{session_name}\t#{E:"+sessionCreationMarkerEnv+"}")
+	if err != nil {
+		return fmt.Errorf("tmux session ownership is indeterminate: %w", err)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(listing)), "\n") {
+		parts := strings.SplitN(line, "\t", 3)
+		if len(parts) == 3 && parts[1] == s.Name && parts[2] == s.creationMarker {
+			return s.teardown(parts[0], true, true)
+		}
+	}
+	return fmt.Errorf("tmux session ownership changed: expected marker %s", s.creationMarker)
 }
 
 // AcknowledgeInitialProcess proves the initial command did not die before the

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1197,6 +1197,11 @@ type Session struct {
 	// Sandbox sessions enable this so pane-dead detection can restart exited tools.
 	RunCommandAsInitialProcess bool
 
+	// launchAckPath is a per-spawn marker written by the initial-process
+	// wrapper. It lets Start distinguish a pane that is still usable from an
+	// initial command that exited while tmux setup was still running.
+	launchAckPath string
+
 	// VimMode guarantees the inner agent's input composer is in insert mode
 	// before any text/Enter is delivered. When the inner tool (Claude Code with
 	// `"editorMode": "vim"`) leaves its prompt in vim NORMAL mode — the default
@@ -1447,7 +1452,15 @@ func (s *Session) startCommandSpec(workDir, command string) (string, []string) {
 		// pass through as the command argument verbatim — bash -c "bash -c '…'"
 		// tail-exec's the inner bash, so no extra lingering process and no
 		// re-escaping of the nested single quotes.
-		tmuxArgs = append(tmuxArgs, bashBinary, "-c", command)
+		if s.launchAckPath != "" {
+			// Keep the acknowledgement protocol out of the command string: both
+			// the marker path and user command are positional arguments, so an
+			// unusual project path or command cannot alter the wrapper script.
+			tmuxArgs = append(tmuxArgs, bashBinary, "-c", launchAckScript,
+				"agent-deck-launch-ack", s.launchAckPath, command)
+		} else {
+			tmuxArgs = append(tmuxArgs, bashBinary, "-c", command)
+		}
 	}
 
 	unitBase := serviceUnitBase(s.Name)
@@ -1490,6 +1503,16 @@ func (s *Session) startCommandSpec(workDir, command string) (string, []string) {
 		return "tmux", tmuxArgs
 	}
 }
+
+const launchAckScript = `ack_path="$1"
+command="$2"
+bash -c "$command" &
+child_pid=$!
+printf 'pid:%s\n' "$child_pid" > "$ack_path"
+wait "$child_pid"
+exit_code=$?
+printf 'exit:%s\n' "$exit_code" > "$ack_path"
+exit "$exit_code"`
 
 // buildScopeArgsFromTmuxArgs reconstructs scope-mode systemd-run argv
 // from the bare tmux args. Used by the three-tier fallback in Start()
@@ -2327,6 +2350,22 @@ func (s *Session) Start(command string) error {
 	workDir = resolvedWorkDir
 
 	s.Command = command
+	// An initial-process command can exit between new-session returning and the
+	// caller observing the pane. Give it a private, explicit exit marker so the
+	// caller can reject that false launch success without guessing by sleeping.
+	if command != "" && s.RunCommandAsInitialProcess {
+		ackFile, err := os.CreateTemp("", "agent-deck-launch-ack-*")
+		if err != nil {
+			return fmt.Errorf("create launch acknowledgement marker: %w", err)
+		}
+		if err := ackFile.Close(); err != nil {
+			_ = os.Remove(ackFile.Name())
+			return fmt.Errorf("close launch acknowledgement marker: %w", err)
+		}
+		s.launchAckPath = ackFile.Name()
+	} else {
+		s.launchAckPath = ""
+	}
 	s.invalidateCache()
 	s.Created = time.Now()
 	s.startupAt = s.Created
@@ -2634,6 +2673,108 @@ func (s *Session) Start(command string) error {
 	// The Stop hook (via Claude settings) handles instant YELLOW detection.
 
 	return nil
+}
+
+// AcknowledgeInitialProcess proves the initial command did not die before the
+// creator finished launching the pane. It is a state snapshot, not a delay:
+// an explicit wrapper exit marker wins; otherwise a live primary pane is the
+// acknowledgement. Slow interactive tools remain valid because a live pane is
+// enough, even before they paint a prompt.
+func (s *Session) AcknowledgeInitialProcess() error {
+	ackPath := s.launchAckPath
+	s.launchAckPath = ""
+	if ackPath == "" {
+		return nil
+	}
+	defer os.Remove(ackPath)
+
+	// The pane is created asynchronously by tmux. Wait for the wrapper's
+	// protocol event (not a guessed process-settle sleep) before sampling it;
+	// otherwise a just-created pane can be reported live before its initial
+	// command has even been scheduled.
+	deadline := time.Now().Add(250 * time.Millisecond)
+	var marker string
+	for {
+		if raw, err := os.ReadFile(ackPath); err == nil {
+			marker = strings.TrimSpace(string(raw))
+			if marker != "" {
+				break
+			}
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if marker != "" {
+		// A pid marker proves the child was forked, not that it survived the
+		// fork-to-exec boundary. Sample its actual process state until it either
+		// records an exit or remains alive through this acknowledgement window.
+		// This is state-driven observation; there is no unconditional launch
+		// sleep, and slow interactive tools need only keep their process alive.
+		for {
+			if raw, err := os.ReadFile(ackPath); err == nil {
+				marker = strings.TrimSpace(string(raw))
+			}
+			if exitCode, _, ok := parseLaunchAckMarker(marker); ok && exitCode != nil {
+				return fmt.Errorf("initial command exited before launch acknowledgement (exit status %d)", *exitCode)
+			}
+			if _, pid, ok := parseLaunchAckMarker(marker); ok && pid > 0 {
+				process, findErr := os.FindProcess(pid)
+				if findErr != nil || process.Signal(syscall.Signal(0)) != nil || processIsZombieOrExiting(pid) {
+					return fmt.Errorf("initial command exited before launch acknowledgement")
+				}
+			}
+			if time.Now().After(deadline) {
+				return nil
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}
+	if marker == "" {
+		return fmt.Errorf("initial command did not acknowledge launch")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), hasSessionProbeTimeout)
+	defer cancel()
+	out, err := s.tmuxCmdContext(ctx, "list-panes", "-t", s.Name+":0.0", "-F", "#{pane_dead}").Output()
+	if err != nil || strings.TrimSpace(string(out)) != "0" {
+		return fmt.Errorf("initial pane exited before launch acknowledgement")
+	}
+	return nil
+}
+
+// parseLaunchAckMarker is deliberately tiny and pure: the on-disk protocol is
+// the boundary between the pane wrapper and the creator process.
+func parseLaunchAckMarker(marker string) (exitCode *int, pid int, ok bool) {
+	if strings.HasPrefix(marker, "exit:") {
+		code, err := strconv.Atoi(strings.TrimPrefix(marker, "exit:"))
+		if err != nil {
+			return nil, 0, false
+		}
+		return &code, 0, true
+	}
+	if strings.HasPrefix(marker, "pid:") {
+		parsedPID, err := strconv.Atoi(strings.TrimPrefix(marker, "pid:"))
+		if err != nil || parsedPID <= 0 {
+			return nil, 0, false
+		}
+		return nil, parsedPID, true
+	}
+	return nil, 0, false
+}
+
+// processIsZombieOrExiting closes the kill(0) blind spot: Unix retains a
+// zombie until its parent reaps it, and signal 0 reports that zombie as alive.
+// The marker's child is owned by the acknowledgement wrapper, so a Z/X state
+// is definitive early-exit evidence rather than a slow-start condition.
+func processIsZombieOrExiting(pid int) bool {
+	out, err := exec.Command("ps", "-o", "state=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return false
+	}
+	state := strings.TrimSpace(string(out))
+	return strings.HasPrefix(state, "Z") || strings.HasPrefix(state, "X")
 }
 
 // hasSessionProbeTimeout bounds a `tmux has-session` existence probe. A tmux

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1524,12 +1524,34 @@ if ! mkfifo "$fifo_path"; then
 fi
 tee "$output_path" < "$fifo_path" &
 tee_pid=$!
-bash -c "$command" > "$fifo_path" 2>&1 &
+# Run the direct command in its own process group when the host provides a
+# session launcher. A background descendant must not keep the FIFO open after
+# the direct child exits; tee still mirrors the complete direct-child stream to
+# the pane and records it for the completion marker.
+if command -v setsid >/dev/null 2>&1; then
+  setsid bash -c "$command" > "$fifo_path" 2>&1 &
+elif command -v perl >/dev/null 2>&1; then
+  perl -MPOSIX -e 'POSIX::setsid() or die "setsid: $!"; exec @ARGV' bash -c "$command" > "$fifo_path" 2>&1 &
+else
+  bash -c "$command" > "$fifo_path" 2>&1 &
+fi
 child_pid=$!
 printf 'pid:%s\n' "$child_pid" > "$marker_tmp" && mv -f "$marker_tmp" "$ack_path"
 wait "$child_pid"
 exit_code=$?
-wait "$tee_pid"
+# The direct child is complete, so reap its process group before draining tee.
+# This closes inherited FIFO descriptors while keeping all bytes already
+# written by the direct child in the output file and pane.
+kill -TERM -- -"$child_pid" 2>/dev/null || true
+drain_deadline=$((SECONDS + 5))
+while kill -0 "$tee_pid" 2>/dev/null; do
+  if [ "$SECONDS" -ge "$drain_deadline" ]; then
+    kill -KILL "$tee_pid" 2>/dev/null || true
+    break
+  fi
+  sleep 0.01
+done
+wait "$tee_pid" 2>/dev/null || true
 {
   printf 'exit:%s\n' "$exit_code"
   if [ -s "$output_path" ]; then
@@ -2736,7 +2758,6 @@ func (s *Session) AcknowledgeInitialProcess() error {
 	// otherwise a just-created pane can be reported live before its initial
 	// command has even been scheduled.
 	deadline := time.Now().Add(250 * time.Millisecond)
-	var completionDeadline time.Time
 	var marker string
 	for {
 		if raw, err := os.ReadFile(ackPath); err == nil {
@@ -2781,17 +2802,8 @@ func (s *Session) AcknowledgeInitialProcess() error {
 				}
 			}
 			if time.Now().After(deadline) {
-				if !childAlive && completionDeadline.IsZero() {
-					// The child has exited, but the wrapper still owns the
-					// authoritative completion publication while tee drains.
-					completionDeadline = time.Now().Add(time.Second)
-				}
-				if !childAlive && time.Now().Before(completionDeadline) {
-					time.Sleep(time.Millisecond)
-					continue
-				}
 				if !childAlive {
-					return fmt.Errorf("initial command exited before launch acknowledgement")
+					return waitForLaunchAckCompletion(ackPath, marker)
 				}
 				retainAck = s.AllowInitialProcessExit
 				return nil
@@ -2811,6 +2823,51 @@ func (s *Session) AcknowledgeInitialProcess() error {
 	}
 	retainAck = s.AllowInitialProcessExit
 	return nil
+}
+
+const (
+	launchAckDrainQuietPeriod = 2 * time.Second
+	launchAckDrainMax         = 30 * time.Second
+)
+
+// waitForLaunchAckCompletion waits for the wrapper's authoritative exit marker
+// after the direct child has already died. The quiet period is extended by
+// observable marker/output progress, while the absolute cap keeps a broken
+// wrapper bounded. This avoids converting a slow filesystem or a large
+// diagnostic into a false early launch failure.
+func waitForLaunchAckCompletion(ackPath, marker string) error {
+	quietDeadline := time.Now().Add(launchAckDrainQuietPeriod)
+	absoluteDeadline := time.Now().Add(launchAckDrainMax)
+	lastProgress := launchAckProgress(ackPath, marker)
+	for {
+		if raw, err := os.ReadFile(ackPath); err == nil {
+			marker = strings.TrimSpace(string(raw))
+			if exitCode, _, ok := parseLaunchAckMarker(marker); ok && exitCode != nil {
+				diagnostic := launchAckDiagnostic(marker)
+				if diagnostic != "" {
+					return fmt.Errorf("initial command exited before launch acknowledgement (exit status %d): %s", *exitCode, diagnostic)
+				}
+				return fmt.Errorf("initial command exited before launch acknowledgement (exit status %d)", *exitCode)
+			}
+		}
+		progress := launchAckProgress(ackPath, marker)
+		if progress != lastProgress {
+			lastProgress = progress
+			quietDeadline = time.Now().Add(launchAckDrainQuietPeriod)
+		}
+		if time.Now().After(quietDeadline) || time.Now().After(absoluteDeadline) {
+			return fmt.Errorf("initial command exited before launch acknowledgement")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func launchAckProgress(ackPath, marker string) string {
+	info, err := os.Stat(ackPath + ".output")
+	if err != nil {
+		return marker
+	}
+	return fmt.Sprintf("%s:%d:%d", marker, info.Size(), info.ModTime().UnixNano())
 }
 
 // WatchInitialProcessCompletion watches the retained acknowledgement marker
@@ -2843,8 +2900,22 @@ func (s *Session) WatchInitialProcessCompletion(cancel <-chan struct{}, callback
 				return
 			default:
 			}
-			if !sessionIdentityMatches(sessionID, s.sessionIdentityFor(sessionName)) {
+			probe := s.probeSessionIdentity(sessionName)
+			switch probe.state {
+			case sessionIdentityMissing:
 				return
+			case sessionIdentityIndeterminate:
+				select {
+				case <-cancel:
+					return
+				case <-ticker.C:
+					continue
+				default:
+				}
+			case sessionIdentityOwned:
+				if !sessionIdentityMatches(sessionID, probe.identity) {
+					return
+				}
 			}
 			if raw, err := os.ReadFile(ackPath); err == nil {
 				marker := strings.TrimSpace(string(raw))
@@ -3528,6 +3599,10 @@ func (s *Session) EnableMouseMode() error {
 // processes actually die. tmux kill-session sends SIGHUP which some CLI
 // tools (e.g. Claude Code 2.1.27+) ignore, leaving orphan processes.
 func (s *Session) Kill() error {
+	return s.teardown(s.Name, false)
+}
+
+func (s *Session) teardown(target string, owned bool) error {
 	// Disconnect control mode pipe
 	if pm := GetPipeManager(); pm != nil {
 		pm.Disconnect(s.Name)
@@ -3538,7 +3613,7 @@ func (s *Session) Kill() error {
 	os.Remove(logFile) // Ignore errors
 
 	// Capture process tree BEFORE killing so we can verify they die
-	_, oldPIDs := s.getPaneProcessTree()
+	_, oldPIDs := s.getPaneProcessTreeFor(target)
 	if len(oldPIDs) > 0 {
 		respawnLog.Info("pre_kill_process_tree", slog.String("session", logging.SanitizeValue(s.Name)), slog.Any("pids", oldPIDs))
 	}
@@ -3547,7 +3622,7 @@ func (s *Session) Kill() error {
 	// SIGKILLed at the deadline yields a non-nil err, which the Exists() re-probe
 	// below resolves: if the server did process the kill, the session is gone and
 	// this returns success anyway.
-	err := s.runBoundedMutation("kill-session", "-t", s.Name)
+	err := s.runBoundedMutation("kill-session", "-t", target)
 
 	// Verify old processes are dead; escalate to SIGKILL if needed. No new
 	// process exists on this path — the session is gone — so nothing is spared.
@@ -3562,8 +3637,14 @@ func (s *Session) Kill() error {
 	// already gone (the post-Unarchive path — Unarchive clears the flag without
 	// restarting tmux). Only surface the error if the session is genuinely
 	// still alive after the kill attempt.
-	if err != nil && !s.Exists() {
-		return nil
+	if err != nil {
+		if owned {
+			if s.probeSessionIdentity(target).state == sessionIdentityMissing {
+				return nil
+			}
+		} else if !s.Exists() {
+			return nil
+		}
 	}
 
 	return err
@@ -3577,18 +3658,55 @@ func (s *Session) KillIfOwned() error {
 	if s == nil || strings.TrimSpace(s.createdSessionID) == "" {
 		return fmt.Errorf("tmux session ownership is unproven")
 	}
-	actual := s.sessionIdentity()
-	if actual == "" && !s.Exists() {
+	probe := s.probeSessionIdentity(s.Name)
+	switch probe.state {
+	case sessionIdentityMissing:
 		return nil
+	case sessionIdentityIndeterminate:
+		return fmt.Errorf("tmux session ownership is indeterminate")
+	case sessionIdentityOwned:
+		if !sessionIdentityMatches(s.createdSessionID, probe.identity) {
+			return fmt.Errorf("tmux session ownership changed: expected %s, found %s", s.createdSessionID, probe.identity)
+		}
+		return s.teardown(s.createdSessionID, true)
 	}
-	if !sessionIdentityMatches(s.createdSessionID, actual) {
-		return fmt.Errorf("tmux session ownership changed: expected %s, found %s", s.createdSessionID, actual)
+	return fmt.Errorf("tmux session ownership is unproven")
+}
+
+type sessionIdentityState uint8
+
+const (
+	sessionIdentityIndeterminate sessionIdentityState = iota
+	sessionIdentityOwned
+	sessionIdentityMissing
+)
+
+type sessionIdentityProbe struct {
+	state    sessionIdentityState
+	identity string
+}
+
+func (s *Session) probeSessionIdentity(name string) sessionIdentityProbe {
+	out, err := s.runBoundedOutput("display-message", "-t", name, "-p", "#{session_id}")
+	actual := strings.TrimSpace(string(out))
+	if actual != "" {
+		return sessionIdentityProbe{state: sessionIdentityOwned, identity: actual}
 	}
-	err := s.runBoundedMutation("kill-session", "-t", s.createdSessionID)
-	if err != nil && !s.sessionIdentityIs(s.createdSessionID) {
-		return nil
+	if err != nil && tmuxSessionAbsence(err) {
+		return sessionIdentityProbe{state: sessionIdentityMissing}
 	}
-	return err
+	return sessionIdentityProbe{state: sessionIdentityIndeterminate}
+}
+
+func tmuxSessionAbsence(err error) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	text := strings.ToLower(strings.TrimSpace(string(exitErr.Stderr)))
+	return strings.Contains(text, "can't find session") ||
+		strings.Contains(text, "no such session") ||
+		strings.Contains(text, "session not found")
 }
 
 func (s *Session) sessionIdentity() string {
@@ -3612,7 +3730,11 @@ func (s *Session) sessionIdentityIs(want string) bool {
 // reported as an empty tree; callers that can act on the difference between
 // "no processes" and "could not tell" must use paneProcessTree instead.
 func (s *Session) getPaneProcessTree() (panePID int, allPIDs []int) {
-	panePID, allPIDs, err := s.paneProcessTree()
+	return s.getPaneProcessTreeFor(s.Name)
+}
+
+func (s *Session) getPaneProcessTreeFor(target string) (panePID int, allPIDs []int) {
+	panePID, allPIDs, err := s.paneProcessTreeFor(target)
 	if err != nil {
 		// A failed probe is indistinguishable from "no panes" to our callers,
 		// and they respond by SKIPPING the SIGTERM->SIGKILL escalation that
@@ -3637,7 +3759,11 @@ func (s *Session) getPaneProcessTree() (panePID int, allPIDs []int) {
 // SIGTERM->SIGKILL the process the user just restarted. See
 // escalateAfterRespawn.
 func (s *Session) paneProcessTree() (panePID int, allPIDs []int, err error) {
-	target := s.Name + ":"
+	return s.paneProcessTreeFor(s.Name)
+}
+
+func (s *Session) paneProcessTreeFor(targetName string) (panePID int, allPIDs []int, err error) {
+	target := targetName + ":"
 	// Bounded — see tmuxPollTimeout. Runs on the respawn path: a hang here
 	// stalls the restart that is supposed to clear the bad state.
 	out, err := s.runBoundedOutput("list-panes", "-t", target, "-F", "#{pane_pid}")

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -3866,28 +3866,18 @@ func (s *Session) captureCreatedSessionIdentity() (string, error) {
 		if err == nil {
 			for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 				parts := strings.SplitN(line, "\t", 3)
-				if len(parts) != 3 || parts[1] != s.Name {
+				if len(parts) != 3 || parts[1] != s.Name || parts[2] != s.creationMarker {
 					continue
 				}
 				identity := strings.TrimSpace(parts[0])
 				if identity == "" {
 					continue
 				}
-				if parts[2] != s.creationMarker {
-					return "", fmt.Errorf("session identity changed during capture: expected marker %s, found %s", s.creationMarker, parts[2])
-				}
 				if s.createdSessionID != "" && !sessionIdentityMatches(s.createdSessionID, identity) {
 					return "", fmt.Errorf("session identity changed during capture: expected %s, found %s", s.createdSessionID, identity)
 				}
 				return identity, nil
 			}
-		} else if identity := strings.TrimSpace(s.createdSessionID); identity != "" {
-			// The creating new-session command's -P/-F output is authoritative. A
-			// launcher may suppress the later marker listing (for example when a
-			// systemd service owns a separate tmux environment), but the immutable
-			// ID printed by the command that created this session remains a safe
-			// cleanup target when that follow-up probe is unavailable.
-			return identity, nil
 		}
 		if time.Now().After(deadline) {
 			return "", fmt.Errorf("identity probe remained indeterminate")

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2541,7 +2541,7 @@ func (s *Session) Start(command string) error {
 	if cwdErr := s.verifyPaneWorkDirUnlessPlaceholder(workDir); cwdErr != nil {
 		cleanupLaunchAckFiles(s.launchAckPath)
 		s.launchAckPath = ""
-		if killErr := s.Kill(); killErr != nil {
+		if killErr := s.KillIfOwned(); killErr != nil {
 			statusLog.Warn("deleted_cwd_session_cleanup_failed",
 				slog.String("session", logging.SanitizeValue(s.Name)),
 				slog.String("error", killErr.Error()))
@@ -2817,19 +2817,35 @@ func (s *Session) AcknowledgeInitialProcess() error {
 // for a headless one-shot that survived the initial acknowledgement window.
 // The completion marker is published only after output capture has drained, so
 // the callback receives a complete diagnostic and the watcher can then remove
-// every temporary file. A missing session ends the watcher without invoking
-// the callback; explicit Kill() is not a launch failure.
-func (s *Session) WatchInitialProcessCompletion(callback func(exitCode int, diagnostic string)) {
+// every temporary file. The watcher captures the tmux name and immutable
+// session identity at launch. A missing, replaced, or superseded session ends
+// the watcher without invoking the callback; explicit Kill() is not a launch
+// failure.
+func (s *Session) WatchInitialProcessCompletion(cancel <-chan struct{}, callback func(exitCode int, diagnostic string)) {
 	ackPath := s.launchAckPath
+	sessionName := s.Name
+	sessionID := s.createdSessionID
 	if ackPath == "" {
 		return
 	}
 	s.launchAckPath = ""
+	if sessionName == "" || sessionID == "" {
+		cleanupLaunchAckFiles(ackPath)
+		return
+	}
 	go func() {
 		defer cleanupLaunchAckFiles(ackPath)
 		ticker := time.NewTicker(10 * time.Millisecond)
 		defer ticker.Stop()
 		for {
+			select {
+			case <-cancel:
+				return
+			default:
+			}
+			if !sessionIdentityMatches(sessionID, s.sessionIdentityFor(sessionName)) {
+				return
+			}
 			if raw, err := os.ReadFile(ackPath); err == nil {
 				marker := strings.TrimSpace(string(raw))
 				if exitCode, _, ok := parseLaunchAckMarker(marker); ok && exitCode != nil {
@@ -2837,10 +2853,11 @@ func (s *Session) WatchInitialProcessCompletion(callback func(exitCode int, diag
 					return
 				}
 			}
-			if !s.Exists() {
+			select {
+			case <-cancel:
 				return
+			case <-ticker.C:
 			}
-			<-ticker.C
 		}
 	}()
 }
@@ -3575,7 +3592,11 @@ func (s *Session) KillIfOwned() error {
 }
 
 func (s *Session) sessionIdentity() string {
-	out, err := s.runBoundedOutput("display-message", "-t", s.Name, "-p", "#{session_id}")
+	return s.sessionIdentityFor(s.Name)
+}
+
+func (s *Session) sessionIdentityFor(name string) string {
+	out, err := s.runBoundedOutput("display-message", "-t", name, "-p", "#{session_id}")
 	if err != nil {
 		return ""
 	}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1519,6 +1519,15 @@ cleanup() {
 }
 trap cleanup EXIT
 rm -f "$output_path" "$fifo_path" "$marker_tmp"
+# A process-group owner is required before starting the direct command. The
+# wrapper cannot safely reap descendants when neither setsid nor the Perl POSIX
+# fallback exists: its own process group also contains tee and this shell, so a
+# guessed negative child PID would leave descendants alive. Fail closed before
+# creating the FIFO or running user code.
+if ! command -v setsid >/dev/null 2>&1 && ! command -v perl >/dev/null 2>&1; then
+  printf 'exit:125\nlaunch acknowledgement requires setsid or perl for process ownership\n' > "$ack_path"
+  exit 125
+fi
 if ! mkfifo "$fifo_path"; then
   exit 125
 fi
@@ -2547,7 +2556,14 @@ func (s *Session) Start(command string) error {
 		return fmt.Errorf("failed to create tmux session: %w (output: %s)", err, string(output))
 	}
 	created = true
-	s.createdSessionID = s.sessionIdentity()
+	s.createdSessionID = ""
+	createdID, identityErr := s.captureCreatedSessionIdentity()
+	if identityErr != nil {
+		cleanupLaunchAckFiles(s.launchAckPath)
+		s.launchAckPath = ""
+		return fmt.Errorf("tmux session created but immutable identity was not captured: %w", identityErr)
+	}
+	s.createdSessionID = createdID
 
 	// Register session in cache immediately to prevent race condition
 	// where Exists() returns false because cache was refreshed before session creation
@@ -3599,10 +3615,10 @@ func (s *Session) EnableMouseMode() error {
 // processes actually die. tmux kill-session sends SIGHUP which some CLI
 // tools (e.g. Claude Code 2.1.27+) ignore, leaving orphan processes.
 func (s *Session) Kill() error {
-	return s.teardown(s.Name, false)
+	return s.teardown(s.Name, false, false)
 }
 
-func (s *Session) teardown(target string, owned bool) error {
+func (s *Session) teardown(target string, owned bool, synchronous bool) error {
 	// Disconnect control mode pipe
 	if pm := GetPipeManager(); pm != nil {
 		pm.Disconnect(s.Name)
@@ -3627,7 +3643,11 @@ func (s *Session) teardown(target string, owned bool) error {
 	// Verify old processes are dead; escalate to SIGKILL if needed. No new
 	// process exists on this path — the session is gone — so nothing is spared.
 	if len(oldPIDs) > 0 {
-		go s.ensureProcessesDead(oldPIDs, nil)
+		if synchronous {
+			EnsurePIDsDead(oldPIDs, 3*time.Second)
+		} else {
+			go s.ensureProcessesDead(oldPIDs, nil)
+		}
 	}
 
 	// Killing a session that no longer exists is success, not failure: tmux
@@ -3655,20 +3675,42 @@ func (s *Session) teardown(target string, owned bool) error {
 // session id, then addresses kill-session by that id so a delete-and-recreate
 // race cannot kill the replacement.
 func (s *Session) KillIfOwned() error {
-	if s == nil || strings.TrimSpace(s.createdSessionID) == "" {
+	if s == nil {
 		return fmt.Errorf("tmux session ownership is unproven")
 	}
-	probe := s.probeSessionIdentity(s.Name)
+	name, identity := s.OwnershipSnapshot()
+	return s.KillIfOwnedSnapshot(name, identity)
+}
+
+// OwnershipSnapshot returns the immutable launch target captured by Start.
+// Callers that retain a launch callback must copy these values before another
+// start can mutate the Session object.
+func (s *Session) OwnershipSnapshot() (name, identity string) {
+	if s == nil {
+		return "", ""
+	}
+	return s.Name, s.createdSessionID
+}
+
+// KillIfOwnedSnapshot is KillIfOwned with an explicitly captured identity.
+// It is used by late callbacks whose Session pointer may be reused for a newer
+// generation. The target name and identity are function arguments, so mutable
+// Session fields cannot redirect cleanup to a replacement session.
+func (s *Session) KillIfOwnedSnapshot(name, identity string) error {
+	if s == nil || strings.TrimSpace(identity) == "" || strings.TrimSpace(name) == "" {
+		return fmt.Errorf("tmux session ownership is unproven")
+	}
+	probe := s.probeSessionIdentity(name)
 	switch probe.state {
 	case sessionIdentityMissing:
 		return nil
 	case sessionIdentityIndeterminate:
 		return fmt.Errorf("tmux session ownership is indeterminate")
 	case sessionIdentityOwned:
-		if !sessionIdentityMatches(s.createdSessionID, probe.identity) {
-			return fmt.Errorf("tmux session ownership changed: expected %s, found %s", s.createdSessionID, probe.identity)
+		if !sessionIdentityMatches(identity, probe.identity) {
+			return fmt.Errorf("tmux session ownership changed: expected %s, found %s", identity, probe.identity)
 		}
-		return s.teardown(s.createdSessionID, true)
+		return s.teardown(identity, true, true)
 	}
 	return fmt.Errorf("tmux session ownership is unproven")
 }
@@ -3692,7 +3734,7 @@ func (s *Session) probeSessionIdentity(name string) sessionIdentityProbe {
 	if actual != "" {
 		return sessionIdentityProbe{state: sessionIdentityOwned, identity: actual}
 	}
-	if err != nil && tmuxSessionAbsence(err) {
+	if (err == nil && actual == "") || (err != nil && tmuxSessionAbsence(err)) {
 		return sessionIdentityProbe{state: sessionIdentityMissing}
 	}
 	return sessionIdentityProbe{state: sessionIdentityIndeterminate}
@@ -3706,7 +3748,10 @@ func tmuxSessionAbsence(err error) bool {
 	text := strings.ToLower(strings.TrimSpace(string(exitErr.Stderr)))
 	return strings.Contains(text, "can't find session") ||
 		strings.Contains(text, "no such session") ||
-		strings.Contains(text, "session not found")
+		strings.Contains(text, "session not found") ||
+		strings.Contains(text, "no server running") ||
+		strings.Contains(text, "server exited unexpectedly") ||
+		strings.Contains(text, "lost server")
 }
 
 func (s *Session) sessionIdentity() string {
@@ -3714,11 +3759,39 @@ func (s *Session) sessionIdentity() string {
 }
 
 func (s *Session) sessionIdentityFor(name string) string {
-	out, err := s.runBoundedOutput("display-message", "-t", name, "-p", "#{session_id}")
-	if err != nil {
-		return ""
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		out, err := s.runBoundedOutput("display-message", "-t", name, "-p", "#{session_id}")
+		if err == nil {
+			if identity := strings.TrimSpace(string(out)); identity != "" {
+				return identity
+			}
+		}
+		if time.Now().After(deadline) {
+			return ""
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
-	return strings.TrimSpace(string(out))
+}
+
+// captureCreatedSessionIdentity is the required, bounded post-create identity
+// step. A live session without this fact cannot be safely owned or cleaned up,
+// so Start refuses to report success rather than arming an unowned watcher.
+func (s *Session) captureCreatedSessionIdentity() (string, error) {
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		probe := s.probeSessionIdentity(s.Name)
+		if probe.state == sessionIdentityOwned {
+			return probe.identity, nil
+		}
+		if probe.state == sessionIdentityMissing {
+			return "", fmt.Errorf("session disappeared before identity capture")
+		}
+		if time.Now().After(deadline) {
+			return "", fmt.Errorf("identity probe remained indeterminate")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 func (s *Session) sessionIdentityIs(want string) bool {

--- a/internal/tmux/tmux_launch_as_test.go
+++ b/internal/tmux/tmux_launch_as_test.go
@@ -65,6 +65,18 @@ func TestStartCommandSpec_LaunchAs_Service_UsesServiceForm(t *testing.T) {
 		"-x", "173", "-y", "41"}, tmuxArgs)
 }
 
+func TestStartCommandSpec_LaunchAs_ServiceCarriesTmuxTmpdir(t *testing.T) {
+	const isolated = "/tmp/agent-deck-service-tmux"
+	t.Setenv("TMUX_TMPDIR", isolated)
+
+	s := &Session{Name: "service-env", WorkDir: "/tmp/project", LaunchAs: "service"}
+	launcher, args := s.startCommandSpec("/tmp/project", "")
+
+	require.Equal(t, "systemd-run", launcher)
+	assert.Contains(t, args, "--setenv=TMUX_TMPDIR="+isolated,
+		"service-mode tmux must receive the caller's isolated socket base")
+}
+
 func TestStartCommandSpec_CarriesCreationIdentityThroughLaunchers(t *testing.T) {
 	for _, launchAs := range []string{"direct", "scope", "service"} {
 		t.Run(launchAs+" captures created identity", func(t *testing.T) {

--- a/internal/tmux/tmux_launch_as_test.go
+++ b/internal/tmux/tmux_launch_as_test.go
@@ -14,6 +14,10 @@
 package tmux
 
 import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -63,24 +67,116 @@ func TestStartCommandSpec_LaunchAs_Service_UsesServiceForm(t *testing.T) {
 
 func TestStartCommandSpec_CarriesCreationIdentityThroughLaunchers(t *testing.T) {
 	for _, launchAs := range []string{"direct", "scope", "service"} {
-		t.Run(launchAs, func(t *testing.T) {
-			s := &Session{
-				Name:                           "agentdeck_test-identity_1234abcd",
-				WorkDir:                        "/tmp/project",
-				LaunchAs:                       launchAs,
-				captureSessionIdentityOnCreate: true,
+		t.Run(launchAs+" captures created identity", func(t *testing.T) {
+			calls, session := startWithFakeLauncher(t, launchAs, false)
+			require.NoError(t, session.Start(""), "fake launcher calls: %s", calls())
+			assert.Equal(t, "$created", session.createdSessionID)
+			wantLauncher := "tmux"
+			if launchAs != "direct" {
+				wantLauncher = "systemd-run"
 			}
-			launcher, args := s.startCommandSpec("/tmp/project", "")
-			if launchAs == "direct" {
-				assert.Equal(t, "tmux", launcher)
-			} else {
-				assert.Equal(t, "systemd-run", launcher)
-				assert.NotContains(t, args, "--pipe", "long-lived launches must not wait on daemon lifetime")
-				assert.Contains(t, args, "-P", "tmux must emit immutable creation identity")
-				assert.Contains(t, args, "-F", "tmux must emit immutable creation identity")
-			}
+			assert.Contains(t, calls(), wantLauncher+" ")
+		})
+
+		t.Run(launchAs+" rejects replacement during capture", func(t *testing.T) {
+			calls, session := startWithFakeLauncher(t, launchAs, true)
+			require.Error(t, session.Start(""))
+			assert.Equal(t, "$created", session.createdSessionID)
+			assert.Contains(t, calls(), "KILLED -u kill-session -t $created")
+			assert.NotContains(t, calls(), "KILLED -u kill-session -t $replacement")
 		})
 	}
+}
+
+func startWithFakeLauncher(t *testing.T, launchAs string, replacement bool) (func() string, *Session) {
+	t.Helper()
+	dir := t.TempDir()
+	callLog := filepath.Join(dir, "calls")
+	fake := filepath.Join(dir, "launcher")
+	script := `#!/bin/sh
+case "$0" in
+*/tmux) mode="tmux" ;;
+*) mode="$1"; shift ;;
+esac
+printf '%s %s\n' "$mode" "$*" >> "$FAKE_LAUNCH_CALLS"
+name=""
+marker=""
+workdir="/"
+previous=""
+for arg in "$@"; do
+  if [ "$previous" = "-s" ]; then name="$arg"; fi
+  if [ "$previous" = "-e" ]; then marker="${arg#*=}"; fi
+  if [ "$previous" = "-c" ]; then workdir="$arg"; fi
+  previous="$arg"
+done
+is_new=0
+is_list=0
+is_display=0
+is_pane_path=0
+is_has=0
+is_kill=0
+for arg in "$@"; do
+  [ "$arg" = "new-session" ] && is_new=1
+  [ "$arg" = "list-sessions" ] && is_list=1
+  [ "$arg" = "display-message" ] && is_display=1
+	[ "$arg" = "#{pane_current_path}" ] && is_pane_path=1
+  [ "$arg" = "has-session" ] && is_has=1
+  [ "$arg" = "kill-session" ] && is_kill=1
+done
+if [ "$is_new" = "1" ]; then
+    printf '%s\t%s\t%s\n' "$name" "$marker" "$workdir" > "$FAKE_LAUNCH_STATE"
+    printf '$created\n'
+    exit 0 ;
+fi
+if [ "$is_list" = "1" ]; then
+    IFS='	' read -r name marker workdir < "$FAKE_LAUNCH_STATE"
+    if [ "$FAKE_LAUNCH_REPLACEMENT" = "1" ]; then printf '$replacement\t%s\tnew-marker\n' "$name"; else printf '$created\t%s\t%s\n' "$name" "$marker"; fi
+    exit 0 ;
+fi
+if [ "$is_display" = "1" ]; then
+    if [ "$is_pane_path" = "1" ]; then IFS='	' read -r name marker workdir < "$FAKE_LAUNCH_STATE"; printf '%s\n' "$workdir"; else if [ "$FAKE_LAUNCH_REPLACEMENT" = "1" ]; then printf '$replacement\n'; else printf '$created\n'; fi; fi
+    exit 0 ;
+fi
+[ "$is_has" = "1" ] && exit 1
+[ "$is_kill" = "1" ] && printf 'KILLED %s\n' "$*" >> "$FAKE_LAUNCH_CALLS"
+exit 0
+`
+	if err := os.WriteFile(fake, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(fake, filepath.Join(dir, "tmux")); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("FAKE_LAUNCH_CALLS", callLog)
+	t.Setenv("FAKE_LAUNCH_STATE", filepath.Join(dir, "state"))
+	if replacement {
+		t.Setenv("FAKE_LAUNCH_REPLACEMENT", "1")
+	} else {
+		t.Setenv("FAKE_LAUNCH_REPLACEMENT", "0")
+	}
+	original := execCommand
+	originalContext := execCommandContext
+	execCommand = func(name string, arg ...string) *exec.Cmd {
+		return exec.Command(fake, append([]string{name}, arg...)...)
+	}
+	execCommandContext = func(ctx context.Context, name string, arg ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, fake, append([]string{name}, arg...)...)
+	}
+	t.Cleanup(func() {
+		execCommand = original
+		execCommandContext = originalContext
+	})
+
+	session := NewSession("launcher-behavior", t.TempDir())
+	session.LaunchAs = launchAs
+	return func() string {
+		raw, err := os.ReadFile(callLog)
+		if err != nil {
+			t.Fatalf("read fake launcher calls: %v", err)
+		}
+		return string(raw)
+	}, session
 }
 
 // TestStartCommandSpec_LaunchAs_Scope_UsesScopeForm explicitly pins the

--- a/internal/tmux/tmux_launch_as_test.go
+++ b/internal/tmux/tmux_launch_as_test.go
@@ -61,6 +61,26 @@ func TestStartCommandSpec_LaunchAs_Service_UsesServiceForm(t *testing.T) {
 		"-x", "173", "-y", "41"}, tmuxArgs)
 }
 
+func TestStartCommandSpec_CarriesCreationIdentityThroughLaunchers(t *testing.T) {
+	for _, launchAs := range []string{"direct", "scope", "service"} {
+		t.Run(launchAs, func(t *testing.T) {
+			s := &Session{
+				Name:                           "agentdeck_test-identity_1234abcd",
+				WorkDir:                        "/tmp/project",
+				LaunchAs:                       launchAs,
+				captureSessionIdentityOnCreate: true,
+			}
+			launcher, args := s.startCommandSpec("/tmp/project", "")
+			if launchAs == "direct" {
+				assert.Equal(t, "tmux", launcher)
+			} else {
+				assert.Equal(t, "systemd-run", launcher)
+				assert.Contains(t, args, "--pipe", "systemd-run must forward tmux's immutable creation identity")
+			}
+		})
+	}
+}
+
 // TestStartCommandSpec_LaunchAs_Scope_UsesScopeForm explicitly pins the
 // SCOPE-MODE argv (legacy PR #467 shape) so a refactor to service mode
 // can't silently break users who set LaunchAs="scope" to keep the old
@@ -75,9 +95,10 @@ func TestStartCommandSpec_LaunchAs_Scope_UsesScopeForm(t *testing.T) {
 	launcher, args := s.startCommandSpec("/tmp/project", "")
 	require.Equal(t, "systemd-run", launcher)
 	require.GreaterOrEqual(t, len(args), 8)
-	assert.Equal(t, []string{"--user", "--scope", "--quiet", "--collect", "--unit"}, args[:5])
-	assert.Equal(t, "agentdeck-tmux-agentdeck-test-scope-1234abcd", args[5])
-	assert.Equal(t, "tmux", args[6])
+	assert.Equal(t, []string{"--user", "--scope", "--quiet", "--pipe", "--collect"}, args[:5])
+	assert.Equal(t, "--unit", args[5])
+	assert.Equal(t, "agentdeck-tmux-agentdeck-test-scope-1234abcd", args[6])
+	assert.Equal(t, "tmux", args[7])
 
 	joined := strings.Join(args, " ")
 	assert.NotContains(t, joined, "--property=Type=forking",

--- a/internal/tmux/tmux_launch_as_test.go
+++ b/internal/tmux/tmux_launch_as_test.go
@@ -75,7 +75,9 @@ func TestStartCommandSpec_CarriesCreationIdentityThroughLaunchers(t *testing.T) 
 				assert.Equal(t, "tmux", launcher)
 			} else {
 				assert.Equal(t, "systemd-run", launcher)
-				assert.Contains(t, args, "--pipe", "systemd-run must forward tmux's immutable creation identity")
+				assert.NotContains(t, args, "--pipe", "long-lived launches must not wait on daemon lifetime")
+				assert.Contains(t, args, "-P", "tmux must emit immutable creation identity")
+				assert.Contains(t, args, "-F", "tmux must emit immutable creation identity")
 			}
 		})
 	}
@@ -94,17 +96,18 @@ func TestStartCommandSpec_LaunchAs_Scope_UsesScopeForm(t *testing.T) {
 
 	launcher, args := s.startCommandSpec("/tmp/project", "")
 	require.Equal(t, "systemd-run", launcher)
-	require.GreaterOrEqual(t, len(args), 8)
-	assert.Equal(t, []string{"--user", "--scope", "--quiet", "--pipe", "--collect"}, args[:5])
-	assert.Equal(t, "--unit", args[5])
-	assert.Equal(t, "agentdeck-tmux-agentdeck-test-scope-1234abcd", args[6])
-	assert.Equal(t, "tmux", args[7])
+	require.GreaterOrEqual(t, len(args), 7)
+	assert.Equal(t, []string{"--user", "--scope", "--quiet", "--collect"}, args[:4])
+	assert.Equal(t, "--unit", args[4])
+	assert.Equal(t, "agentdeck-tmux-agentdeck-test-scope-1234abcd", args[5])
+	assert.Equal(t, "tmux", args[6])
 
 	joined := strings.Join(args, " ")
 	assert.NotContains(t, joined, "--property=Type=forking",
 		"scope mode must not contain service-only properties")
 	assert.NotContains(t, joined, "--property=Restart=",
 		"Restart= is invalid on scopes (systemd rejects)")
+	assert.NotContains(t, joined, "--pipe")
 }
 
 // TestStartCommandSpec_LaunchAs_Direct_UsesDirectTmux pins that an

--- a/internal/tmux/tmux_launch_as_test.go
+++ b/internal/tmux/tmux_launch_as_test.go
@@ -79,19 +79,71 @@ func TestStartCommandSpec_CarriesCreationIdentityThroughLaunchers(t *testing.T) 
 		})
 
 		t.Run(launchAs+" rejects replacement during capture", func(t *testing.T) {
-			calls, session := startWithFakeLauncher(t, launchAs, true)
+			calls, state, session := startWithFakeLauncherOptions(t, launchAs, true, false)
 			require.Error(t, session.Start(""))
 			assert.Equal(t, "$created", session.createdSessionID)
 			assert.Contains(t, calls(), "KILLED -u kill-session -t $created")
 			assert.NotContains(t, calls(), "KILLED -u kill-session -t $replacement")
+			assert.True(t, fakeSessionAlive(state(), "$replacement", session.Name),
+				"same-name replacement must survive failed identity capture")
 		})
 	}
 }
 
+func TestStart_RepeatedStartWithMarkerCaptureDoesNotReusePriorOwnership(t *testing.T) {
+	calls, state, session := startWithFakeLauncherOptions(t, "direct", false, true)
+	require.NoError(t, session.Start(""), "first fake launcher calls: %s", calls())
+	oldName := session.Name
+	oldID := session.createdSessionID
+	spawn := execCommand
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		if name == "tmux" && containsArg(args, "new-session") && session.createdSessionID != "" {
+			t.Errorf("new Start spawn retained prior createdSessionID %q", session.createdSessionID)
+		}
+		return spawn(name, args...)
+	}
+	t.Cleanup(func() { execCommand = spawn })
+
+	require.NoError(t, session.Start(""), "second fake launcher calls: %s", calls())
+	if session.Name == oldName {
+		t.Fatalf("repeated Start must regenerate the existing session name")
+	}
+	assert.Equal(t, "$new", session.createdSessionID)
+	assert.Contains(t, state(), "$created\t"+oldName+"\t", "the prior session must survive the second Start")
+	assert.Contains(t, state(), "$new\t"+session.Name+"\t", "the new marker-owned session must survive capture")
+	assert.NotContains(t, calls(), "KILLED -u kill-session -t "+oldID,
+		"stale ownership must not roll back the prior session")
+}
+
+func containsArg(args []string, want string) bool {
+	for _, arg := range args {
+		if arg == want {
+			return true
+		}
+	}
+	return false
+}
+
+func fakeSessionAlive(state, wantID, wantName string) bool {
+	for _, line := range strings.Split(strings.TrimSpace(state), "\n") {
+		fields := strings.Split(line, "\t")
+		if len(fields) == 6 && fields[0] == wantID && fields[1] == wantName && fields[4] == "1" && fields[5] == "1" {
+			return true
+		}
+	}
+	return false
+}
+
 func startWithFakeLauncher(t *testing.T, launchAs string, replacement bool) (func() string, *Session) {
+	calls, _, session := startWithFakeLauncherOptions(t, launchAs, replacement, false)
+	return calls, session
+}
+
+func startWithFakeLauncherOptions(t *testing.T, launchAs string, replacement, repeated bool) (func() string, func() string, *Session) {
 	t.Helper()
 	dir := t.TempDir()
 	callLog := filepath.Join(dir, "calls")
+	stateLog := filepath.Join(dir, "state")
 	fake := filepath.Join(dir, "launcher")
 	script := `#!/bin/sh
 case "$0" in
@@ -124,21 +176,88 @@ for arg in "$@"; do
   [ "$arg" = "kill-session" ] && is_kill=1
 done
 if [ "$is_new" = "1" ]; then
-    printf '%s\t%s\t%s\n' "$name" "$marker" "$workdir" > "$FAKE_LAUNCH_STATE"
-    printf '$created\n'
+  expected="$FAKE_LAUNCH_EXPECTED_MODE"
+  if [ "$expected" = "tmux" ] && [ "$mode" != "tmux" ]; then
+    printf 'wrong launcher: expected direct tmux, got %s\n' "$mode" >&2
+    exit 97
+  fi
+  if [ "$expected" = "scope" ]; then
+    [ "$mode" = "systemd-run" ] || { printf 'wrong launcher: expected systemd scope, got %s\n' "$mode" >&2; exit 97; }
+    printf '%s\n' "$*" | grep -q -- '--scope' || { printf 'wrong launcher: expected scope form\n' >&2; exit 97; }
+    printf '%s\n' "$*" | grep -q -- '\.service' && { printf 'wrong launcher: scope received service form\n' >&2; exit 97; }
+  fi
+  if [ "$expected" = "service" ]; then
+    [ "$mode" = "systemd-run" ] || { printf 'wrong launcher: expected systemd service, got %s\n' "$mode" >&2; exit 97; }
+    printf '%s\n' "$*" | grep -q -- '\.service' || { printf 'wrong launcher: expected service form\n' >&2; exit 97; }
+    printf '%s\n' "$*" | grep -q -- '--scope' && { printf 'wrong launcher: service received scope form\n' >&2; exit 97; }
+  fi
+fi
+if [ "$is_new" = "1" ]; then
+    count=0
+    [ -f "$FAKE_LAUNCH_COUNT" ] && count=$(cat "$FAKE_LAUNCH_COUNT")
+    count=$((count + 1))
+    printf '%s\n' "$count" > "$FAKE_LAUNCH_COUNT"
+    id='$created'
+    output='$created'
+    if [ "$count" -gt 1 ] && [ "$FAKE_LAUNCH_REPEATED" = "1" ]; then
+      id='$new'
+      output=''
+    fi
+	if [ "$FAKE_LAUNCH_REPLACEMENT" = "1" ]; then
+	      printf '%s\t%s\t%s\t%s\t1\t0\n' '$created' "$name" "$marker" "$workdir" >> "$FAKE_LAUNCH_STATE"
+	      printf '%s\t%s\t%s\t%s\t1\t1\n' '$replacement' "$name" 'new-marker' "$workdir" >> "$FAKE_LAUNCH_STATE"
+	    else
+	      printf '%s\t%s\t%s\t%s\t1\t1\n' "$id" "$name" "$marker" "$workdir" >> "$FAKE_LAUNCH_STATE"
+    fi
+    printf '%s\n' "$output"
     exit 0 ;
 fi
 if [ "$is_list" = "1" ]; then
-    IFS='	' read -r name marker workdir < "$FAKE_LAUNCH_STATE"
-    if [ "$FAKE_LAUNCH_REPLACEMENT" = "1" ]; then printf '$replacement\t%s\tnew-marker\n' "$name"; else printf '$created\t%s\t%s\n' "$name" "$marker"; fi
+	    while IFS='	' read -r id name marker workdir alive visible; do
+	      [ "$alive" = "1" ] && [ "$visible" = "1" ] && printf '%s\t%s\t%s\n' "$id" "$name" "$marker"
+    done < "$FAKE_LAUNCH_STATE"
     exit 0 ;
 fi
 if [ "$is_display" = "1" ]; then
-    if [ "$is_pane_path" = "1" ]; then IFS='	' read -r name marker workdir < "$FAKE_LAUNCH_STATE"; printf '%s\n' "$workdir"; else if [ "$FAKE_LAUNCH_REPLACEMENT" = "1" ]; then printf '$replacement\n'; else printf '$created\n'; fi; fi
+    target=""
+    previous=""
+    for arg in "$@"; do
+      [ "$previous" = "-t" ] && target="$arg"
+      previous="$arg"
+    done
+    found=0
+	    while IFS='	' read -r id name marker workdir alive visible; do
+      [ "$alive" = "1" ] || continue
+      if [ "$target" = "$name" ] || [ "$target" = "$id" ]; then
+        found=1
+        if [ "$is_pane_path" = "1" ]; then printf '%s\n' "$workdir"; else printf '%s\n' "$id"; fi
+        break
+      fi
+    done < "$FAKE_LAUNCH_STATE"
+    [ "$found" = "1" ] || { printf "can't find session\n" >&2; exit 1; }
     exit 0 ;
 fi
-[ "$is_has" = "1" ] && exit 1
-[ "$is_kill" = "1" ] && printf 'KILLED %s\n' "$*" >> "$FAKE_LAUNCH_CALLS"
+if [ "$is_has" = "1" ]; then
+    target=""
+    previous=""
+    for arg in "$@"; do [ "$previous" = "-t" ] && target="$arg"; previous="$arg"; done
+	    while IFS='	' read -r id name marker workdir alive visible; do
+	      [ "$alive" = "1" ] && [ "$visible" = "1" ] && [ "$target" = "$name" ] && exit 0
+    done < "$FAKE_LAUNCH_STATE"
+    exit 1
+fi
+if [ "$is_kill" = "1" ]; then
+    target=""
+    previous=""
+    for arg in "$@"; do [ "$previous" = "-t" ] && target="$arg"; previous="$arg"; done
+    tmp="$FAKE_LAUNCH_STATE.tmp"
+	    while IFS='	' read -r id name marker workdir alive visible; do
+	      if [ "$target" = "$id" ] || [ "$target" = "$name" ]; then alive=0; fi
+	      printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$id" "$name" "$marker" "$workdir" "$alive" "$visible" >> "$tmp"
+    done < "$FAKE_LAUNCH_STATE"
+    mv "$tmp" "$FAKE_LAUNCH_STATE"
+    printf 'KILLED %s\n' "$*" >> "$FAKE_LAUNCH_CALLS"
+fi
 exit 0
 `
 	if err := os.WriteFile(fake, []byte(script), 0o700); err != nil {
@@ -149,11 +268,22 @@ exit 0
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("FAKE_LAUNCH_CALLS", callLog)
-	t.Setenv("FAKE_LAUNCH_STATE", filepath.Join(dir, "state"))
+	t.Setenv("FAKE_LAUNCH_STATE", stateLog)
+	t.Setenv("FAKE_LAUNCH_COUNT", filepath.Join(dir, "count"))
+	expectedMode := launchAs
+	if expectedMode == "direct" {
+		expectedMode = "tmux"
+	}
+	t.Setenv("FAKE_LAUNCH_EXPECTED_MODE", expectedMode)
 	if replacement {
 		t.Setenv("FAKE_LAUNCH_REPLACEMENT", "1")
 	} else {
 		t.Setenv("FAKE_LAUNCH_REPLACEMENT", "0")
+	}
+	if repeated {
+		t.Setenv("FAKE_LAUNCH_REPEATED", "1")
+	} else {
+		t.Setenv("FAKE_LAUNCH_REPEATED", "0")
 	}
 	original := execCommand
 	originalContext := execCommandContext
@@ -171,12 +301,18 @@ exit 0
 	session := NewSession("launcher-behavior", t.TempDir())
 	session.LaunchAs = launchAs
 	return func() string {
-		raw, err := os.ReadFile(callLog)
-		if err != nil {
-			t.Fatalf("read fake launcher calls: %v", err)
-		}
-		return string(raw)
-	}, session
+			raw, err := os.ReadFile(callLog)
+			if err != nil {
+				t.Fatalf("read fake launcher calls: %v", err)
+			}
+			return string(raw)
+		}, func() string {
+			raw, err := os.ReadFile(stateLog)
+			if err != nil {
+				t.Fatalf("read fake launcher state: %v", err)
+			}
+			return string(raw)
+		}, session
 }
 
 // TestStartCommandSpec_LaunchAs_Scope_UsesScopeForm explicitly pins the

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -3096,12 +3096,12 @@ func TestStartCommandSpec_UserScope(t *testing.T) {
 
 	launcher, args := s.startCommandSpec("/tmp/project", "")
 	require.Equal(t, "systemd-run", launcher)
-	require.GreaterOrEqual(t, len(args), 8)
-	assert.Equal(t, []string{"--user", "--scope", "--quiet", "--pipe", "--collect"}, args[:5])
-	assert.Equal(t, "--unit", args[5])
-	assert.Equal(t, "agentdeck-tmux-agentdeck-test-session-1234abcd", args[6])
+	require.GreaterOrEqual(t, len(args), 7)
+	assert.Equal(t, []string{"--user", "--scope", "--quiet", "--collect"}, args[:4])
+	assert.Equal(t, "--unit", args[4])
+	assert.Equal(t, "agentdeck-tmux-agentdeck-test-session-1234abcd", args[5])
 	assert.Equal(t, []string{"tmux", "-u", "new-session", "-d", "-s", "agentdeck_test-session_1234abcd", "-c", "/tmp/project",
-		"-x", "173", "-y", "41"}, args[7:])
+		"-x", "173", "-y", "41"}, args[6:])
 }
 
 // TestStartCommandSpec_InitialProcess_WrapsBashRegardlessOfContent is the

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -3097,10 +3097,11 @@ func TestStartCommandSpec_UserScope(t *testing.T) {
 	launcher, args := s.startCommandSpec("/tmp/project", "")
 	require.Equal(t, "systemd-run", launcher)
 	require.GreaterOrEqual(t, len(args), 8)
-	assert.Equal(t, []string{"--user", "--scope", "--quiet", "--collect", "--unit"}, args[:5])
-	assert.Equal(t, "agentdeck-tmux-agentdeck-test-session-1234abcd", args[5])
+	assert.Equal(t, []string{"--user", "--scope", "--quiet", "--pipe", "--collect"}, args[:5])
+	assert.Equal(t, "--unit", args[5])
+	assert.Equal(t, "agentdeck-tmux-agentdeck-test-session-1234abcd", args[6])
 	assert.Equal(t, []string{"tmux", "-u", "new-session", "-d", "-s", "agentdeck_test-session_1234abcd", "-c", "/tmp/project",
-		"-x", "173", "-y", "41"}, args[6:])
+		"-x", "173", "-y", "41"}, args[7:])
 }
 
 // TestStartCommandSpec_InitialProcess_WrapsBashRegardlessOfContent is the

--- a/internal/ui/issue1830_tui_resume_by_id_test.go
+++ b/internal/ui/issue1830_tui_resume_by_id_test.go
@@ -1,6 +1,9 @@
 package ui
 
 import (
+	"os"
+	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
@@ -23,6 +26,15 @@ import (
 // resume chokepoint.
 func TestIssue1830_TUICreateResumeByIDVouchesOwnership(t *testing.T) {
 	const wantID = "a1a1a1a1-2222-4333-8444-555555555555"
+	home := setXDGTestHome(t)
+	claude := filepath.Join(home, "bin", "claude")
+	if err := os.MkdirAll(filepath.Dir(claude), 0o755); err != nil {
+		t.Fatalf("mkdir Claude fixture: %v", err)
+	}
+	if err := os.WriteFile(claude, []byte("#!/bin/sh\nsleep 30\n"), 0o755); err != nil {
+		t.Fatalf("write Claude fixture: %v", err)
+	}
+	writeXDGTestConfig(t, home, "[claude]\ncommand = "+strconv.Quote(claude)+"\n")
 
 	opts := session.NewClaudeOptions(nil)
 	opts.SessionMode = "resume"


### PR DESCRIPTION
Fixes #1793.

- Recover once through the existing attribution gate when Codex visibly holds this send but did not transition active.
- Add a deterministic regression for the swallowed-Enter path.
- Documented the separate JSONL-completion/error report as unproven; it is not changed.

Verification:
- `AGENT_DECK_TEST_TMP_BASE=/private/tmp/agent-deck-tests go test ./cmd/agent-deck -run "TestIssue1793|TestIssue1855|TestSendWithRetryTarget|TestExecuteSend" -count=1`
- `AGENT_DECK_TEST_TMP_BASE=/private/tmp/agent-deck-tests go test ./internal/send -count=1`
- `AGENT_DECK_TEST_TMP_BASE=/private/tmp/agent-deck-tests go test ./internal/session -run "TestCodexCompletion|TestDebounceFlipFromRunning" -count=1`

`scripts/run-tests.sh` is absent from this checkout. The unscoped full command package suite is blocked by its ambient automatic-parent lookup, not a test assertion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex prompt delivery verification, including recovery when Enter is not registered.
  * Prevented unrelated, stale, delayed, or empty drafts from being treated as submitted.
  * Improved reliability and cleanup for short-lived, bounded, and failed session launches.
  * Preserved launch and restart failure details in status reporting.
  * Improved safety when sessions are recreated during startup or cleanup.

* **User Experience**
  * The `add --json` response clearly reports that registration does not start the session.
  * Improved recognition of Codex prompts while ignoring empty prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->