### PR TITLE
fix(tmux): stop treating pi's line-leading "→" as a busy marker

### DIFF
--- a/internal/tmux/patterns.go
+++ b/internal/tmux/patterns.go
@@ -155,10 +155,17 @@ func DefaultRawPatterns(toolName string) *RawPatterns {
 				// when subagents are actively running. These patterns are
 				// specific enough to NOT match the idle status bar or
 				// package-update banners.
+				//
+				// Deliberately NO line-leading "→" pattern: markdown
+				// nests/continues assistant prose with a bare arrow, and a
+				// finished answer stays on screen, so an idle session whose
+				// final message contained "    → ..." bullet lines matched
+				// busy forever (instance stuck "running"). Genuine pi
+				// subagent work is covered by the markers below and by the
+				// "Working" spinner detection.
 				"delegate_task",
 				`re:(?m)^\[subagent\]`,
 				`re:(?m)^\[running\]`,
-				`re:(?m)^\s*→\s`,
 			},
 			PromptPatterns: []string{`re:(?m)^\s*pi>\s*`},
 			SpinnerChars:   []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"},

--- a/internal/tmux/patterns_test.go
+++ b/internal/tmux/patterns_test.go
@@ -165,11 +165,18 @@ func TestDefaultRawPatterns_PiSubagentSignals(t *testing.T) {
 		"delegate_task agent=researcher",
 		"[subagent] researching",
 		"[running] subagent-1",
-		"  → delegated task",
 	} {
 		if !matchesBusy(content) {
 			t.Errorf("active Pi subagent marker was not detected: %q", content)
 		}
+	}
+
+	// Assistant markdown nests/continues prose with a bare line-leading
+	// "→". Those lines remain visible after the turn ends, so treating
+	// them as subagent activity pinned a finished, idle session at
+	// "running" indefinitely. A line-leading arrow must NOT be busy.
+	if matchesBusy("Two committed files:\n1. migration.org\n    → renames the platform row\n2. help.org\n    → adds a paragraph") {
+		t.Fatal("assistant markdown arrow bullets must not mark an idle Pi session busy")
 	}
 }
 


### PR DESCRIPTION
## Problem

A pi session that has **finished** its work stays `running` (green) forever when its final answer contains markdown arrow bullets.

Agent Deck derives pi status from the tmux pane (pi emits no lifecycle hook files). The busy scanner only inspects the **last 25 lines**, and a matched busy pattern is **authoritative**. A completed turn's answer stays on screen, so lines like

```
1. migration.org
    → renames the platform row
```

keep matching the pi busy regex `re:(?m)^\s*→\s`. The instance never settles to `waiting`, and its `last_activity_at` keeps refreshing. Other idle pi sessions (whose answers have no arrow bullets) correctly show `waiting`, which makes it look intermittent.

## Root cause

The arrow pattern came from 157d2e6f ("fix: pi subagent status detection + running to waiting debounce fix"), where the over-broad `"subagent"` string — it matched `pi-subagents` in package-update banners — was replaced with four "specific" markers, including the bare arrow. That replacement has the same over-matching flaw:

- assistant markdown nests/continues prose with a bare line-leading `→`;
- pi and pi-subagents use `→` only as a **model-selection cursor** (`isSelected ? "→ " : "  "`) and as a **fallback-chain separator** (`.join(" → ")`) — never as a running-status marker.

So the pattern cannot tell a live subagent marker from an old answer.

## Fix

Drop the `re:(?m)^\s*→\s` busy pattern. Genuine subagent activity stays covered by `delegate_task` / `[subagent]` / `[running]` and by the `"Working"` spinner-banner detection (whole-pane scan).

Adds a regression test asserting assistant arrow bullets are not busy.

## Verification

- RED against the old pattern: `regexp.MustCompile("(?m)^\\s*→\\s").MatchString("...\n    → renames the platform row\n...")` → `true`
- GREEN after the change; `go test ./internal/tmux/` passes.

## Follow-up (not in this PR)

More generally, a content-pattern match on an **unchanging** pane can hold a non-hook session green indefinitely. Bounding that re-check (e.g. requiring fresh pane activity before re-affirming busy) would harden every non-hook tool, not just pi.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where idle sessions could incorrectly appear busy when completed assistant responses contained indented arrow-style bullet lines.
  * Busy-state detection continues to recognize active subagent work and working indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->