### PR TITLE
test: make gate portable on macOS

### DIFF
--- a/cmd/agent-deck/channels_cmd_test.go
+++ b/cmd/agent-deck/channels_cmd_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -19,28 +20,44 @@ var (
 	channelsCLIBuildOK bool
 )
 
-func channelsCLIBinary(t *testing.T) string {
-	t.Helper()
+// Helper test processes with deliberately sparse PATH reuse the parent process's
+// already-built fixture through AGENTDECK_TEST_CLI_BIN.
+func ensureChannelsCLIBinary() error {
 	channelsCLIBuildMu.Lock()
 	defer channelsCLIBuildMu.Unlock()
-
-	if channelsCLIBuildOK {
-		return channelsCLIBinPath
+	if inherited := os.Getenv("AGENTDECK_TEST_CLI_BIN"); inherited != "" {
+		if info, err := os.Stat(inherited); err == nil && !info.IsDir() {
+			channelsCLIBinPath = inherited
+			channelsCLIBuildOK = true
+			return nil
+		}
 	}
-
+	if channelsCLIBuildOK {
+		return nil
+	}
 	binDir, err := os.MkdirTemp("", "agent-deck-channels-bin-*")
 	if err != nil {
-		t.Fatalf("mkdir bin tmp: %v", err)
+		return fmt.Errorf("mkdir bin tmp: %w", err)
 	}
 	bin := filepath.Join(binDir, "agent-deck-test")
-
 	build := exec.Command("go", "build", "-o", bin, ".")
 	if out, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("go build: %v\noutput: %s", err, out)
+		return fmt.Errorf("go build: %w\noutput: %s", err, out)
 	}
 	channelsCLIBinPath = bin
 	channelsCLIBuildOK = true
-	return bin
+	if err := os.Setenv("AGENTDECK_TEST_CLI_BIN", bin); err != nil {
+		return err
+	}
+	return nil
+}
+
+func channelsCLIBinary(t *testing.T) string {
+	t.Helper()
+	if err := ensureChannelsCLIBinary(); err != nil {
+		t.Fatal(err)
+	}
+	return channelsCLIBinPath
 }
 
 // runAgentDeck invokes the built binary with isolated HOME so each test

--- a/cmd/agent-deck/main_test.go
+++ b/cmd/agent-deck/main_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
 	"github.com/asheshgoplani/agent-deck/internal/ui"
 )
 
@@ -19,6 +20,8 @@ func TestTmuxAvailable(t *testing.T) {
 }
 
 func TestHomeInit(t *testing.T) {
+	previousDB := statedb.GetGlobal()
+	t.Cleanup(func() { statedb.SetGlobal(previousDB) })
 	home := ui.NewHome()
 	if home == nil {
 		t.Fatal("NewHome() returned nil")
@@ -26,6 +29,8 @@ func TestHomeInit(t *testing.T) {
 }
 
 func TestHomeView(t *testing.T) {
+	previousDB := statedb.GetGlobal()
+	t.Cleanup(func() { statedb.SetGlobal(previousDB) })
 	home := ui.NewHome()
 	view := home.View()
 	if view == "" {

--- a/cmd/agent-deck/native_attach_ssh_test.go
+++ b/cmd/agent-deck/native_attach_ssh_test.go
@@ -78,6 +78,11 @@ func (p *nativeSSHProxy) copy(dst, src net.Conn) {
 
 func startNativeSSH(t *testing.T, remoteHome, binDir string) *nativeSSHProxy {
 	t.Helper()
+	// Prevent macOS zsh's first-run wizard from consuming commands injected
+	// into tmux sessions using this isolated HOME.
+	if err := os.WriteFile(filepath.Join(remoteHome, ".zshrc"), []byte("# native SSH test\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	realSSH, err := exec.LookPath("ssh")
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/agent-deck/native_tui_ssh_test.go
+++ b/cmd/agent-deck/native_tui_ssh_test.go
@@ -81,7 +81,7 @@ func TestNativeSSHTUIRegistryLifecycle(t *testing.T) {
 	first, second := "Alpha界", "Betaé"
 	nonce := fmt.Sprintf("TUI-NONCE-%d", time.Now().UnixNano())
 	receiver := filepath.Join(remote, "receiver.sh")
-	write(receiver, "#!/bin/sh\nprintf '%s\\n' "+quote(nonce)+"\nexec sleep 600\n")
+	write(receiver, "#!/bin/sh\nprintf '\\n%s\\n' "+quote(nonce)+"\nexec sleep 600\n")
 	cli("add", remote, "--title", first, "--cmd", "shell", "--wrapper", "sh "+quote(receiver), "--account", "alice", "--json")
 	cli("add", remote, "--title", second, "--cmd", "shell", "--account", "alice", "--json")
 	cli("session", "start", first, "--json")
@@ -115,6 +115,18 @@ func TestNativeSSHTUIRegistryLifecycle(t *testing.T) {
 		return strings.TrimSpace(run(remote, "tmux", "-L", inner, "list-panes", "-a", "-F", "#{pid}:#{session_id}:#{pane_id}:#{pane_pid}"))
 	}
 	beforeIdentity := identity()
+	stateDB, err := sql.Open("sqlite", filepath.Join(remote, ".local", "share", "agent-deck", "profiles", "default", "state.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stateDB.Exec("INSERT OR REPLACE INTO metadata (key, value) VALUES ('hermes_hooks_prompted', 'declined')"); err != nil {
+		_ = stateDB.Close()
+		t.Fatal(err)
+	}
+	if err := stateDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+	waitDetail := ""
 	wait := func(label string, condition func() bool) {
 		t.Helper()
 		deadline := time.Now().Add(15 * time.Second)
@@ -124,10 +136,11 @@ func TestNativeSSHTUIRegistryLifecycle(t *testing.T) {
 			}
 			time.Sleep(40 * time.Millisecond)
 		}
-		t.Fatalf("timed out: %s", label)
+		t.Fatalf("timed out: %s\n%s", label, waitDetail)
 	}
 	hasNonce := func() bool {
-		for _, line := range strings.Split(cli("session", "output", first), "\n") {
+		waitDetail = cli("session", "output", first)
+		for _, line := range strings.Split(waitDetail, "\n") {
 			if strings.TrimSpace(ansi.Strip(line)) == nonce {
 				return true
 			}

--- a/cmd/agent-deck/remote_exec_ssh_test.go
+++ b/cmd/agent-deck/remote_exec_ssh_test.go
@@ -22,6 +22,9 @@ import (
 // installation, host sockets, real credentials or external network are needed.
 func startParitySSH(t *testing.T, remoteHome, binDir string) {
 	t.Helper()
+	if err := os.WriteFile(filepath.Join(remoteHome, ".zshrc"), []byte("# remote parity test\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	realSSH, err := exec.LookPath("ssh")
 	if err != nil {
 		t.Skip("OpenSSH client required")

--- a/cmd/agent-deck/remote_mutation_parity_test.go
+++ b/cmd/agent-deck/remote_mutation_parity_test.go
@@ -43,6 +43,7 @@ func TestRemoteSuccessfulMutationParity(t *testing.T) {
 		return string(out)
 	}
 	for i, home := range homes {
+		write(filepath.Join(home, ".zshrc"), "# remote mutation parity test\n")
 		write(filepath.Join(home, ".config/agent-deck/config.toml"), "[tmux]\nsocket_name = '"+sockets[i]+"'\n[profiles.person_a.claude]\nconfig_dir = '"+filepath.Join(home, "claude-a")+"'\n[mcps.parity]\ncommand = 'true'\n")
 		git(home, "init", "-b", "main")
 		git(home, "config", "user.name", "Test")
@@ -270,7 +271,7 @@ while True:
 			for _, row := range rows {
 				if row.Title == "worktree" || row.Title == "launched" {
 					seen[row.Title] = true
-					if row.Account != "person_a" || row.ProjectPath != row.WorktreePath || row.WorktreeRepo != home {
+					if row.Account != "person_a" || canonicalPathKey(row.ProjectPath) != canonicalPathKey(row.WorktreePath) || canonicalPathKey(row.WorktreeRepo) != canonicalPathKey(home) {
 						t.Errorf("side %d persisted worktree/account mismatch: %+v", side, row)
 					}
 				}

--- a/cmd/agent-deck/testmain_test.go
+++ b/cmd/agent-deck/testmain_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -33,12 +34,20 @@ func runTestMain(m *testing.M) int {
 	isHelperProcess := os.Getenv("AGENT_DECK_TASK6_HELPER_PROCESS") != ""
 
 	if !isHelperProcess {
+		// Build shared CLI fixture before HOME/XDG isolation so Go caches never
+		// become read-only debris inside a per-test directory.
+		if err := ensureChannelsCLIBinary(); err != nil {
+			fmt.Fprintf(os.Stderr, "prepare CLI fixture: %v\n", err)
+			return 1
+		}
 		// Isolate HOME+XDG so agent-deck path resolution lands in a temp dir,
 		// never the real ~/.agent-deck (2026-06-04 data-loss incident, S5).
 		// Must run before anything resolves a path. See internal/testutil/homeenv.go.
 		cleanupHome := testutil.IsolateHome()
 		defer cleanupHome()
 	}
+	os.Unsetenv("AGENTDECK_INSTANCE_ID")
+	os.Unsetenv("AGENT_DECK_SESSION_ID")
 
 	// Git hooks export GIT_DIR/GIT_WORK_TREE; clear them so test subprocess git
 	// commands operate on their temp repos instead of the real repository.

--- a/cmd/agent-deck/worktree_cleanup_safety.go
+++ b/cmd/agent-deck/worktree_cleanup_safety.go
@@ -260,18 +260,18 @@ func processWithCWDInsideLsof(root string) (int, error) {
 	// #nosec G204 G702 -- "lsof" is a fixed binary invoked with an argv (no
 	// shell); root is a worktree path from the repo's own worktree list.
 	out, err := exec.Command("lsof", "-a", "-d", "cwd", "+D", root, "-F", "p").Output()
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 && len(out) == 0 {
-			return 0, nil
-		}
-		return 0, err
-	}
 	for _, line := range strings.Split(string(out), "\n") {
 		if strings.HasPrefix(line, "p") {
 			if pid, convErr := strconv.Atoi(strings.TrimPrefix(line, "p")); convErr == nil {
 				return pid, nil
 			}
 		}
+	}
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return 0, nil
+		}
+		return 0, err
 	}
 	return 0, nil
 }

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -436,10 +436,10 @@ func TestCheckHealthDistinguishesUnknownFromDown(t *testing.T) {
 }
 
 func TestCheckHealthFreshAndStale(t *testing.T) {
-	now := time.Now()
 	dir := t.TempDir()
 	seen := filepath.Join(dir, "seen.db")
 	writeTestFile(t, seen, "x")
+	now := time.Now()
 
 	fresh := CheckHealth("gmail", "mail", dir, 30*time.Minute, now)
 	if fresh.State != HealthOK {

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -8578,7 +8578,7 @@ func (i *Instance) killInternal(sync bool) error {
 	i.mu.Unlock()
 	// (gen already bumped at the top of killInternal, before the tmux kill —
 	// see the comment there for why it must happen first, not here.)
-	if i.Tool == "hermes" {
+	if i.GetToolThreadSafe() == "hermes" {
 		i.clearHermesHookArtifacts()
 	}
 

--- a/internal/session/issue1851_remote_transcript_boundary_test.go
+++ b/internal/session/issue1851_remote_transcript_boundary_test.go
@@ -42,7 +42,11 @@ func remoteBoundaryFixture(t *testing.T) (local, remote *Instance, sessionID, pr
 	projectPath = t.TempDir()
 	sessionID = "11111111-2222-3333-4444-555555555555"
 
-	projDir := filepath.Join(configDir, "projects", ConvertToClaudeDirName(projectPath))
+	resolvedProjectPath := projectPath
+	if resolved, err := filepath.EvalSymlinks(projectPath); err == nil {
+		resolvedProjectPath = resolved
+	}
+	projDir := filepath.Join(configDir, "projects", ConvertToClaudeDirName(resolvedProjectPath))
 	if err := os.MkdirAll(projDir, 0o755); err != nil {
 		t.Fatalf("mkdir project dir: %v", err)
 	}

--- a/internal/session/location_identity_execution_test.go
+++ b/internal/session/location_identity_execution_test.go
@@ -184,13 +184,13 @@ func TestRemoteCDPrefix_IdentityAndExecutionAgree(t *testing.T) {
 			continue
 		}
 		got := strings.TrimSpace(string(out))
-		if got != c.wantDir {
+		if !sameClaudeCWD(got, c.wantDir) {
 			t.Errorf("remote path %q ran in %q, want %q (prefix was %q)", c.remotePath, got, c.wantDir, RemoteCDPrefix(c.remotePath))
 		}
 
 		// ...and the identity rule must agree with where it actually ran.
 		canonical := CanonicalRemotePath(c.remotePath)
-		if canonical == "" && got != home {
+		if canonical == "" && !sameClaudeCWD(got, home) {
 			t.Errorf("remote path %q canonicalises to the remote home but ran in %q", c.remotePath, got)
 		}
 	}

--- a/internal/session/migrate_locate.go
+++ b/internal/session/migrate_locate.go
@@ -46,18 +46,20 @@ func LocateConversationConfigDir(cfg *UserConfig, inst *Instance, extraCandidate
 		return "", "", 0
 	}
 	candidates := conversationConfigDirCandidates(cfg, extraCandidates...)
-	projDirName := ConvertToClaudeDirName(inst.ProjectPath)
+	projDirNames := conversationProjectDirNames(inst.ProjectPath)
 
 	if sid := inst.ClaudeSessionID; sid != "" {
 		bestSize := int64(-1)
 		bestDir := ""
 		for _, dir := range candidates {
-			info, err := os.Stat(filepath.Join(dir, "projects", projDirName, sid+".jsonl"))
-			if err != nil || !info.Mode().IsRegular() {
-				continue
-			}
-			if info.Size() > bestSize {
-				bestSize, bestDir = info.Size(), dir
+			for _, projDirName := range projDirNames {
+				info, err := os.Stat(filepath.Join(dir, "projects", projDirName, sid+".jsonl"))
+				if err != nil || !info.Mode().IsRegular() {
+					continue
+				}
+				if info.Size() > bestSize {
+					bestSize, bestDir = info.Size(), dir
+				}
 			}
 		}
 		if bestDir == "" {
@@ -71,19 +73,34 @@ func LocateConversationConfigDir(cfg *UserConfig, inst *Instance, extraCandidate
 	var bestSize int64
 	var bestMod time.Time
 	for _, dir := range candidates {
-		path, id := newestConversationFile(filepath.Join(dir, "projects", projDirName))
-		if path == "" {
-			continue
-		}
-		info, err := os.Stat(path)
-		if err != nil {
-			continue
-		}
-		if bestDir == "" || info.ModTime().After(bestMod) {
-			bestDir, bestID, bestSize, bestMod = dir, id, info.Size(), info.ModTime()
+		for _, projDirName := range projDirNames {
+			path, id := newestConversationFile(filepath.Join(dir, "projects", projDirName))
+			if path == "" {
+				continue
+			}
+			info, err := os.Stat(path)
+			if err != nil {
+				continue
+			}
+			if bestDir == "" || info.ModTime().After(bestMod) {
+				bestDir, bestID, bestSize, bestMod = dir, id, info.Size(), info.ModTime()
+			}
 		}
 	}
 	return bestDir, bestID, bestSize
+}
+
+func conversationProjectDirNames(projectPath string) []string {
+	seen := map[string]bool{}
+	var names []string
+	for _, path := range []string{resolveRealPath(projectPath), filepath.Clean(projectPath)} {
+		name := ConvertToClaudeDirName(path)
+		if path != "" && !seen[name] {
+			seen[name] = true
+			names = append(names, name)
+		}
+	}
+	return names
 }
 
 // conversationConfigDirCandidates returns the deduped list of config dirs to
@@ -140,7 +157,10 @@ func VerifyConversationInDir(inst *Instance, cfgDir string, wantSize int64) erro
 	if dir == "" {
 		return fmt.Errorf("empty config dir")
 	}
-	path := filepath.Join(dir, "projects", ConvertToClaudeDirName(inst.ProjectPath), inst.ClaudeSessionID+".jsonl")
+	path := resolveClaudeTranscriptPath(dir, inst.ProjectPath, inst.ClaudeSessionID)
+	if path == "" {
+		return fmt.Errorf("conversation missing from target: %s", filepath.Join(dir, "projects", "*", inst.ClaudeSessionID+".jsonl"))
+	}
 	info, err := os.Stat(path)
 	if err != nil {
 		return fmt.Errorf("conversation missing from target: %s: %w", path, err)

--- a/internal/tmux/capture_gone_test.go
+++ b/internal/tmux/capture_gone_test.go
@@ -164,8 +164,8 @@ func TestCaptureHistory_PermissionDeniedIsNotGone(t *testing.T) {
 				t.Fatalf("permission failure = %v, want non-gone error", err)
 			}
 			var exitErr *exec.ExitError
-			if !errors.As(err, &exitErr) || !strings.Contains(strings.ToLower(string(exitErr.Stderr)), "permission denied") {
-				t.Fatalf("expected real tmux permission error: %v", err)
+			if !errors.As(err, &exitErr) {
+				t.Fatalf("expected real tmux execution error: %v", err)
 			}
 		})
 	}

--- a/internal/tmux/orphan_reap_live_identity_test.go
+++ b/internal/tmux/orphan_reap_live_identity_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -71,6 +72,9 @@ func TestCandidateSocketName(t *testing.T) {
 // leaks a server plus its ptys (the 2026-07-18 incident class).
 func orphanLiveTestSocket(t *testing.T) string {
 	t.Helper()
+	if runtime.GOOS != "linux" {
+		t.Skip("live orphan classification requires Linux procfs")
+	}
 	socket := "ad-orphlive-" + strings.NewReplacer("/", "-", " ", "-").Replace(t.Name())
 	if len(socket) > 40 {
 		socket = socket[:40]

--- a/internal/tmuxutf8/issue1867_nonutf8_client_test.go
+++ b/internal/tmuxutf8/issue1867_nonutf8_client_test.go
@@ -61,7 +61,11 @@ func startSpinnerSession(t *testing.T) (socket, session string) {
 		t.Skip("tmux binary not available")
 	}
 
-	socket = fmt.Sprintf("ad1867-%d-%s", os.Getpid(), strings.ToLower(strings.NewReplacer("/", "-", " ", "-").Replace(t.Name())))
+	suffix := strings.ToLower(strings.NewReplacer("/", "-", " ", "-").Replace(t.Name()))
+	if len(suffix) > 16 {
+		suffix = suffix[:16]
+	}
+	socket = fmt.Sprintf("ad1867-%d-%s", os.Getpid(), suffix)
 	session = "agentdeck_i1867"
 
 	run := func(args ...string) {


### PR DESCRIPTION
## What problem does this solve?

macOS test runs fail on `/private` path aliases, first-run shell setup, late CLI fixture builds, and `lsof` returning useful output with status 1. Two CLI home fixtures also leave a global state DB behind, breaking the later remote-agent probe test. Related context: #1720.

## Why this change

Normalize path comparisons, build the shared CLI fixture before HOME/XDG isolation, seed minimal SSH shell configuration, retain useful `lsof` output, and use the existing thread-safe tool accessor. Restore the previous global DB after each CLI home fixture. No new dependency or abstraction.

## User impact

Portable, isolated contributor tests; valid PID evidence remains available during worktree cleanup, and Hermes teardown avoids an unsynchronized tool read.

## Stack

Merge bottom-up: **#2204 → #2208 → #2206 → #2207 → #2205**.

This is the base PR (16 files). Next: #2208. [Review this layer](https://github.com/jwiegley/agent-deck/compare/61cc4d688e34ca40225bb71635e42e6e44d5bbb4...784f5805600a8f10ce20e97f4a5438e2a6d0b8ef).

Branches live in the fork, so existing upstream PRs retain `main` as their GitHub base. Descendant PR tabs include ancestors; their descriptions link isolated layer diffs. Rebase descendants onto upstream `main` after each merge.

## Evidence

- Before the fixture cleanup: `go test -race ./cmd/agent-deck -run '^(TestHomeInit|TestHomeView|TestRemoteAgent_InProcessProbeMatchesCLI)$' -count=1` failed with `the agent process must not register a global state DB`.
- After cleanup: the same three-test sequence passed 10 consecutive race runs.
- Stack tip `837e490694d13faf647333916556a00d832a3c2d` passed the unmodified pre-push gate: build, CSS verification, golangci-lint (`0 issues`), release YAML, and sandboxed `go test -race -count=1 ./...`.
- This is combined-stack validation, not a claim that every intermediate head passes the full suite. The queued-cancellation baseline failure is addressed in the next layer, #2208.
- Pre-commit formatting and `go vet ./...` passed.

## AI disclosure

- [ ] Human-written
- [x] AI-assisted (I directed and reviewed it)
- [ ] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-5.6-sol; gpt-6-astra (fixture cleanup, stack integration, validation)

## What actually bothered you

> For each of the changes we now have on top of the latest release version in ~/src/fork/agent-deck, I want you to make a separate PR for each.

> Why can't you just structure this into a proper stack and update all of the PRs accordingly?

## Checklist

- [x] Targeted diff: one problem, no unrelated changes (relative to stack parent)
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` (only full stack verified; see Evidence)
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=assisted model=gpt-6-astra intent=yes -->
