### PR TITLE
fix(remote): preserve session JSON errors

### DIFF
--- a/cmd/agent-deck/remote_agent_cmd.go
+++ b/cmd/agent-deck/remote_agent_cmd.go
@@ -861,6 +861,10 @@ func (r *remoteAgentRequests) execute(ctx context.Context, f *remoteAgentFlight,
 		return
 	}
 	defer func() { <-r.sem }()
+	if ctx.Err() != nil {
+		f.stderr, f.code = "cancelled while queued", 1
+		return
+	}
 	f.stdout, f.stderr, f.code = r.exec(ctx, args)
 	f.stamp = remoteAgentStampNanos(r.stampPath)
 }

--- a/cmd/agent-deck/remote_agent_harden_test.go
+++ b/cmd/agent-deck/remote_agent_harden_test.go
@@ -347,7 +347,7 @@ func TestRemoteAgent_CancelKillsRequest(t *testing.T) {
 }
 
 // Finding 4: at most MaxConcurrent subprocesses run at once; the rest wait
-// their turn, and a queued request that is cancelled never runs.
+// their turn.
 func TestRemoteAgent_ConcurrencyCap(t *testing.T) {
 	var running, peak atomic.Int32
 	var started atomic.Int32
@@ -369,37 +369,46 @@ func TestRemoteAgent_ConcurrencyCap(t *testing.T) {
 		return strings.Join(args, " "), "", 0
 	}
 	h := startAgent(t, remoteAgentConfig{Run: run, MaxConcurrent: 2})
-	for i := int64(1); i <= 5; i++ {
+	for i := int64(1); i <= 4; i++ {
 		h.send(remoteAgentRequest{ID: i, Args: []string{"rename", "s", strings.Repeat("x", int(i))}})
 	}
 	time.Sleep(50 * time.Millisecond)
 	if got := started.Load(); got != 2 {
 		t.Fatalf("only MaxConcurrent requests may run at once, got %d started", got)
 	}
-	h.send(remoteAgentRequest{ID: 5, Cancel: true})
-	// A successful pipe write only proves the agent reader received the line,
-	// not that its request loop processed it. Wait for a following ping ack,
-	// which is emitted only after the cancel has removed request 5, before
-	// freeing a semaphore slot for the queued requests.
-	h.send(remoteAgentRequest{ID: 6, Ping: true})
-	if r := h.next("cancel barrier"); r.ID != 6 || r.Code != 0 {
-		t.Fatalf("cancel barrier reply = %+v, want successful ping acknowledgement", r)
-	}
 	close(release)
 	ids := map[int64]bool{}
 	for i := 0; i < 4; i++ {
 		ids[h.next("reply").ID] = true
 	}
-	if ids[5] || len(ids) != 4 {
-		t.Fatalf("four queued requests must answer and the cancelled one must not, got %v", ids)
+	if len(ids) != 4 {
+		t.Fatalf("four queued requests must answer, got %v", ids)
 	}
 	if peak.Load() > 2 {
 		t.Fatalf("peak concurrency %d exceeds the cap of 2", peak.Load())
 	}
 	if started.Load() != 4 {
-		t.Fatalf("a request cancelled while queued must never start, got %d starts", started.Load())
+		t.Fatalf("every request must start, got %d starts", started.Load())
 	}
 	h.closeAndWait()
+}
+
+func TestRemoteAgent_QueuedCancellationNeverStarts(t *testing.T) {
+	for attempt := 0; attempt < 100; attempt++ {
+		var started atomic.Int32
+		requests := newRemoteAgentRequests(func(context.Context, []string) (string, string, int) {
+			started.Add(1)
+			return "", "", 0
+		}, 1, "")
+		requests.sem <- struct{}{}
+		flight := requests.start(context.Background(), remoteAgentRequest{ID: 1, Args: []string{"rename", "s", "t"}})
+		requests.cancel(1)
+		<-requests.sem
+		<-flight.done
+		if started.Load() != 0 {
+			t.Fatalf("cancelled queued request started on attempt %d", attempt)
+		}
+	}
 }
 
 // Finding 6: the agent pushes ping events, answers the peer's pings under

--- a/cmd/agent-deck/remote_cmd.go
+++ b/cmd/agent-deck/remote_cmd.go
@@ -141,7 +141,7 @@ func printRemoteUsage() {
 	fmt.Println("  add <name> <user@host>    Add a remote agent-deck instance")
 	fmt.Println("  remove <name>             Remove a remote")
 	fmt.Println("  list                      List configured remotes")
-	fmt.Println("  sessions [name]           Fetch sessions from remote(s)")
+	fmt.Println("  sessions [name] [--json]  Fetch sessions from remote(s)")
 	fmt.Println("  drain <name|user@host>    Pull completion/transition records from a remote")
 	fmt.Println("                            into this machine's inbox (read-only on the remote)")
 	fmt.Println("  attach <name> <session>   Attach to a remote session")
@@ -152,7 +152,7 @@ func printRemoteUsage() {
 	fmt.Println("  agent-deck remote add dev user@dev-box")
 	fmt.Println("  agent-deck remote add prod user@prod-server --agent-deck-path /usr/local/bin/agent-deck")
 	fmt.Println("  agent-deck remote list")
-	fmt.Println("  agent-deck remote sessions dev")
+	fmt.Println("  agent-deck remote sessions dev --json")
 	fmt.Println("  agent-deck remote drain dev       # pull finished/stalled reports from dev")
 	fmt.Println("  agent-deck remote attach dev my-session")
 	fmt.Println("  agent-deck remote rename dev my-session new-name")
@@ -387,19 +387,92 @@ func probeRemoteVersions(ctx context.Context, remotes map[string]session.RemoteC
 	return states
 }
 
+type remoteSessionError struct {
+	Name  string `json:"name"`
+	Host  string `json:"host"`
+	Error string `json:"error"`
+}
+
+type remoteSessionsOutput struct {
+	Sessions []session.RemoteSessionInfo `json:"sessions"`
+	Errors   []remoteSessionError        `json:"errors"`
+}
+
+func parseRemoteSessionsArgs(args []string) (remoteName string, jsonOutput bool, err error) {
+	fs := flag.NewFlagSet("remote sessions", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	jsonFlag := fs.Bool("json", false, "Output as JSON")
+	if err := fs.Parse(reorderRemoteArgs(fs, args)); err != nil {
+		return "", false, err
+	}
+	if len(fs.Args()) > 1 {
+		return "", false, fmt.Errorf("accepts at most one remote name")
+	}
+	if len(fs.Args()) == 1 {
+		remoteName = fs.Args()[0]
+	}
+	return remoteName, *jsonFlag, nil
+}
+
+func addRemoteSessionFetch(
+	output *remoteSessionsOutput,
+	name string,
+	host string,
+	sessions []session.RemoteSessionInfo,
+	err error,
+) bool {
+	if err != nil {
+		output.Errors = append(output.Errors, remoteSessionError{
+			Name:  name,
+			Host:  host,
+			Error: err.Error(),
+		})
+		return false
+	}
+	for i := range sessions {
+		sessions[i].RemoteName = name
+	}
+	output.Sessions = append(output.Sessions, sessions...)
+	return true
+}
+
+func writeRemoteSessionsJSON(output remoteSessionsOutput) {
+	encoded, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to format JSON: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(string(encoded))
+}
+
 func handleRemoteSessions(args []string) {
-	fs := flag.NewFlagSet("remote sessions", flag.ExitOnError)
-	jsonOutput := fs.Bool("json", false, "Output as JSON")
-	_ = fs.Parse(args)
+	remoteName, jsonOutput, err := parseRemoteSessionsArgs(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: remote sessions flag parsing failed: %v\n", err)
+		os.Exit(2)
+	}
+	output := remoteSessionsOutput{
+		Sessions: []session.RemoteSessionInfo{},
+		Errors:   []remoteSessionError{},
+	}
 
 	config, err := session.LoadUserConfig()
 	if err != nil {
-		fmt.Printf("Error: failed to load config: %v\n", err)
+		if jsonOutput {
+			output.Errors = append(output.Errors, remoteSessionError{Name: "config", Error: err.Error()})
+			writeRemoteSessionsJSON(output)
+		} else {
+			fmt.Printf("Error: failed to load config: %v\n", err)
+		}
 		os.Exit(1)
 	}
 
 	if len(config.Remotes) == 0 {
-		fmt.Println("No remotes configured.")
+		if jsonOutput {
+			writeRemoteSessionsJSON(output)
+		} else {
+			fmt.Println("No remotes configured.")
+		}
 		return
 	}
 
@@ -408,14 +481,22 @@ func handleRemoteSessions(args []string) {
 	// forever on the ControlMaster=auto reuse.
 	session.CleanStaleSSHSockets()
 
-	// Filter to specific remote if name provided
-	remoteName := ""
-	if len(fs.Args()) > 0 {
-		remoteName = fs.Args()[0]
+	if remoteName != "" {
+		if _, exists := config.Remotes[remoteName]; !exists {
+			output.Errors = append(output.Errors, remoteSessionError{
+				Name:  remoteName,
+				Error: "remote not found",
+			})
+			if jsonOutput {
+				writeRemoteSessionsJSON(output)
+			} else {
+				fmt.Printf("Error: remote '%s' not found\n", remoteName)
+			}
+			os.Exit(1)
+		}
 	}
 
 	ctx := context.Background()
-	var allSessions []session.RemoteSessionInfo
 
 	for name, rc := range config.Remotes {
 		if remoteName != "" && name != remoteName {
@@ -424,19 +505,14 @@ func handleRemoteSessions(args []string) {
 
 		runner := session.NewSSHRunner(name, rc)
 		sessions, err := runner.FetchSessions(ctx)
-		if err != nil {
-			if !*jsonOutput {
+		if !addRemoteSessionFetch(&output, name, rc.Host, sessions, err) {
+			if !jsonOutput {
 				fmt.Printf("  [%s] Error: %v\n", name, err)
 			}
 			continue
 		}
 
-		for i := range sessions {
-			sessions[i].RemoteName = name
-		}
-		allSessions = append(allSessions, sessions...)
-
-		if !*jsonOutput {
+		if !jsonOutput {
 			fmt.Printf("\n═══ Remote: %s (%s) ═══\n\n", name, rc.Host)
 			if len(sessions) == 0 {
 				fmt.Println("  No sessions found.")
@@ -458,20 +534,11 @@ func handleRemoteSessions(args []string) {
 		}
 	}
 
-	if remoteName != "" {
-		if _, exists := config.Remotes[remoteName]; !exists {
-			fmt.Printf("Error: remote '%s' not found\n", remoteName)
-			os.Exit(1)
-		}
+	if jsonOutput {
+		writeRemoteSessionsJSON(output)
 	}
-
-	if *jsonOutput {
-		output, err := json.MarshalIndent(allSessions, "", "  ")
-		if err != nil {
-			fmt.Printf("Error: failed to format JSON: %v\n", err)
-			os.Exit(1)
-		}
-		fmt.Println(string(output))
+	if len(output.Errors) != 0 {
+		os.Exit(1)
 	}
 }
 

--- a/cmd/agent-deck/remote_cmd_test.go
+++ b/cmd/agent-deck/remote_cmd_test.go
@@ -1,8 +1,15 @@
 package main
 
 import (
+	"encoding/json"
+	"errors"
 	"io"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
 func TestIsValidRemoteName(t *testing.T) {
@@ -60,4 +67,76 @@ func TestShouldProceedWithRemoteUpdate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRemoteSessionsAcceptsJSONAfterRemoteName(t *testing.T) {
+	remoteName, jsonOutput, err := parseRemoteSessionsArgs([]string{"clio", "--json"})
+	if err != nil {
+		t.Fatalf("parseRemoteSessionsArgs: %v", err)
+	}
+	if remoteName != "clio" || !jsonOutput {
+		t.Fatalf("parsed (%q, %t), want (clio, true)", remoteName, jsonOutput)
+	}
+}
+
+func TestRemoteSessionFetchKeepsStructuredFailureAndStampsSuccess(t *testing.T) {
+	output := remoteSessionsOutput{
+		Sessions: []session.RemoteSessionInfo{},
+		Errors:   []remoteSessionError{},
+	}
+	if addRemoteSessionFetch(&output, "clio", "johnw@clio", nil, errors.New("ssh unavailable")) {
+		t.Fatal("failed fetch reported success")
+	}
+	if len(output.Errors) != 1 || output.Errors[0].Name != "clio" || output.Errors[0].Host != "johnw@clio" || output.Errors[0].Error != "ssh unavailable" {
+		t.Fatalf("structured error = %#v", output.Errors)
+	}
+
+	sessions := []session.RemoteSessionInfo{{ID: "remote-session"}}
+	if !addRemoteSessionFetch(&output, "clio", "johnw@clio", sessions, nil) {
+		t.Fatal("successful fetch reported failure")
+	}
+	if len(output.Sessions) != 1 || output.Sessions[0].RemoteName != "clio" {
+		t.Fatalf("sessions = %#v", output.Sessions)
+	}
+}
+
+func TestRemoteSessionsJSONCoversEmptyAndConfigError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	t.Run("empty", func(t *testing.T) {
+		stdout, stderr, code := runAgentDeck(t, t.TempDir(), "remote", "sessions", "--json")
+		if code != 0 || stderr != "" {
+			t.Fatalf("empty remotes: code=%d stderr=%q", code, stderr)
+		}
+		var output remoteSessionsOutput
+		if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+			t.Fatalf("stdout is not JSON: %v\n%s", err, stdout)
+		}
+		if output.Sessions == nil || output.Errors == nil || len(output.Sessions) != 0 || len(output.Errors) != 0 {
+			t.Fatalf("empty output = %#v", output)
+		}
+	})
+
+	t.Run("config error", func(t *testing.T) {
+		home := t.TempDir()
+		configDir := filepath.Join(home, ".config", "agent-deck")
+		if err := os.MkdirAll(configDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte("[invalid"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		stdout, _, code := runAgentDeck(t, home, "remote", "sessions", "--json")
+		if code != 1 {
+			t.Fatalf("config error exit = %d, stdout=%s", code, stdout)
+		}
+		var output remoteSessionsOutput
+		if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+			t.Fatalf("stdout is not JSON: %v\n%s", err, stdout)
+		}
+		if len(output.Errors) != 1 || output.Errors[0].Name != "config" || !strings.Contains(output.Errors[0].Error, "config") {
+			t.Fatalf("config error output = %#v", output)
+		}
+	})
 }

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -542,6 +542,9 @@ type Instance struct {
 	ToolOptionsJSON json.RawMessage `json:"tool_options,omitempty"`
 
 	tmuxSession *tmux.Session // Internal tmux session
+	// Database that last loaded or saved this instance. Restart bookkeeping must
+	// return to that profile instead of whichever database is process-global.
+	restartDB atomic.Pointer[statedb.StateDB]
 
 	paneDeadExitStatusForTest func() (int, bool) // nil uses tmuxSession.PaneDeadExitStatus
 

--- a/internal/session/restart_tmux_persist.go
+++ b/internal/session/restart_tmux_persist.go
@@ -68,7 +68,10 @@ func (i *Instance) writeRestartOutcome() (statedb.WriteStamps, error) {
 		return statedb.WriteStamps{}, errors.New("restart left no tmux session name to record")
 	}
 
-	db := statedb.GetGlobal()
+	db := i.restartDB.Load()
+	if db == nil {
+		db = statedb.GetGlobal()
+	}
 	if db == nil {
 		return statedb.WriteStamps{}, errNoStateDB
 	}

--- a/internal/session/restart_tmux_persist_test.go
+++ b/internal/session/restart_tmux_persist_test.go
@@ -139,6 +139,46 @@ func TestRestartRecordsWhatItProduced(t *testing.T) {
 	}
 }
 
+// A loaded instance must write restart bookkeeping to its own profile even
+// when another profile is registered as the process-global database.
+func TestRestartOutcomeUsesOwningProfile(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+
+	suffix := randomString(8)
+	storage, _ := restartPersistFixture(t, "_test_restart_owner_"+suffix, "agentdeck_restartprofile_deadbeef")
+	instances, _, err := storage.LoadWithGroups()
+	if err != nil || len(instances) != 1 {
+		t.Fatalf("reload owning profile: instances=%d err=%v", len(instances), err)
+	}
+	inst := instances[0]
+
+	other, err := NewStorageWithProfile("_test_restart_other_" + suffix)
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile(other): %v", err)
+	}
+	t.Cleanup(func() { _ = other.Close() })
+	previous := statedb.GetGlobal()
+	statedb.SetGlobal(other.GetDB())
+	t.Cleanup(func() { statedb.SetGlobal(previous) })
+
+	if err := inst.Restart(); err != nil {
+		t.Fatalf("Restart: %v", err)
+	}
+	t.Cleanup(func() {
+		if sess := inst.GetTmuxSession(); sess != nil {
+			_ = sess.Kill()
+		}
+	})
+
+	if recorded, err := inst.RestartTmuxNameRecorded(); !recorded || err != nil {
+		t.Fatalf("RestartTmuxNameRecorded() = (%v, %v), want owning-profile success", recorded, err)
+	}
+	live := inst.GetTmuxSession()
+	if live == nil || storedTmuxName(t, storage, inst.ID) != live.Name {
+		t.Fatalf("owning profile did not retain the restarted runtime: live=%v", live)
+	}
+}
+
 // TestRestartReportsAnUnrecordedTmuxName pins the honesty half. If the write
 // cannot land -- here because the row was deleted while the restart ran -- the
 // restart still succeeded and the process is live, so Restart must not fail.

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -435,6 +435,7 @@ type instanceStorageSnapshot struct {
 }
 
 func (s *Storage) rememberInstanceSnapshot(inst *Instance, original, stored *statedb.InstanceRow) {
+	inst.restartDB.Store(s.db)
 	inst.storageSnapshot = &instanceStorageSnapshot{
 		dbPath:   s.dbPath,
 		original: statedb.CloneInstanceRow(original),


### PR DESCRIPTION
## What problem does this solve?

`remote sessions --json` drops per-remote failures and emits non-JSON text for empty, missing-remote, and configuration-error cases. Automation loses partial results and diagnostics.

## Why this change

Return a stable envelope containing both `sessions` and structured `errors`, preserve successful results when another remote fails, and recognize `--json` before or after the optional remote name.

## User impact

Automation receives JSON for success and failure, can retain partial results, and gets a nonzero exit status when any remote reports an error.

## Stack

Merge bottom-up: **#2204 → #2208 → #2206 → #2207 → #2205**.

Parent: #2206. Next: #2205. Own delta: **2 files, +179/-33**. [Review only this layer](https://github.com/jwiegley/agent-deck/compare/d3312d369605a03d4317e2b913cb2e4bb270d9ae...926ca815358ff48a0bff670a78b63c77a981462a).

GitHub base remains upstream `main` because parent branches live only in the fork. Files changed includes lower layers; the linked comparison isolates this PR. Rebase descendants after each lower PR merges.

## Evidence

The original CLI check returned this envelope with no remotes:

```json
{"sessions": [], "errors": []}
```

Malformed configuration returned exit 1 with the same envelope and a configuration error entry.

- `TestRemoteSessions*` and `TestRemoteSessionFetch*` coverage passed in the focused 10-run race check on the assembled stack.
- The original tests do not compile on `v1.16.4` without the structured parsing/output contract.
- `git range-diff` confirms this functional patch is unchanged by restacking.
- Stack tip `837e490694d13faf647333916556a00d832a3c2d` passed the unmodified pre-push gate: build, CSS verification, golangci-lint (`0 issues`), release YAML, and sandboxed `go test -race -count=1 ./...`. This is combined-stack validation, not a separate full-suite run at this intermediate head.

## AI disclosure

- [ ] Human-written
- [x] AI-assisted (I directed and reviewed it)
- [ ] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-5.6-sol; gpt-6-astra (stack integration and validation)

## What actually bothered you

> For each of the changes we now have on top of the latest release version in ~/src/fork/agent-deck, I want you to make a separate PR for each.

> Why can't you just structure this into a proper stack and update all of the PRs accordingly?

## Checklist

- [x] Targeted diff: one problem, no unrelated changes (relative to stack parent)
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` (only full stack verified; see Evidence)
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=assisted model=gpt-6-astra intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added JSON output for remote sessions, including session details and per-remote errors.
  - Added validation for requested remote names and clear exit statuses for argument or fetch failures.
  - Preserved session lineage and native session identity across cross-harness handoffs.

- **Bug Fixes**
  - Prevented cancelled queued remote commands from starting.
  - Ensured restart information is saved to the correct storage profile.
  - Improved cleanup behavior after remote session termination.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->