### PR TITLE
fix(remote): honor queued cancellations

### DIFF
--- a/cmd/agent-deck/remote_agent_cmd.go
+++ b/cmd/agent-deck/remote_agent_cmd.go
@@ -861,6 +861,10 @@ func (r *remoteAgentRequests) execute(ctx context.Context, f *remoteAgentFlight,
 		return
 	}
 	defer func() { <-r.sem }()
+	if ctx.Err() != nil {
+		f.stderr, f.code = "cancelled while queued", 1
+		return
+	}
 	f.stdout, f.stderr, f.code = r.exec(ctx, args)
 	f.stamp = remoteAgentStampNanos(r.stampPath)
 }

--- a/cmd/agent-deck/remote_agent_harden_test.go
+++ b/cmd/agent-deck/remote_agent_harden_test.go
@@ -347,7 +347,7 @@ func TestRemoteAgent_CancelKillsRequest(t *testing.T) {
 }
 
 // Finding 4: at most MaxConcurrent subprocesses run at once; the rest wait
-// their turn, and a queued request that is cancelled never runs.
+// their turn.
 func TestRemoteAgent_ConcurrencyCap(t *testing.T) {
 	var running, peak atomic.Int32
 	var started atomic.Int32
@@ -369,37 +369,46 @@ func TestRemoteAgent_ConcurrencyCap(t *testing.T) {
 		return strings.Join(args, " "), "", 0
 	}
 	h := startAgent(t, remoteAgentConfig{Run: run, MaxConcurrent: 2})
-	for i := int64(1); i <= 5; i++ {
+	for i := int64(1); i <= 4; i++ {
 		h.send(remoteAgentRequest{ID: i, Args: []string{"rename", "s", strings.Repeat("x", int(i))}})
 	}
 	time.Sleep(50 * time.Millisecond)
 	if got := started.Load(); got != 2 {
 		t.Fatalf("only MaxConcurrent requests may run at once, got %d started", got)
 	}
-	h.send(remoteAgentRequest{ID: 5, Cancel: true})
-	// A successful pipe write only proves the agent reader received the line,
-	// not that its request loop processed it. Wait for a following ping ack,
-	// which is emitted only after the cancel has removed request 5, before
-	// freeing a semaphore slot for the queued requests.
-	h.send(remoteAgentRequest{ID: 6, Ping: true})
-	if r := h.next("cancel barrier"); r.ID != 6 || r.Code != 0 {
-		t.Fatalf("cancel barrier reply = %+v, want successful ping acknowledgement", r)
-	}
 	close(release)
 	ids := map[int64]bool{}
 	for i := 0; i < 4; i++ {
 		ids[h.next("reply").ID] = true
 	}
-	if ids[5] || len(ids) != 4 {
-		t.Fatalf("four queued requests must answer and the cancelled one must not, got %v", ids)
+	if len(ids) != 4 {
+		t.Fatalf("four queued requests must answer, got %v", ids)
 	}
 	if peak.Load() > 2 {
 		t.Fatalf("peak concurrency %d exceeds the cap of 2", peak.Load())
 	}
 	if started.Load() != 4 {
-		t.Fatalf("a request cancelled while queued must never start, got %d starts", started.Load())
+		t.Fatalf("every request must start, got %d starts", started.Load())
 	}
 	h.closeAndWait()
+}
+
+func TestRemoteAgent_QueuedCancellationNeverStarts(t *testing.T) {
+	for attempt := 0; attempt < 100; attempt++ {
+		var started atomic.Int32
+		requests := newRemoteAgentRequests(func(context.Context, []string) (string, string, int) {
+			started.Add(1)
+			return "", "", 0
+		}, 1, "")
+		requests.sem <- struct{}{}
+		flight := requests.start(context.Background(), remoteAgentRequest{ID: 1, Args: []string{"rename", "s", "t"}})
+		requests.cancel(1)
+		<-requests.sem
+		<-flight.done
+		if started.Load() != 0 {
+			t.Fatalf("cancelled queued request started on attempt %d", attempt)
+		}
+	}
 }
 
 // Finding 6: the agent pushes ping events, answers the peer's pings under


### PR DESCRIPTION
## What problem does this solve?

A request cancelled while waiting for remote-agent capacity can still start when cancellation and capacity become ready together and the semaphore select chooses capacity.

## Why this change

Recheck `ctx.Err()` after acquiring capacity and before invoking the subprocess. Keep concurrency-cap coverage separate from a queued-cancellation regression that explicitly orders cancellation before capacity release. No new scheduling abstraction.

## User impact

Requests cancelled while queued do not later execute or mutate state.

## Stack

Merge bottom-up: **#2204 → #2208 → #2206 → #2207 → #2205**.

Parent: #2204. Next: #2206. Own delta: **2 files, +27/-6**. [Review only this layer](https://github.com/jwiegley/agent-deck/compare/784f5805600a8f10ce20e97f4a5438e2a6d0b8ef...f6d43658efcedccd47f7241dacbe2ac8c2acb11f).

GitHub base remains upstream `main` because the parent branch lives only in the fork. The cumulative Files changed tab includes #2204. Rebase descendants after each lower PR merges.

## Evidence

- Applying the original regression to `v1.16.4` failed with `cancelled queued request started on attempt 1`.
- `TestRemoteAgent_QueuedCancellationNeverStarts` and `TestRemoteAgent_ConcurrencyCap` passed 10 consecutive race runs on the assembled stack.
- `git range-diff` confirms this functional patch is unchanged by restacking.
- Stack tip `837e490694d13faf647333916556a00d832a3c2d` passed the unmodified pre-push gate: build, CSS verification, golangci-lint (`0 issues`), release YAML, and sandboxed `go test -race -count=1 ./...`. This is combined-stack validation, not a separate full-suite run at this intermediate head.

## AI disclosure

- [ ] Human-written
- [x] AI-assisted (I directed and reviewed it)
- [ ] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-5.6-sol; gpt-6-astra (stack integration and validation)

## What actually bothered you

> For each of the changes we now have on top of the latest release version in ~/src/fork/agent-deck, I want you to make a separate PR for each.

> Why can't you just structure this into a proper stack and update all of the PRs accordingly?

## Checklist

- [x] Targeted diff: one problem, no unrelated changes (relative to stack parent)
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` (only full stack verified; see Evidence)
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=assisted model=gpt-6-astra intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cancelled requests waiting to start now exit promptly with a cancellation error.
  * Prevented cancelled requests from launching command execution after acquiring capacity.
  * Improved request handling so active and queued requests respect cancellation consistently.

* **Tests**
  * Expanded coverage for concurrency limits and cancellation behavior, including repeated queued-request scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->