### PR TITLE
fix: recover from poisoned tmux server cwd via cd-assert retry

### DIFF
--- a/internal/tmux/issue2214_pane_cwd_assert_test.go
+++ b/internal/tmux/issue2214_pane_cwd_assert_test.go
@@ -1,0 +1,195 @@
+package tmux
+
+// Regression tests for #2214: every pane inherits the tmux server's cwd
+// instead of the session's project dir.
+//
+// Root cause (extends #1713): even when -c points at a valid directory, a tmux
+// server whose own cwd has been deleted births every new pane in that dead
+// directory. The pane's shell prints
+//
+//	shell-init: error retrieving current directory: getcwd: ...
+//
+// and the agent exits in ~256 ms. SpawnBaseDir ("/") prevents this for servers
+// agent-deck starts, but an external server started before the fix was deployed
+// (or by another tool) remains poisoned indefinitely, failing every spawn.
+//
+// Fix (workdir_guard.go): when verifyPaneWorkDir returns ErrPaneCwdDeleted,
+// retry the spawn once with the command wrapped so the pane asserts its own
+// directory:
+//
+//	/bin/sh -c 'cd -- <project dir> && <original command>'
+//
+// The shell builtin cd bypasses the inherited dead vnode and puts the agent in
+// the right tree. Traps avoided:
+//   - "exec"-prefixed commands: cd is a builtin inside /bin/sh; the outer exec
+//     is never parsed as the top-level statement.
+//   - Worktree sessions: the dir passed to wrapCommandForCwdAssert is already
+//     the final resolved path (worktrees are resolved before Start() is called).
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- wrapCommandForCwdAssert -------------------------------------------------
+
+func TestWrapCommandForCwdAssert_PlainPathAndCommand(t *testing.T) {
+	got := wrapCommandForCwdAssert("/home/user/project", "claude --session-id abc")
+	assert.Equal(t, "/bin/sh -c 'cd -- /home/user/project && claude --session-id abc'", got)
+}
+
+func TestWrapCommandForCwdAssert_ExecPrefixedCommand(t *testing.T) {
+	// "exec"-prefixed commands were the original trap (#2214): `exec cd '<dir>'`
+	// execs a binary named "cd" and exits 127. Inside /bin/sh -c the exec is a
+	// shell builtin, so `cd` is also a builtin and the sequence works correctly.
+	got := wrapCommandForCwdAssert("/project", "exec claude --resume 91fd7978")
+	assert.Equal(t, "/bin/sh -c 'cd -- /project && exec claude --resume 91fd7978'", got)
+}
+
+func TestWrapCommandForCwdAssert_EmptyCommand(t *testing.T) {
+	// An empty command (shell sessions) must produce a valid /bin/sh invocation
+	// that just changes directory. The shell exits 0 after the cd.
+	got := wrapCommandForCwdAssert("/project", "")
+	assert.Equal(t, "/bin/sh -c 'cd -- /project'", got)
+}
+
+func TestWrapCommandForCwdAssert_SingleQuoteInDir(t *testing.T) {
+	// Paths containing single quotes must be embedded safely.
+	got := wrapCommandForCwdAssert("/path/to/it's project", "claude")
+	// Single quotes are escaped as '"'"': it's -> it'"'"'s
+	assert.Contains(t, got, "/bin/sh -c '")
+	assert.Contains(t, got, "it'\"'\"'s")
+	assert.Contains(t, got, "claude")
+}
+
+func TestWrapCommandForCwdAssert_SingleQuoteInCommand(t *testing.T) {
+	got := wrapCommandForCwdAssert("/project", "bash -c 'stty susp undef; claude'")
+	assert.Contains(t, got, "/bin/sh -c '")
+	assert.Contains(t, got, "/project")
+	// The single quotes inside the command must be escaped.
+	assert.NotContains(t, got, "stty susp undef; claude'", "unescaped inner single quote would break the outer shell string")
+}
+
+func TestWrapCommandForCwdAssert_PathWithSpaces(t *testing.T) {
+	// Spaces in directory paths are valid and must survive the embedding.
+	got := wrapCommandForCwdAssert("/home/user/my project", "claude")
+	assert.Equal(t, "/bin/sh -c 'cd -- /home/user/my project && claude'", got)
+}
+
+// --- recovery in Start() when server is poisoned (#2214) --------------------
+
+// TestStart_RetriesWithCwdAssertOnPoisonedServer verifies that when the first
+// spawn lands in a deleted cwd (poisoned server), Start() retries once with a
+// command that explicitly cds into the project directory. The second pane probe
+// returns a valid directory, so Start() succeeds instead of failing.
+func TestStart_RetriesWithCwdAssertOnPoisonedServer(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+
+	workDir := t.TempDir()
+	deleted := filepath.Join(t.TempDir(), "server-cwd")
+	require.NoError(t, os.Mkdir(deleted, 0o755))
+	require.NoError(t, os.RemoveAll(deleted))
+
+	// Probe sequence: first call returns the deleted path (simulating a poisoned
+	// server on the first spawn), subsequent calls return the good workDir (the
+	// cd-wrapped retry landed correctly).
+	probeCallCount := 0
+	prev := panePathProbe
+	prevDelay := paneCwdRecheckDelay
+	panePathProbe = func(*Session) (string, error) {
+		probeCallCount++
+		// paneCwdProbeAttempts = 3 re-probes per verifyPaneWorkDir call.
+		// The first three probes belong to the first attempt; everything after
+		// that belongs to the retry.
+		if probeCallCount <= paneCwdProbeAttempts {
+			return deleted, nil
+		}
+		return workDir, nil
+	}
+	paneCwdRecheckDelay = 0
+	t.Cleanup(func() {
+		panePathProbe = prev
+		paneCwdRecheckDelay = prevDelay
+	})
+
+	socket := privateSocketName2214(t)
+	s := &Session{
+		Name:        "agentdeck_2214_retry",
+		DisplayName: "retry-cwd-assert",
+		SocketName:  socket,
+		WorkDir:     workDir,
+	}
+
+	err := s.Start("")
+
+	require.NoError(t, err, "Start must succeed when the retry with cd-assert lands in the right directory")
+	assert.True(t, s.Exists(), "the session must be alive after the successful retry")
+	t.Cleanup(func() { _ = s.Kill() })
+
+	// The wrapped command must reference the project dir.
+	assert.Contains(t, s.Command, workDir,
+		"Start must store the cwd-assert wrapped command so Restart uses the same safe form")
+}
+
+// TestStart_PropagatesErrorWhenRetryAlsoFails verifies that when both the
+// initial spawn and the cwd-assert retry land in a deleted directory, Start()
+// still returns ErrPaneCwdDeleted and leaves no live session behind.
+func TestStart_PropagatesErrorWhenRetryAlsoFails(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+
+	workDir := t.TempDir()
+	deleted := filepath.Join(t.TempDir(), "server-cwd")
+	require.NoError(t, os.Mkdir(deleted, 0o755))
+	require.NoError(t, os.RemoveAll(deleted))
+
+	// All probe calls return the deleted path — the retry also fails.
+	stubPanePathProbe(t, deleted)
+
+	socket := privateSocketName2214(t)
+	s := &Session{
+		Name:        "agentdeck_2214_fail",
+		DisplayName: "retry-also-fails",
+		SocketName:  socket,
+		WorkDir:     workDir,
+	}
+
+	err := s.Start("")
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrPaneCwdDeleted))
+	assert.False(t, s.Exists(), "no broken session must be left behind after a failed retry")
+}
+
+// TestWrapCommandForCwdAssert_IsRoundTrippable verifies that the shell string
+// produced by wrapCommandForCwdAssert is parseable by /bin/sh. It runs
+// `sh -c <wrapped>` and checks the exit code. A malformed quoting would cause
+// a parse error and non-zero exit.
+func TestWrapCommandForCwdAssert_IsRoundTrippable(t *testing.T) {
+	dir := t.TempDir()
+	// The command just exits 0.
+	wrapped := wrapCommandForCwdAssert(dir, "true")
+	// sh -c interprets the wrapped string.
+	assert.True(t, strings.HasPrefix(wrapped, "/bin/sh -c '"),
+		"wrapper must always start with /bin/sh -c '")
+}
+
+// --- helpers -----------------------------------------------------------------
+
+func privateSocketName2214(t *testing.T) string {
+	t.Helper()
+	socket := "ad2214-" + strings.NewReplacer("/", "-", " ", "-").Replace(t.Name())
+	if len(socket) > 40 {
+		socket = socket[:40]
+	}
+	kill := func() { _ = exec.Command("tmux", "-L", socket, "kill-server").Run() }
+	kill()
+	t.Cleanup(kill)
+	return socket
+}

--- a/internal/tmux/issue2214_pane_cwd_assert_test.go
+++ b/internal/tmux/issue2214_pane_cwd_assert_test.go
@@ -42,7 +42,7 @@ import (
 
 func TestWrapCommandForCwdAssert_PlainPathAndCommand(t *testing.T) {
 	got := wrapCommandForCwdAssert("/home/user/project", "claude --session-id abc")
-	assert.Equal(t, "/bin/sh -c 'cd -- /home/user/project && claude --session-id abc'", got)
+	assert.Equal(t, `/bin/sh -c 'cd -- "/home/user/project" && claude --session-id abc'`, got)
 }
 
 func TestWrapCommandForCwdAssert_ExecPrefixedCommand(t *testing.T) {
@@ -50,14 +50,14 @@ func TestWrapCommandForCwdAssert_ExecPrefixedCommand(t *testing.T) {
 	// execs a binary named "cd" and exits 127. Inside /bin/sh -c the exec is a
 	// shell builtin, so `cd` is also a builtin and the sequence works correctly.
 	got := wrapCommandForCwdAssert("/project", "exec claude --resume 91fd7978")
-	assert.Equal(t, "/bin/sh -c 'cd -- /project && exec claude --resume 91fd7978'", got)
+	assert.Equal(t, `/bin/sh -c 'cd -- "/project" && exec claude --resume 91fd7978'`, got)
 }
 
 func TestWrapCommandForCwdAssert_EmptyCommand(t *testing.T) {
 	// An empty command (shell sessions) must produce a valid /bin/sh invocation
 	// that just changes directory. The shell exits 0 after the cd.
 	got := wrapCommandForCwdAssert("/project", "")
-	assert.Equal(t, "/bin/sh -c 'cd -- /project'", got)
+	assert.Equal(t, `/bin/sh -c 'cd -- "/project"'`, got)
 }
 
 func TestWrapCommandForCwdAssert_SingleQuoteInDir(t *testing.T) {
@@ -73,14 +73,19 @@ func TestWrapCommandForCwdAssert_SingleQuoteInCommand(t *testing.T) {
 	got := wrapCommandForCwdAssert("/project", "bash -c 'stty susp undef; claude'")
 	assert.Contains(t, got, "/bin/sh -c '")
 	assert.Contains(t, got, "/project")
-	// The single quotes inside the command must be escaped.
-	assert.NotContains(t, got, "stty susp undef; claude'", "unescaped inner single quote would break the outer shell string")
+	// The single quotes inside the command must be escaped with '"'"'.
+	// Check that the escaped form of the opening quote appears ('"'"'stty...) and
+	// that the raw unescaped opening sequence bash -c 'stty is not present.
+	assert.Contains(t, got, `'"'"'stty`, "inner single quote must use the end-quote/literal/reopen escape")
+	assert.NotContains(t, got, "bash -c 'stty", "unescaped inner single quote would break the outer shell string")
 }
 
 func TestWrapCommandForCwdAssert_PathWithSpaces(t *testing.T) {
 	// Spaces in directory paths are valid and must survive the embedding.
+	// The dir is double-quoted inside the inner sh script so the space is not
+	// treated as a word boundary by the shell.
 	got := wrapCommandForCwdAssert("/home/user/my project", "claude")
-	assert.Equal(t, "/bin/sh -c 'cd -- /home/user/my project && claude'", got)
+	assert.Equal(t, `/bin/sh -c 'cd -- "/home/user/my project" && claude'`, got)
 }
 
 // --- recovery in Start() when server is poisoned (#2214) --------------------
@@ -178,6 +183,12 @@ func TestWrapCommandForCwdAssert_IsRoundTrippable(t *testing.T) {
 	// sh -c interprets the wrapped string.
 	assert.True(t, strings.HasPrefix(wrapped, "/bin/sh -c '"),
 		"wrapper must always start with /bin/sh -c '")
+	// Actually execute it: pass the entire wrapped string to sh -c so the outer
+	// shell parses the quoting, then runs /bin/sh -c '<inner>'. Exit code 0 means
+	// both the quoting was syntactically valid and cd succeeded.
+	cmd := exec.Command("sh", "-c", wrapped)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "wrapped command must execute without error (output: %s)", out)
 }
 
 // --- helpers -----------------------------------------------------------------

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2463,13 +2463,50 @@ func (s *Session) Start(command string) error {
 	// already be poisoned, so confirm where the pane actually landed. Reporting
 	// such a session as started is the exact "looked created, never ran the
 	// agent" failure from the report — tear it down and say why instead.
+	//
+	// #2214: when the pane IS born in a deleted cwd (poisoned server), killing
+	// and returning the error is not the end of the story. The pane's shell
+	// landed in a dead directory because the server ignored -c; but the target
+	// directory itself is fine. Rather than surfacing an unrecoverable error,
+	// retry once with the command wrapped so the pane asserts its own directory:
+	//   /bin/sh -c 'cd -- <dir> && <original command>'
+	// The shell builtin cd bypasses the inherited dead vnode and puts the agent
+	// in the right tree. This pattern survives "exec "-prefixed commands because
+	// cd is a builtin inside the /bin/sh wrapper, not an external binary.
 	if cwdErr := s.verifyPaneWorkDirUnlessPlaceholder(workDir); cwdErr != nil {
 		if killErr := s.Kill(); killErr != nil {
 			statusLog.Warn("deleted_cwd_session_cleanup_failed",
 				slog.String("session", logging.SanitizeValue(s.Name)),
 				slog.String("error", killErr.Error()))
 		}
-		return cwdErr
+		if !errors.Is(cwdErr, ErrPaneCwdDeleted) {
+			return cwdErr
+		}
+		// Poisoned server: retry once with a cd-wrapped command (#2214).
+		statusLog.Warn("tmux_start_retry_cwd_assert",
+			slog.String("session", logging.SanitizeValue(s.Name)),
+			slog.String("workdir", logging.SanitizeValue(workDir)),
+			slog.String("issue", "2214"))
+		wrappedCommand := wrapCommandForCwdAssert(workDir, command)
+		s.Command = wrappedCommand
+		if s.Exists() {
+			sanitized := sanitizeName(s.DisplayName)
+			s.Name = SessionPrefix + sanitized + "_" + generateShortID()
+		}
+		retryLauncher, retryArgs := s.startCommandSpec(workDir, wrappedCommand)
+		retryOutput, retryErr := newSpawnCommand(retryLauncher, retryArgs...).CombinedOutput()
+		if retryErr != nil {
+			return fmt.Errorf("failed to create tmux session (cwd-assert retry): %w (output: %s)", retryErr, string(retryOutput))
+		}
+		registerSessionInCache(s.Name)
+		if verifyCwdErr := s.verifyPaneWorkDirUnlessPlaceholder(workDir); verifyCwdErr != nil {
+			if killErr := s.Kill(); killErr != nil {
+				statusLog.Warn("deleted_cwd_session_cleanup_failed",
+					slog.String("session", logging.SanitizeValue(s.Name)),
+					slog.String("error", killErr.Error()))
+			}
+			return verifyCwdErr
+		}
 	}
 
 	// PERFORMANCE: Batch all session options into a single subprocess call.

--- a/internal/tmux/workdir_guard.go
+++ b/internal/tmux/workdir_guard.go
@@ -343,3 +343,29 @@ func deletedPaneCwdError(socketName, workDir, panePath string) error {
 			"them (issue #1713)",
 		ErrPaneCwdDeleted, panePath, workDir, socketLabel(socketName), SpawnBaseDir)
 }
+
+// wrapCommandForCwdAssert wraps cmd so the pane changes into dir before running
+// the original command. This is the recovery path for issue #2214: when a tmux
+// server's own cwd has been deleted, tmux ignores the -c start directory for
+// every new pane. Passing -c <good dir> does not rescue the child because the
+// pane inherits the server's dead vnode before the new-session call can chdir
+// it. Having the command itself cd into the project directory works because the
+// shell builtin cd operates on the filesystem directly, bypassing the broken
+// cwd the pane was born in.
+//
+// /bin/sh is used rather than the user's login shell so the wrapper is available
+// on every POSIX platform. The outer bash -c layer from startCommandSpec is not
+// involved in the cd: bash forks /bin/sh, which cds, then execs the original
+// command (even when that command starts with "exec ").
+func wrapCommandForCwdAssert(dir, cmd string) string {
+	// Escape single quotes for safe embedding inside a single-quoted string.
+	// Pattern: end quote, escaped literal quote, restart quote.
+	// Example: it's -> it'"'"'s
+	escapedDir := strings.ReplaceAll(dir, "'", "'\"'\"'")
+	inner := "cd -- " + escapedDir
+	if cmd != "" {
+		escapedCmd := strings.ReplaceAll(cmd, "'", "'\"'\"'")
+		inner += " && " + escapedCmd
+	}
+	return "/bin/sh -c '" + inner + "'"
+}

--- a/internal/tmux/workdir_guard.go
+++ b/internal/tmux/workdir_guard.go
@@ -358,11 +358,26 @@ func deletedPaneCwdError(socketName, workDir, panePath string) error {
 // involved in the cd: bash forks /bin/sh, which cds, then execs the original
 // command (even when that command starts with "exec ").
 func wrapCommandForCwdAssert(dir, cmd string) string {
-	// Escape single quotes for safe embedding inside a single-quoted string.
-	// Pattern: end quote, escaped literal quote, restart quote.
-	// Example: it's -> it'"'"'s
-	escapedDir := strings.ReplaceAll(dir, "'", "'\"'\"'")
-	inner := "cd -- " + escapedDir
+	// dir is embedded as a double-quoted token inside the inner /bin/sh script so
+	// that paths containing spaces are treated as a single argument by cd.
+	//
+	// Two-pass escaping:
+	//   Pass 1 — double-quote context: escape \, $, `, and " so they are not
+	//            interpreted by the inner shell when dir is wrapped in "...".
+	//            Single quotes are literal inside double quotes and need no escaping
+	//            at this level.
+	//   Pass 2 — outer single-quote context: the entire inner script is wrapped in
+	//            '...' for the /bin/sh -c invocation. Any single quote surviving
+	//            from pass 1 would break that wrapping, so escape them with the
+	//            standard '"'"' pattern.
+	dirDQ := dir
+	dirDQ = strings.ReplaceAll(dirDQ, `\`, `\\`)
+	dirDQ = strings.ReplaceAll(dirDQ, `$`, `\$`)
+	dirDQ = strings.ReplaceAll(dirDQ, "`", "\\`")
+	dirDQ = strings.ReplaceAll(dirDQ, `"`, `\"`)
+	dirForShell := strings.ReplaceAll(dirDQ, "'", "'\"'\"'")
+
+	inner := `cd -- "` + dirForShell + `"`
 	if cmd != "" {
 		escapedCmd := strings.ReplaceAll(cmd, "'", "'\"'\"'")
 		inner += " && " + escapedCmd


### PR DESCRIPTION
## What problem does this solve?

Every pane spawned on a tmux server whose own cwd has been deleted inherits that dead directory. The existing #1713 guard detects this (ErrPaneCwdDeleted) and tears the session down, but then returns an unrecoverable error even though the target project directory is healthy. The result: every agent-deck launch / session start fails until the tmux server is restarted, which kills all live sessions. Fixes #2214.

## Why this change

tmux's -c flag does not rescue panes when the server itself holds a deleted cwd. The server ignores -c in that state and every new pane inherits the dead vnode. Wrapping the launched command as /bin/sh -c 'cd -- dir && original command' bypasses this: the shell builtin cd operates on the filesystem directly, not on the inherited vnode, and the agent lands in the right directory.

The retry is a one-shot recovery inside Session.Start: detect ErrPaneCwdDeleted, kill the broken pane, retry with the cd-wrapped command, verify again. If the retry also fails, the existing error is propagated unchanged.

## User impact

Sessions that previously failed with spawn_died_fast / 256 ms on a poisoned tmux server now start correctly. No change to behavior for healthy servers.

## Evidence

Behavior change is covered by the new test TestStart_RetriesWithCwdAssertOnPoisonedServer: the pane probe returns a deleted path on the first three probes (simulating a poisoned server), then returns the valid workDir on the retry, and Start() succeeds instead of failing. The test TestStart_PropagatesErrorWhenRetryAlsoFails verifies that a truly broken server (both attempts fail) still returns ErrPaneCwdDeleted and leaves no live session behind.

Unit tests for wrapCommandForCwdAssert cover plain paths, exec-prefixed commands, empty commands, paths and commands with single quotes, and paths with spaces.

## AI disclosure
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-sonnet-4-6

## What actually bothered you

The human asked: fix GitHub issue #2214 in asheshgoplani/agent-deck -- every pane inherits the tmux server's cwd instead of the session's project dir, so a server started in a since-removed worktree kills every spawn in ~256ms.

## Checklist
- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] Allow edits from maintainers is enabled

<!-- gate:ai=authored model=claude-sonnet-4-6 intent=yes -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session startup when the tmux server is associated with a deleted working directory.
  * Automatically retries once using the requested working directory when the initial pane starts in an invalid location.
  * Preserves commands and working directories containing spaces or special characters during recovery.
  * Reports a clear error and cleans up the session if the retry also fails.
* **Tests**
  * Added coverage for working-directory recovery, command handling, quoting, and retry scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->