### PR TITLE
fix(session): persist restart outcome to owning profile

### DIFF
--- a/cmd/agent-deck/remote_agent_cmd.go
+++ b/cmd/agent-deck/remote_agent_cmd.go
@@ -861,6 +861,10 @@ func (r *remoteAgentRequests) execute(ctx context.Context, f *remoteAgentFlight,
 		return
 	}
 	defer func() { <-r.sem }()
+	if ctx.Err() != nil {
+		f.stderr, f.code = "cancelled while queued", 1
+		return
+	}
 	f.stdout, f.stderr, f.code = r.exec(ctx, args)
 	f.stamp = remoteAgentStampNanos(r.stampPath)
 }

--- a/cmd/agent-deck/remote_agent_harden_test.go
+++ b/cmd/agent-deck/remote_agent_harden_test.go
@@ -347,7 +347,7 @@ func TestRemoteAgent_CancelKillsRequest(t *testing.T) {
 }
 
 // Finding 4: at most MaxConcurrent subprocesses run at once; the rest wait
-// their turn, and a queued request that is cancelled never runs.
+// their turn.
 func TestRemoteAgent_ConcurrencyCap(t *testing.T) {
 	var running, peak atomic.Int32
 	var started atomic.Int32
@@ -369,37 +369,46 @@ func TestRemoteAgent_ConcurrencyCap(t *testing.T) {
 		return strings.Join(args, " "), "", 0
 	}
 	h := startAgent(t, remoteAgentConfig{Run: run, MaxConcurrent: 2})
-	for i := int64(1); i <= 5; i++ {
+	for i := int64(1); i <= 4; i++ {
 		h.send(remoteAgentRequest{ID: i, Args: []string{"rename", "s", strings.Repeat("x", int(i))}})
 	}
 	time.Sleep(50 * time.Millisecond)
 	if got := started.Load(); got != 2 {
 		t.Fatalf("only MaxConcurrent requests may run at once, got %d started", got)
 	}
-	h.send(remoteAgentRequest{ID: 5, Cancel: true})
-	// A successful pipe write only proves the agent reader received the line,
-	// not that its request loop processed it. Wait for a following ping ack,
-	// which is emitted only after the cancel has removed request 5, before
-	// freeing a semaphore slot for the queued requests.
-	h.send(remoteAgentRequest{ID: 6, Ping: true})
-	if r := h.next("cancel barrier"); r.ID != 6 || r.Code != 0 {
-		t.Fatalf("cancel barrier reply = %+v, want successful ping acknowledgement", r)
-	}
 	close(release)
 	ids := map[int64]bool{}
 	for i := 0; i < 4; i++ {
 		ids[h.next("reply").ID] = true
 	}
-	if ids[5] || len(ids) != 4 {
-		t.Fatalf("four queued requests must answer and the cancelled one must not, got %v", ids)
+	if len(ids) != 4 {
+		t.Fatalf("four queued requests must answer, got %v", ids)
 	}
 	if peak.Load() > 2 {
 		t.Fatalf("peak concurrency %d exceeds the cap of 2", peak.Load())
 	}
 	if started.Load() != 4 {
-		t.Fatalf("a request cancelled while queued must never start, got %d starts", started.Load())
+		t.Fatalf("every request must start, got %d starts", started.Load())
 	}
 	h.closeAndWait()
+}
+
+func TestRemoteAgent_QueuedCancellationNeverStarts(t *testing.T) {
+	for attempt := 0; attempt < 100; attempt++ {
+		var started atomic.Int32
+		requests := newRemoteAgentRequests(func(context.Context, []string) (string, string, int) {
+			started.Add(1)
+			return "", "", 0
+		}, 1, "")
+		requests.sem <- struct{}{}
+		flight := requests.start(context.Background(), remoteAgentRequest{ID: 1, Args: []string{"rename", "s", "t"}})
+		requests.cancel(1)
+		<-requests.sem
+		<-flight.done
+		if started.Load() != 0 {
+			t.Fatalf("cancelled queued request started on attempt %d", attempt)
+		}
+	}
 }
 
 // Finding 6: the agent pushes ping events, answers the peer's pings under

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -542,6 +542,9 @@ type Instance struct {
 	ToolOptionsJSON json.RawMessage `json:"tool_options,omitempty"`
 
 	tmuxSession *tmux.Session // Internal tmux session
+	// Database that last loaded or saved this instance. Restart bookkeeping must
+	// return to that profile instead of whichever database is process-global.
+	restartDB atomic.Pointer[statedb.StateDB]
 
 	paneDeadExitStatusForTest func() (int, bool) // nil uses tmuxSession.PaneDeadExitStatus
 

--- a/internal/session/restart_tmux_persist.go
+++ b/internal/session/restart_tmux_persist.go
@@ -68,7 +68,10 @@ func (i *Instance) writeRestartOutcome() (statedb.WriteStamps, error) {
 		return statedb.WriteStamps{}, errors.New("restart left no tmux session name to record")
 	}
 
-	db := statedb.GetGlobal()
+	db := i.restartDB.Load()
+	if db == nil {
+		db = statedb.GetGlobal()
+	}
 	if db == nil {
 		return statedb.WriteStamps{}, errNoStateDB
 	}

--- a/internal/session/restart_tmux_persist_test.go
+++ b/internal/session/restart_tmux_persist_test.go
@@ -139,6 +139,46 @@ func TestRestartRecordsWhatItProduced(t *testing.T) {
 	}
 }
 
+// A loaded instance must write restart bookkeeping to its own profile even
+// when another profile is registered as the process-global database.
+func TestRestartOutcomeUsesOwningProfile(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+
+	suffix := randomString(8)
+	storage, _ := restartPersistFixture(t, "_test_restart_owner_"+suffix, "agentdeck_restartprofile_deadbeef")
+	instances, _, err := storage.LoadWithGroups()
+	if err != nil || len(instances) != 1 {
+		t.Fatalf("reload owning profile: instances=%d err=%v", len(instances), err)
+	}
+	inst := instances[0]
+
+	other, err := NewStorageWithProfile("_test_restart_other_" + suffix)
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile(other): %v", err)
+	}
+	t.Cleanup(func() { _ = other.Close() })
+	previous := statedb.GetGlobal()
+	statedb.SetGlobal(other.GetDB())
+	t.Cleanup(func() { statedb.SetGlobal(previous) })
+
+	if err := inst.Restart(); err != nil {
+		t.Fatalf("Restart: %v", err)
+	}
+	t.Cleanup(func() {
+		if sess := inst.GetTmuxSession(); sess != nil {
+			_ = sess.Kill()
+		}
+	})
+
+	if recorded, err := inst.RestartTmuxNameRecorded(); !recorded || err != nil {
+		t.Fatalf("RestartTmuxNameRecorded() = (%v, %v), want owning-profile success", recorded, err)
+	}
+	live := inst.GetTmuxSession()
+	if live == nil || storedTmuxName(t, storage, inst.ID) != live.Name {
+		t.Fatalf("owning profile did not retain the restarted runtime: live=%v", live)
+	}
+}
+
 // TestRestartReportsAnUnrecordedTmuxName pins the honesty half. If the write
 // cannot land -- here because the row was deleted while the restart ran -- the
 // restart still succeeded and the process is live, so Restart must not fail.

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -435,6 +435,7 @@ type instanceStorageSnapshot struct {
 }
 
 func (s *Storage) rememberInstanceSnapshot(inst *Instance, original, stored *statedb.InstanceRow) {
+	inst.restartDB.Store(s.db)
 	inst.storageSnapshot = &instanceStorageSnapshot{
 		dbPath:   s.dbPath,
 		original: statedb.CloneInstanceRow(original),


### PR DESCRIPTION
## What problem does this solve?

Restart bookkeeping uses the process-global state database. When a loaded instance belongs to another profile, recording its replacement tmux name fails with `instance row not found` and leaves the owning profile pointing to the old runtime.

## Why this change

Remember the database that last loaded or saved each instance and use it for restart bookkeeping. An atomic pointer makes that association race-safe; instances without an owning database retain the existing global fallback.

The previous 224-file runtime-authority rewrite has been removed. This PR no longer introduces lifecycle generations, schemas, CAS, process-identity redesign, or UI coordination. It does not claim to fix #1721, which was already fixed by #1754 in `v1.16.4`.

## User impact

Restarting a session loaded from a non-global profile records its new tmux name in the correct profile.

## Stack

Merge bottom-up: **#2204 → #2208 → #2206 → #2207 → #2205**.

Parent: #2208. Next: #2207. Own delta: **4 files, +48/-1**, one commit (`d3312d36`). [Review only the restart fix](https://github.com/jwiegley/agent-deck/compare/f6d43658efcedccd47f7241dacbe2ac8c2acb11f...d3312d369605a03d4317e2b913cb2e4bb270d9ae).

GitHub base remains upstream `main` because parent branches live only in the fork. The Files changed tab currently shows 21 files including #2204 and #2208; only the four-file linked delta belongs to this PR. Rebase onto upstream `main` after those lower layers merge.

## Evidence

- Before the fix: `TestRestartOutcomeUsesOwningProfile` failed with `RestartTmuxNameRecorded() = (false, ... instance row not found)`.
- The owning-profile regression and neighboring restart persistence tests passed 10 consecutive race runs on the assembled stack.
- `git range-diff` confirms the minimized functional patch is unchanged by restacking.
- Stack tip `837e490694d13faf647333916556a00d832a3c2d` passed the unmodified pre-push gate: build, CSS verification, golangci-lint (`0 issues`), release YAML, and sandboxed `go test -race -count=1 ./...`. This is combined-stack validation, not a separate full-suite run at this intermediate head.
- `go vet ./...` and `go build ./...` also passed after the earlier rebase.

## AI disclosure

- [ ] Human-written
- [x] AI-assisted (I directed and reviewed it)
- [ ] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-5.6-sol; gpt-6-astra (stack integration and validation)

## What actually bothered you

> That's way, way, way too large. I need you to review and analyze the contents of that PR, and pare it down to what is actually needed.

> Why can't you just structure this into a proper stack and update all of the PRs accordingly?

## Checklist

- [x] Targeted diff: one problem, no unrelated changes (relative to stack parent)
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` (only full stack verified; see Evidence)
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=assisted model=gpt-6-astra intent=yes -->
