### PR TITLE
fix: mark-unread (u) no longer reverts to gray on the next reload

### DIFF
--- a/internal/statedb/set_acknowledged_stamps_test.go
+++ b/internal/statedb/set_acknowledged_stamps_test.go
@@ -1,0 +1,118 @@
+package statedb
+
+import (
+	"testing"
+	"time"
+)
+
+// The `u` key (mark unread) clears the acknowledged flag with a targeted write
+// and then saves the accompanying status. The TUI is both writer and reader of
+// this database, so that write must be identifiable as its own: otherwise the
+// save reads the bump as another process's change, aborts, and reloads --
+// rebuilding acknowledged from the stale stored status and undoing the mark.
+
+func ackRow(id string) *InstanceRow {
+	return &InstanceRow{
+		ID:          id,
+		Title:       "target",
+		ProjectPath: "/tmp/proj",
+		GroupPath:   "Ungrouped",
+		Command:     "claude",
+		Tool:        "claude",
+		Status:      "idle",
+		TmuxSession: "agentdeck_target_deadbeef",
+		CreatedAt:   time.Now(),
+	}
+}
+
+func TestSetAcknowledgedStamped_StampsIdentifyOurOwnBump(t *testing.T) {
+	db := newTestDB(t)
+	if err := db.SaveInstances([]*InstanceRow{ackRow("ack-stamped")}); err != nil {
+		t.Fatalf("SaveInstances: %v", err)
+	}
+	loadedAt, err := db.LastModified()
+	if err != nil {
+		t.Fatalf("LastModified: %v", err)
+	}
+
+	stamps, err := db.SetAcknowledgedStamped("ack-stamped", false)
+	if err != nil {
+		t.Fatalf("SetAcknowledgedStamped: %v", err)
+	}
+	current, err := db.LastModified()
+	if err != nil {
+		t.Fatalf("LastModified after write: %v", err)
+	}
+
+	if !stamps.SoleWriterSince(loadedAt, current) {
+		t.Errorf("stamps do not identify our own bump: before=%d after=%d loadedAt=%d current=%d "+
+			"(the TUI reads its own acknowledged write as an external change, aborts the save "+
+			"that would persist the new status, and reloads the stale one)",
+			stamps.Before, stamps.After, loadedAt, current)
+	}
+}
+
+// A write by somebody else between our load and our write must NOT be adopted:
+// the database really has moved on and the abort is the correct outcome.
+func TestSetAcknowledgedStamped_ForeignWriteIsNotAdopted(t *testing.T) {
+	db := newTestDB(t)
+	if err := db.SaveInstances([]*InstanceRow{ackRow("ack-foreign")}); err != nil {
+		t.Fatalf("SaveInstances: %v", err)
+	}
+	loadedAt, err := db.LastModified()
+	if err != nil {
+		t.Fatalf("LastModified: %v", err)
+	}
+
+	// Another process writes after we loaded.
+	if err := db.Touch(); err != nil {
+		t.Fatalf("Touch: %v", err)
+	}
+
+	stamps, err := db.SetAcknowledgedStamped("ack-foreign", false)
+	if err != nil {
+		t.Fatalf("SetAcknowledgedStamped: %v", err)
+	}
+	current, err := db.LastModified()
+	if err != nil {
+		t.Fatalf("LastModified after write: %v", err)
+	}
+
+	if stamps.SoleWriterSince(loadedAt, current) {
+		t.Error("adopted a bump that followed another process's write: the TUI would then " +
+			"overwrite whatever that process changed")
+	}
+}
+
+// SetAcknowledged keeps its existing signature and behavior for the callers
+// that do not need the stamps.
+func TestSetAcknowledged_StillPersistsAndTouches(t *testing.T) {
+	db := newTestDB(t)
+	if err := db.SaveInstances([]*InstanceRow{ackRow("ack-plain")}); err != nil {
+		t.Fatalf("SaveInstances: %v", err)
+	}
+	before, err := db.LastModified()
+	if err != nil {
+		t.Fatalf("LastModified: %v", err)
+	}
+
+	if err := db.SetAcknowledged("ack-plain", true); err != nil {
+		t.Fatalf("SetAcknowledged: %v", err)
+	}
+
+	statuses, err := db.ReadAllStatuses()
+	if err != nil {
+		t.Fatalf("ReadAllStatuses: %v", err)
+	}
+	if !statuses["ack-plain"].Acknowledged {
+		t.Error("acknowledged flag was not persisted")
+	}
+	after, err := db.LastModified()
+	if err != nil {
+		t.Fatalf("LastModified after write: %v", err)
+	}
+	if after <= before {
+		t.Errorf("last_modified did not advance (%d -> %d): peers poll it to notice the change",
+			before, after)
+	}
+}

--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -1594,6 +1594,22 @@ func (s *StateDB) touchWithRetry() error {
 
 // SetAcknowledged sets or clears the acknowledged flag for an instance.
 func (s *StateDB) SetAcknowledged(id string, ack bool) error {
+	_, err := s.SetAcknowledgedStamped(id, ack)
+	return err
+}
+
+// SetAcknowledgedStamped is SetAcknowledged for a caller that is also a reader
+// of this database: it returns the WriteStamps identifying the last_modified
+// bump this write produced.
+//
+// The TUI decides whether to save by comparing last_modified against the value
+// it captured when it last loaded. This write moves last_modified, so a TUI
+// that cannot recognise its own bump reads it as another process's change and
+// abandons the save that would have persisted the status change accompanying
+// it — then reloads, which rebuilds the session's acknowledged state from the
+// STALE stored status. Same self-inflicted false positive WriteRestartOutcome's
+// stamps exist to prevent (#1868).
+func (s *StateDB) SetAcknowledgedStamped(id string, ack bool) (WriteStamps, error) {
 	v := 0
 	if ack {
 		v = 1
@@ -1602,9 +1618,9 @@ func (s *StateDB) SetAcknowledged(id string, ack bool) error {
 		_, err := s.db.Exec("UPDATE instances SET acknowledged = ? WHERE id = ?", v, id)
 		return err
 	}); err != nil {
-		return err
+		return WriteStamps{}, err
 	}
-	return s.touchWithRetry()
+	return s.touchStamp()
 }
 
 // SetArchived sets or clears the archive timestamp for a single instance via a

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -11434,9 +11434,20 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				tmuxSess := item.Session.GetTmuxSession()
 				if tmuxSess != nil {
 					tmuxSess.ResetAcknowledged()
-					// Persist to SQLite so background sync doesn't overwrite
+					// Persist to SQLite so background sync doesn't overwrite.
+					//
+					// Adopt the write: it moves last_modified, and without that
+					// the save below reads this TUI's OWN bump as an external
+					// change, aborts, and reloads instead. The reload rebuilds
+					// acknowledged from the stored status -- still "idle",
+					// precisely because the save that would have written
+					// "waiting" was the one that aborted -- so the row went
+					// straight back to gray and the key looked like it did
+					// nothing. Same self-inflicted false positive as #1868.
 					if db := statedb.GetGlobal(); db != nil {
-						_ = db.SetAcknowledged(item.Session.ID, false)
+						if stamps, err := db.SetAcknowledgedStamped(item.Session.ID, false); err == nil {
+							h.adoptOwnWrite(stamps, "mark_unread")
+						}
 					}
 					// Clear idle optimization so UpdateStatus does a full check
 					item.Session.ForceNextStatusCheck()
@@ -13615,46 +13626,58 @@ func (h *Home) saveInstancesWithForce(force bool) {
 // the dedup pass) for no reason. That self-inflicted false positive is what
 // #1868 was really hitting.
 //
-// The marker is advanced only when the restart's write was the sole change
-// since this TUI loaded: nothing landed between the load and the write, and
-// nothing has landed since. Anything else means the database really has moved
-// on, the abort is correct, and it stays -- the reload picks up what the other
-// process wrote, and the restart's own outcome is durable either way because
-// the targeted write already landed.
-//
-// last_modified is a UnixNano stamp, so this is an exact identity test on our
-// own write rather than a time window that could swallow somebody else's.
+// The conditions under which the marker actually moves live on adoptOwnWrite,
+// which the mark-unread path shares.
 func (h *Home) adoptRestartRecord(sessionID string) {
-	if h.storage == nil {
-		return
-	}
 	inst := h.getInstanceByID(sessionID)
 	if inst == nil {
 		return
 	}
-	stamps := inst.RestartRecordStamps()
-	if stamps.After == 0 {
-		return
+	h.adoptOwnWrite(inst.RestartRecordStamps(), "restart_record")
+}
+
+// adoptOwnWrite advances this TUI's freshness marker past a targeted write it
+// just made itself, so the save that follows does not read its own bump as
+// another process's change.
+//
+// Shared by every caller that makes a targeted write and then saves. `what`
+// names the write for the diagnostic log only.
+//
+// The marker moves only when this write was the sole change since this TUI
+// loaded: nothing landed between the load and the write, and nothing has landed
+// since. Anything else means the database really has moved on, the abort is
+// correct, and it stays -- the reload picks up what the other process wrote,
+// and the targeted write's own outcome is durable either way because it already
+// landed.
+//
+// last_modified is a UnixNano stamp, so this is an exact identity test on our
+// own write rather than a time window that could swallow somebody else's.
+// Returns true when the marker moved.
+func (h *Home) adoptOwnWrite(stamps statedb.WriteStamps, what string) bool {
+	if h.storage == nil || stamps.After == 0 {
+		return false
 	}
 	current, err := h.storage.GetFileMtime()
 	if err != nil || current.IsZero() {
-		return
+		return false
 	}
 
 	h.reloadMu.Lock()
 	defer h.reloadMu.Unlock()
 	if !stamps.SoleWriterSince(h.lastLoadMtime.UnixNano(), current.UnixNano()) {
-		uiLog.Debug("restart_record_not_sole_writer",
+		uiLog.Debug("own_write_not_sole_writer",
+			slog.String("write", what),
 			slog.Int64("before", stamps.Before),
 			slog.Int64("after", stamps.After),
 			slog.Int64("current", current.UnixNano()))
-		return
+		return false
 	}
 	h.lastLoadMtime = current
 	if h.storageWatcher != nil {
 		// Our own bump should not make the watcher schedule a reload either.
 		h.storageWatcher.NotifySave()
 	}
+	return true
 }
 
 // saveGroupState saves only group expanded/collapsed state to SQLite.

--- a/internal/ui/mark_unread_save_test.go
+++ b/internal/ui/mark_unread_save_test.go
@@ -118,3 +118,23 @@ func TestMarkUnread_ForeignWriteStillAbortsTheSave(t *testing.T) {
 			"whatever that process changed")
 	}
 }
+
+// RemoteSession parity for the `u` action: mark-unread is local-only by
+// construction, so there is no remote path to cover.
+//
+// Everything the handler does is local state a remote row does not have. It
+// clears the acknowledged flag on the local tmux.Session, writes the local
+// SQLite `acknowledged` column, and reads the recomputed local status back.
+// RemoteSessionInfo (internal/session/ssh.go) carries no acknowledged field --
+// it ships id/title/path/group/tool/status/substate/archived/last-activity and
+// nothing about whether the viewer has seen the session -- and the SSH surface
+// exposes no acknowledge or unread verb to forward the action to.
+//
+// Routing `u` to a remote would mean designing that protocol first, which is
+// well outside a fix for the local save aborting on its own write. Recorded as
+// a documented skip rather than a silent omission, per the repository's
+// RemoteSession parity guideline.
+func TestMarkUnread_RemoteSessionIsOutOfScope(t *testing.T) {
+	t.Skip("mark-unread is local-only: RemoteSessionInfo has no acknowledged field and the " +
+		"remote surface has no acknowledge/unread operation to route the action to")
+}

--- a/internal/ui/mark_unread_save_test.go
+++ b/internal/ui/mark_unread_save_test.go
@@ -1,0 +1,120 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Pressing `u` (mark unread) clears the acknowledged flag with a targeted
+// write, flips the in-memory status to waiting, and saves.
+//
+// The targeted write moves last_modified. The save's external-change guard
+// compares last_modified against the value captured at load, so without
+// adoptOwnWrite the guard fires on this TUI's OWN bump: the save aborts and
+// schedules a reload instead, the reload rebuilds acknowledged from the stored
+// status -- still "idle", because the aborted save was the one that would have
+// written "waiting" -- and the row goes straight back to gray. The key flashes
+// yellow and reverts, however many times it is pressed.
+//
+// This exercises the same sequence as the `u` case in updateInner, minus the
+// tmux session it needs to reach that code.
+func TestMarkUnread_SaveIsNotAbortedByItsOwnWrite(t *testing.T) {
+	h, storage := newHeadlessHomeForTest(t, "_test_mark_unread_save")
+
+	inst := &session.Instance{
+		ID:          "mark-unread-001",
+		Title:       "worker",
+		ProjectPath: "/tmp/mark-unread-proj",
+		GroupPath:   session.DefaultGroupPath,
+		Command:     "claude",
+		Tool:        "claude",
+		Status:      session.StatusIdle,
+		CreatedAt:   time.Now(),
+	}
+	all := []*session.Instance{inst}
+	if err := storage.SaveWithGroups(all, session.NewGroupTree(all)); err != nil {
+		t.Fatalf("seed SaveWithGroups: %v", err)
+	}
+	h.instances = all
+	h.instanceByID[inst.ID] = inst
+	h.groupTree = session.NewGroupTree(all)
+
+	// The TUI's freshness marker as of its last load.
+	loaded, err := storage.GetFileMtime()
+	if err != nil {
+		t.Fatalf("GetFileMtime: %v", err)
+	}
+	h.lastLoadMtime = loaded
+
+	// --- what the `u` key does ---
+	stamps, err := storage.GetDB().SetAcknowledgedStamped(inst.ID, false)
+	if err != nil {
+		t.Fatalf("SetAcknowledgedStamped: %v", err)
+	}
+	if !h.adoptOwnWrite(stamps, "mark_unread") {
+		t.Fatal("adoptOwnWrite refused our own write: nothing else touched this database")
+	}
+	inst.Status = session.StatusWaiting
+	h.saveInstances()
+	// --- end ---
+
+	rows, err := storage.GetDB().LoadInstances()
+	if err != nil {
+		t.Fatalf("LoadInstances: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("LoadInstances returned %d rows, want 1", len(rows))
+	}
+	if rows[0].Status != string(session.StatusWaiting) {
+		t.Errorf("stored status = %q, want %q: the save aborted on this TUI's own acknowledged "+
+			"write, so a reload restores the session as acknowledged (gray) and mark-unread "+
+			"appears to do nothing", rows[0].Status, session.StatusWaiting)
+	}
+}
+
+// The guard must still fire for a real external write. Adopting unconditionally
+// would trade a lost mark-unread for a lost update: this TUI would overwrite
+// whatever the other process changed while it was stale.
+func TestMarkUnread_ForeignWriteStillAbortsTheSave(t *testing.T) {
+	h, storage := newHeadlessHomeForTest(t, "_test_mark_unread_foreign")
+
+	inst := &session.Instance{
+		ID:          "mark-unread-002",
+		Title:       "worker",
+		ProjectPath: "/tmp/mark-unread-proj",
+		GroupPath:   session.DefaultGroupPath,
+		Command:     "claude",
+		Tool:        "claude",
+		Status:      session.StatusIdle,
+		CreatedAt:   time.Now(),
+	}
+	all := []*session.Instance{inst}
+	if err := storage.SaveWithGroups(all, session.NewGroupTree(all)); err != nil {
+		t.Fatalf("seed SaveWithGroups: %v", err)
+	}
+	h.instances = all
+	h.instanceByID[inst.ID] = inst
+	h.groupTree = session.NewGroupTree(all)
+
+	loaded, err := storage.GetFileMtime()
+	if err != nil {
+		t.Fatalf("GetFileMtime: %v", err)
+	}
+	h.lastLoadMtime = loaded
+
+	// Another process writes after we loaded.
+	if err := storage.GetDB().Touch(); err != nil {
+		t.Fatalf("Touch: %v", err)
+	}
+
+	stamps, err := storage.GetDB().SetAcknowledgedStamped(inst.ID, false)
+	if err != nil {
+		t.Fatalf("SetAcknowledgedStamped: %v", err)
+	}
+	if h.adoptOwnWrite(stamps, "mark_unread") {
+		t.Error("adopted the marker past another process's write: the next save would revert " +
+			"whatever that process changed")
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

Pressing `u` (mark unread) on an idle session flashes yellow and then snaps back
to gray. Pressing it again does the same thing. The session stays "read" no
matter how many times you press the key.

## Why this change

The `u` handler clears the acknowledged flag with a targeted write, flips the
in-memory status to waiting, then saves:

```go
tmuxSess.ResetAcknowledged()
db.SetAcknowledged(item.Session.ID, false)   // ends in touchWithRetry()
item.Session.ForceNextStatusCheck()
item.Session.UpdateStatus()                  // -> waiting, in memory
h.saveInstances()
```

`SetAcknowledged` stamps `metadata.last_modified`. `saveInstancesWithForce`
compares `GetFileMtime()` (which *is* `metadata.last_modified` — the file mtime
never moves under WAL, see `storage_mtime_test.go`) against `h.lastLoadMtime`,
so the save reads the bump it just caused as another process's write, aborts,
and calls `TriggerReload()` instead.

The reload replaces `h.instances` wholesale and rehydrates each session through
`ReconnectSessionLazy(..., previousStatus)`, which reconstructs the acknowledged
flag from the stored **status** — still `idle`, precisely because the aborted
save was the one that would have written `waiting`. The row goes back to gray.
The `acknowledged` column the keypress wrote is not consulted at all:
`LoadInstances` does not select it.

Confirmed in the debug log (unfixed build, `u` pressed at 15:39:56):

```
15:39:56.436  DEBUG status  waiting_not_acknowledged  session=unread-probe
15:39:56.436  WARN  ui      save_external_change_detected force=false
                            our_load=15:39:46.459 current_mtime=15:39:56.436
15:40:06.683  DEBUG status  idle_acknowledged         session=unread-probe
```

tmux reported `waiting` correctly; the save aborted on its own bump; ten seconds
later the reload had put it back to `idle_acknowledged`.

This is the same self-inflicted false positive #1868 hit on the restart path, so
it reuses that remedy rather than inventing one: `SetAcknowledgedStamped` returns
the `WriteStamps` identifying its own bump, and `adoptOwnWrite` — extracted from
`adoptRestartRecord`, which now delegates to it — advances `lastLoadMtime` past
it **only** when this TUI was the sole writer since it loaded. A genuine external
write still aborts the save and reloads, unchanged.

Two alternatives I did not take: reordering the save before the ack write cures
this one symptom but leaves the next save aborting on the same stale marker; and
force-saving would push a whole stale snapshot, which is the lost-update shape
the #1868 comment explicitly warns against.

## User impact

`u` marks a session unread and it stays unread. No other behavior changes.

## Evidence

Live before/after on a claude-tool session, isolated `HOME` and tmux socket.
`○` = idle (gray), `◐` = waiting (yellow); counters are the header's
`● active / ◐ waiting / ○ idle` tallies.

```
### BEFORE — origin/main v1.16.4
  DB before:     tool=claude status=idle ack=1
  cursor on:     │ unread-probe  ○ idle
  before u:      row=○ unread-probe   counters:● 0   ◐ 0   ○ 1
  +3s  after u:  row=○ unread-probe   counters:● 0   ◐ 0   ○ 1
  +15s after u:  row=○ unread-probe   counters:● 0   ◐ 0   ○ 1
  DB after:      tool=claude status=idle ack=0      <-- ack cleared, status never moved

### AFTER — this branch
  DB before:     tool=claude status=idle ack=1
  cursor on:     │ unread-probe  ○ idle
  before u:      row=○ unread-probe   counters:● 0   ◐ 0   ○ 1
  +3s  after u:  row=◐ unread-probe   counters:● 0   ◐ 1   ○ 0
  +15s after u:  row=◐ unread-probe   counters:● 0   ◐ 1   ○ 0
  DB after:      tool=claude status=waiting ack=0
```

Regression test `TestMarkUnread_SaveIsNotAbortedByItsOwnWrite` reproduces it
without a TUI. With `adoptOwnWrite` neutered:

```
--- FAIL: TestMarkUnread_SaveIsNotAbortedByItsOwnWrite (0.01s)
    mark_unread_save_test.go:71: stored status = "idle", want "waiting": the save
    aborted on this TUI's own acknowledged write, so a reload restores the session
    as acknowledged (gray) and mark-unread appears to do nothing
```

and with it restored, `ok github.com/asheshgoplani/agent-deck/internal/ui`.
`TestMarkUnread_ForeignWriteStillAbortsTheSave` pins the other direction: a real
external write is still not adopted.

Hot-path note: this adds one `GetFileMtime()` (a single `metadata` SELECT) per
`u` keypress and nothing to the status loop, the list, or startup.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-5

## What actually bothered you

Reported by the user who runs agent-deck as their daily driver, in their words:

> "I am using the feature where I, on the session, click the U letter to make the
> session unread. But for some reason, from time to time, no matter how many times
> I click, it doesn't change the state. It looks like it changed and completely
> reverts it."

They asked me to find out why and fix it. The "from time to time" is real: the
abort fires on every press, but it is only *visible* when the stored status has
already settled to `idle` — press `u` within ~2s of a session going gray, before
the status sweep has persisted `idle`, and the reload happens to restore
`waiting` and it looks like it worked.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` — see the note below; it does not go green on this machine before or after this branch
- [x] If this touches a hot path: before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

Note on the suite: the packages this branch touches are green (`internal/statedb`, `internal/ui`). The full
`go test ./...` run does NOT go green on this machine, before or after this branch.

- Reproduce on unmodified `origin/main` at the same parallelism:
  `TestCLIStoredAccountVisibility` (this box's tmux 3.6a prints a control-mode
  warning to stdout, which breaks `--json` parsing), `TestCheckHealthFreshAndStale`
  (clock/mtime), and the remote/SSH tests.
- Environment-dependent on my checkout specifically: `TestDeepSeekLifecycle_*`,
  `TestTmuxBootstrap_ServerIsRunning`, `TestTestMainDoesNotLeakBootstrapServer`,
  `TestSession_Exists_StaysInBudgetWithAChildHoldingTheOutputDescriptors`. These
  are not attributable to this diff: the same commit passes 3/3 from a worktree
  under `/tmp` and fails 5/5 from my home checkout, and reverting this branch's
  only source change does not fix them. I did not identify the local cause and
  am not claiming one.

https://claude.ai/code/session_018KXZweqKoD9oiLogCKMXkH

<!-- gate:ai=authored model=claude-opus-5 intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Marking an item as unread now reliably preserves the change without triggering an unnecessary reload.
  * Updates made by the current session are correctly recognized, preventing the save from being abandoned.
  * Changes made by another process remain protected and are not overwritten during a mark-unread operation.

* **Reliability**
  * Improved handling of concurrent updates when saving acknowledgment changes.
  * Acknowledgment updates now retry safely when the database is busy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->