### PR TITLE
fix(launch): report spawn death when pane dies before message delivery

### DIFF
--- a/cmd/agent-deck/issue2215_spawn_died_send_error_test.go
+++ b/cmd/agent-deck/issue2215_spawn_died_send_error_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Issue #2215: when a pane dies before the -m message is delivered, launch
+// reported the paste-buffer transport fault ("delivery is indeterminate and
+// must not be retried") instead of the spawn death that is already recorded in
+// the spawn-failure sidecar.
+//
+// sendErrOrSpawnDied selects the right error based on pane state and the
+// presence of a spawn-failure record. These tests cover all three branches.
+
+var pasteBufferErr = errors.New("paste-buffer failed after writing to the pane, delivery is indeterminate and must not be retried: exit status 1")
+
+// TestIssue2215_PaneAliveKeepsOriginalError: when the pane is still alive the
+// paste-buffer error is the correct diagnosis; leave it unchanged.
+func TestIssue2215_PaneAliveKeepsOriginalError(t *testing.T) {
+	result := sendErrOrSpawnDied(pasteBufferErr, false /* paneGone */, nil)
+	if result != pasteBufferErr {
+		t.Fatalf("pane alive: want original error unchanged, got %v", result)
+	}
+}
+
+// TestIssue2215_PaneGoneNoRecordKeepsOriginalError: if the pane is gone but
+// there is no spawn-failure record, keep the original error so the operator
+// still has something actionable.
+func TestIssue2215_PaneGoneNoRecordKeepsOriginalError(t *testing.T) {
+	result := sendErrOrSpawnDied(pasteBufferErr, true /* paneGone */, nil)
+	if result != pasteBufferErr {
+		t.Fatalf("pane gone but no record: want original error, got %v", result)
+	}
+}
+
+// TestIssue2215_PaneGoneWithRecordReportsSpawnDeath: the main regression case.
+// When the pane died and a spawn-failure record exists, the error must name
+// the spawn death (with reason and elapsed_ms) and must NOT say "indeterminate"
+// or "must not be retried" -- delivery definitively did not happen.
+func TestIssue2215_PaneGoneWithRecordReportsSpawnDeath(t *testing.T) {
+	rec := &session.SpawnFailureRecord{
+		Reason:    "spawn_died_fast",
+		ElapsedMs: 256,
+	}
+	result := sendErrOrSpawnDied(pasteBufferErr, true /* paneGone */, rec)
+
+	if result == nil {
+		t.Fatal("expected non-nil error")
+	}
+	msg := result.Error()
+
+	if !strings.Contains(msg, "spawn_died_fast") {
+		t.Errorf("error must include spawn reason; got: %q", msg)
+	}
+	if !strings.Contains(msg, "256") {
+		t.Errorf("error must include elapsed_ms; got: %q", msg)
+	}
+	if !strings.Contains(msg, "did not happen") {
+		t.Errorf("error must say delivery did not happen; got: %q", msg)
+	}
+	if strings.Contains(msg, "indeterminate") {
+		t.Errorf("error must not say 'indeterminate' when pane died; got: %q", msg)
+	}
+	if strings.Contains(msg, "must not be retried") {
+		t.Errorf("error must not block relaunch with 'must not be retried'; got: %q", msg)
+	}
+}

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -747,7 +747,15 @@ func handleLaunch(profile string, args []string) {
 				tool:                        newInstance.Tool,
 				composerPasteFreeBeforeSend: pasteFreeBeforeSend,
 			}); err != nil {
-				out.Error(fmt.Sprintf("failed to send initial message: %v", err), ErrCodeInvalidOperation)
+				// Check whether the pane died before delivery was attempted.
+				// When it did, the paste-buffer failure is a symptom of the
+				// dead pane, not a transport fault. The spawn-failure sidecar
+				// already has the real cause, so report that instead and make
+				// it clear delivery definitively did not happen (not
+				// indeterminate).
+				paneGone := !tmuxSess.Exists() || tmuxSess.IsPaneDead()
+				out.Error(fmt.Sprintf("failed to send initial message: %v",
+					sendErrOrSpawnDied(err, paneGone, newInstance.SpawnFailure())), ErrCodeInvalidOperation)
 				os.Exit(1)
 			}
 			verifyPromptConsumedAfterLaunchAttributed(
@@ -851,4 +859,19 @@ func resolveLaunchPath(rawPathArg, groupSelector, profile string) (string, error
 	}
 
 	return os.Getwd()
+}
+
+// sendErrOrSpawnDied returns a clear "pane exited before delivery" error when
+// the send failure is explained by the pane having died (paneGone is true and
+// a spawn-failure record exists). In that case the paste-buffer error is a
+// symptom of the dead pane, not a transport fault, and the "delivery is
+// indeterminate" wording is wrong: delivery definitively did not happen.
+//
+// When the pane is still alive, or when no spawn-failure record is available,
+// the original send error is returned unchanged.
+func sendErrOrSpawnDied(sendErr error, paneGone bool, rec *session.SpawnFailureRecord) error {
+	if !paneGone || rec == nil {
+		return sendErr
+	}
+	return fmt.Errorf("pane exited before delivery (reason: %s, elapsed_ms: %d); delivery did not happen", rec.Reason, rec.ElapsedMs)
 }


### PR DESCRIPTION
## What problem does this solve?

When `launch -m --no-wait` fails to deliver the initial message because the pane died before delivery, the error blamed the paste-buffer transport layer with "delivery is indeterminate and must not be retried." That misleads investigation toward tmux transport and falsely blocks the one safe recovery action: relaunching. The pane had already exited before delivery was attempted; the spawn-failure sidecar already recorded the real cause.

## Why this change

The paste-buffer error text implied two things that were both wrong: that the message may or may not have been received (directing investigation at tmux), and that retrying is unsafe (blocking relaunch). In reality the pane died before delivery, so the message definitely was not received and relaunch is the correct response. The fix classifies the pane-death case and surfaces the spawn failure reason instead.

## User impact

A `launch -m --no-wait` failure on a dead pane now says "pane exited before delivery (reason: spawn_died_fast, elapsed_ms: 256); delivery did not happen" rather than a paste-buffer error. The operator sees the right cause immediately and knows relaunch is safe.

## Summary

- When `launch -m` fails to deliver the initial message because the pane died, the error now reports the spawn death (reason and elapsed_ms from the existing spawn-failure sidecar) instead of the misleading paste-buffer transport fault.
- When the pane is still alive, the original paste-buffer error is kept unchanged.
- The check is extracted into a small helper (`sendErrOrSpawnDied`) so the branch logic is unit-testable without tmux.

## Motivation

The previous message ("paste-buffer failed after writing to the pane, delivery is indeterminate and must not be retried") implied:

1. The message may or may not have been received -- directing investigation at the tmux transport.
2. Retrying is unsafe -- blocking the one safe recovery action (relaunch).

In reality the pane died before delivery was attempted; the spawn-failure sidecar already recorded the true cause. The new message says "pane exited before delivery (reason: spawn_died_fast, elapsed_ms: 256); delivery did not happen" -- which names the right subsystem and removes the false relaunch block.

## Test plan

- [x] `TestIssue2215_PaneAliveKeepsOriginalError`: pane alive, original paste-buffer error returned unchanged.
- [x] `TestIssue2215_PaneGoneNoRecordKeepsOriginalError`: pane gone but no spawn-failure record, original error kept.
- [x] `TestIssue2215_PaneGoneWithRecordReportsSpawnDeath`: pane gone with a `spawn_died_fast` record, new error includes reason and elapsed_ms, does not say "indeterminate" or "must not be retried", says "did not happen".

Fixes #2215

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s):** claude-sonnet-4-6

## What actually bothered you

The human asked: fix GitHub issue #2215 in asheshgoplani/agent-deck -- the `--no-wait` launch error message blamed the paste-buffer transport when the pane was already dead, blocking relaunch and hiding the real failure reason.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] Allow edits from maintainers is enabled