### PR TITLE
fix(session): preserve distinct Codex completion turns

### DIFF
--- a/internal/session/codex_turn_identity_test.go
+++ b/internal/session/codex_turn_identity_test.go
@@ -1,0 +1,223 @@
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCodexDistinctCompletedTurnsReachInboxWithinShortWindow(t *testing.T) {
+	inboxTestHome(t)
+	profile := "_test-codex-turn-identity"
+	now := time.Unix(1_780_000_000, 0)
+	parentID := "parent-codex-turns"
+	child := &Instance{
+		ID:              "child-codex-turns",
+		Title:           "codex-worker",
+		ProjectPath:     "/tmp/codex-worker",
+		GroupPath:       DefaultGroupPath,
+		ParentSessionID: parentID,
+		Tool:            "codex",
+		Status:          StatusWaiting,
+		CreatedAt:       now,
+		CodexSessionID:  "thread-1",
+	}
+	parent := &Instance{
+		ID:          parentID,
+		Title:       "orchestrator",
+		ProjectPath: "/tmp/parent",
+		GroupPath:   DefaultGroupPath,
+		Tool:        "claude",
+		Status:      StatusRunning,
+		CreatedAt:   now,
+	}
+	storage, err := NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("storage: %v", err)
+	}
+	defer storage.Close()
+	if err := storage.SaveWithGroups([]*Instance{child, parent}, nil); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	d := NewTransitionDaemon()
+	d.turnLiveCheck = func(*Instance) bool { return true }
+	d.notifier.wake = nil
+
+	setCompletedCodexTurnForTest(child, "thread-1", "turn-a")
+	d.recordTerminalTurns(profile, map[string]*Instance{child.ID: child}, map[string]string{child.ID: "waiting"}, nil)
+	first, err := DrainInboxForParent(parentID)
+	if err != nil {
+		t.Fatalf("drain turn A: %v", err)
+	}
+	if len(first) != 1 {
+		t.Fatalf("turn A delivered %d records, want 1", len(first))
+	}
+	if first[0].LastOutputHash != "codex:thread-1:turn-a" {
+		t.Fatalf("turn A identity = %q, want %q", first[0].LastOutputHash, "codex:thread-1:turn-a")
+	}
+
+	// Turn B has the same child, status, and user-visible transition as turn A,
+	// and completes well inside the legacy 90-second window. Its validated Codex
+	// turn id is the only reliable evidence that this is a new completion.
+	setCompletedCodexTurnForTest(child, "thread-1", "turn-b")
+	d.recordTerminalTurns(profile, map[string]*Instance{child.ID: child}, map[string]string{child.ID: "waiting"}, nil)
+	second, err := DrainInboxForParent(parentID)
+	if err != nil {
+		t.Fatalf("drain turn B: %v", err)
+	}
+	if len(second) != 1 {
+		t.Fatalf("distinct turn B inside 90 seconds delivered %d records, want 1", len(second))
+	}
+	if second[0].LastOutputHash != "codex:thread-1:turn-b" {
+		t.Fatalf("turn B identity = %q, want %q", second[0].LastOutputHash, "codex:thread-1:turn-b")
+	}
+
+	// A daemon restart must not replay turn B. The notifier reloads its durable
+	// state and still suppresses a same-turn retry after the short window.
+	restarted := NewTransitionNotifier()
+	restarted.wake = nil
+	retry := TransitionNotificationEvent{
+		ChildSessionID: child.ID,
+		ChildTitle:     child.Title,
+		Profile:        profile,
+		FromStatus:     "running",
+		ToStatus:       "waiting",
+		Timestamp:      second[0].Timestamp.Add(91 * time.Second),
+		LastOutputHash: transitionEventOutputHash(child),
+	}
+	got := restarted.NotifyTransition(retry)
+	if got.DeliveryResult != transitionDeliveryDropped {
+		t.Fatalf("same turn after daemon restart = %q, want deduped drop", got.DeliveryResult)
+	}
+	third, err := DrainInboxForParent(parentID)
+	if err != nil {
+		t.Fatalf("drain retried turn B: %v", err)
+	}
+	if len(third) != 0 {
+		t.Fatalf("same turn B replay delivered %d records after restart, want 0", len(third))
+	}
+
+	// Once the producer's output-hash TTL expires it intentionally re-commits a
+	// liveness ping. The durable consumer ledger must still recognize the same
+	// turn fingerprint and prevent a second parent effect.
+	lateRetry := retry
+	lateRetry.Timestamp = second[0].Timestamp.Add(defaultOutputHashDedupTTL + time.Second)
+	late := restarted.NotifyTransition(lateRetry)
+	if late.DeliveryResult != transitionDeliveryCommitted {
+		t.Fatalf("same turn after producer TTL = %q, want committed liveness ping", late.DeliveryResult)
+	}
+	fourth, err := DrainInboxForParent(parentID)
+	if err != nil {
+		t.Fatalf("drain late turn B retry: %v", err)
+	}
+	if len(fourth) != 0 {
+		t.Fatalf("consumer replayed consumed turn B after producer TTL: %d records", len(fourth))
+	}
+}
+
+func TestCodexTurnIdentityRequiresConvergedBoundEvidence(t *testing.T) {
+	tests := []struct {
+		name                                                 string
+		tool, bound, started, completed, startedSID, doneSID string
+		want                                                 string
+	}{
+		{name: "matching", tool: "codex", bound: "thread-1", started: "thread-1:turn-a", completed: "thread-1:turn-a", startedSID: "thread-1", doneSID: "thread-1", want: "codex:thread-1:turn-a"},
+		{name: "missing completion", tool: "codex", bound: "thread-1", started: "thread-1:turn-a", startedSID: "thread-1"},
+		{name: "mismatched generation", tool: "codex", bound: "thread-1", started: "thread-1:turn-b", completed: "thread-1:turn-a", startedSID: "thread-1", doneSID: "thread-1"},
+		{name: "wrong bound session", tool: "codex", bound: "thread-2", started: "thread-1:turn-a", completed: "thread-1:turn-a", startedSID: "thread-1", doneSID: "thread-1"},
+		{name: "mismatched evidence sessions", tool: "codex", bound: "thread-1", started: "thread-1:turn-a", completed: "thread-1:turn-a", startedSID: "thread-1", doneSID: "thread-2"},
+		{name: "legacy tool", tool: "shell", bound: "thread-1", started: "thread-1:turn-a", completed: "thread-1:turn-a", startedSID: "thread-1", doneSID: "thread-1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			inst := &Instance{
+				Tool:                        tc.tool,
+				CodexSessionID:              tc.bound,
+				codexStartedGeneration:      tc.started,
+				codexCompletedGeneration:    tc.completed,
+				codexStartedSessionID:       tc.startedSID,
+				codexCompletedSessionID:     tc.doneSID,
+				codexInvalidatingGeneration: "",
+			}
+			if got := transitionEventOutputHash(inst); got != tc.want {
+				t.Fatalf("transitionEventOutputHash() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+
+	invalidated := &Instance{
+		Tool:                        "codex",
+		CodexSessionID:              "thread-1",
+		codexStartedGeneration:      "thread-1:turn-a",
+		codexCompletedGeneration:    "thread-1:turn-a",
+		codexStartedSessionID:       "thread-1",
+		codexCompletedSessionID:     "thread-1",
+		codexInvalidatingGeneration: "thread-1:turn-a",
+	}
+	if got := transitionEventOutputHash(invalidated); got != "" {
+		t.Fatalf("invalidated completion identity = %q, want empty", got)
+	}
+}
+
+func TestShortWindowDedupRemainsForNonCodexSignals(t *testing.T) {
+	base := time.Unix(1_780_000_000, 0)
+	for _, tc := range []struct {
+		name, first, second string
+	}{
+		{name: "legacy empty signal"},
+		{name: "claude transcript signal", first: "jsonl:100", second: "jsonl:200"},
+		{name: "untrusted lookalike", first: "codexish:thread-1:turn-a", second: "codexish:thread-1:turn-b"},
+		{name: "upgrade boundary is conservative", second: "codex:thread-1:turn-b"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			n := &TransitionNotifier{state: transitionNotifyState{Records: map[string]transitionNotifyRecord{
+				"child": {From: "running", To: "waiting", At: base.Unix(), OutputHash: tc.first},
+			}}}
+			event := TransitionNotificationEvent{
+				ChildSessionID: "child",
+				FromStatus:     "running",
+				ToStatus:       "waiting",
+				Timestamp:      base.Add(time.Second),
+				LastOutputHash: tc.second,
+			}
+			if !n.isDuplicate(event) {
+				t.Fatal("non-Codex signal bypassed the legacy short-window dedup")
+			}
+		})
+	}
+}
+
+func TestShortWindowAllowsDistinctTrustedCodexTurns(t *testing.T) {
+	base := time.Unix(1_780_000_000, 0)
+	n := &TransitionNotifier{state: transitionNotifyState{Records: map[string]transitionNotifyRecord{
+		"child": {From: "running", To: "waiting", At: base.Unix(), OutputHash: "codex:thread-1:turn-a"},
+	}}}
+	distinctTurn := TransitionNotificationEvent{
+		ChildSessionID: "child",
+		FromStatus:     "running",
+		ToStatus:       "waiting",
+		Timestamp:      base.Add(time.Second),
+		LastOutputHash: "codex:thread-1:turn-b",
+	}
+	if n.isDuplicate(distinctTurn) {
+		t.Fatal("distinct validated Codex turn was suppressed by the legacy short window")
+	}
+
+	sameTurn := distinctTurn
+	sameTurn.LastOutputHash = "codex:thread-1:turn-a"
+	if !n.isDuplicate(sameTurn) {
+		t.Fatal("same validated Codex turn was not deduplicated")
+	}
+}
+
+func setCompletedCodexTurnForTest(inst *Instance, sessionID, turnID string) {
+	generation := sessionID + ":" + turnID
+	inst.mu.Lock()
+	defer inst.mu.Unlock()
+	inst.CodexSessionID = sessionID
+	inst.codexStartedGeneration = generation
+	inst.codexCompletedGeneration = generation
+	inst.codexStartedSessionID = sessionID
+	inst.codexCompletedSessionID = sessionID
+	inst.codexInvalidatingGeneration = ""
+}

--- a/internal/session/transition_notifier.go
+++ b/internal/session/transition_notifier.go
@@ -35,6 +35,12 @@ const (
 	// callers that haven't been wired to populate LastOutputHash still
 	// get the legacy guarantee.
 	shortWindowDedupSeconds = 90
+
+	// codexTurnSignalPrefix distinguishes a validated Codex completion
+	// generation from transcript-size and legacy pane signals carried in the
+	// existing LastOutputHash field. Only signals minted after
+	// codexCompletionConverged may bypass the legacy short-window guard.
+	codexTurnSignalPrefix = "codex:"
 )
 
 type TransitionNotificationEvent struct {
@@ -53,8 +59,8 @@ type TransitionNotificationEvent struct {
 	// applies. Observability hook only — does not affect delivery/dedup.
 	Substate string `json:"substate,omitempty"`
 
-	// LastOutputHash is a cheap stable signal (e.g. SHA-1 of the last N
-	// bytes of the child's tmux pane at transition time) used by the
+	// LastOutputHash is a cheap stable signal (for example, transcript size or
+	// a validated Codex completion generation) used by the
 	// notifier's #1142 dedup to suppress repeated [EVENT] notifications
 	// for a dormant child whose pane content hasn't changed. Optional —
 	// empty string disables hash-based dedup and falls back to the legacy
@@ -431,7 +437,8 @@ func isLiveSessionStatus(status Status) bool {
 //
 //  1. Short-window (legacy): identical (from→to) within shortWindowDedupSeconds.
 //     Catches duplicate polls inside one daemon tick and back-compat callers
-//     that don't populate LastOutputHash.
+//     that don't populate LastOutputHash. Distinct validated Codex turn
+//     signals bypass this layer; same-turn retries continue to layer 2.
 //
 //  2. Output-hash (issue #1142): identical to_status AND identical
 //     LastOutputHash within outputHashDedupTTL. Suppresses a dormant child
@@ -453,7 +460,9 @@ func (n *TransitionNotifier) isDuplicate(event TransitionNotificationEvent) bool
 	elapsed := event.Timestamp.Unix() - record.At
 
 	if record.From == event.FromStatus && record.To == event.ToStatus && elapsed <= shortWindowDedupSeconds {
-		return true
+		if !distinctCodexTurnSignals(record.OutputHash, event.LastOutputHash) {
+			return true
+		}
 	}
 
 	if event.LastOutputHash != "" &&
@@ -464,6 +473,21 @@ func (n *TransitionNotifier) isDuplicate(event TransitionNotificationEvent) bool
 	}
 
 	return false
+}
+
+func distinctCodexTurnSignals(previous, current string) bool {
+	previous = strings.TrimSpace(previous)
+	current = strings.TrimSpace(current)
+	return isCodexTurnSignal(previous) && isCodexTurnSignal(current) && previous != current
+}
+
+func isCodexTurnSignal(signal string) bool {
+	generation, ok := strings.CutPrefix(strings.TrimSpace(signal), codexTurnSignalPrefix)
+	if !ok {
+		return false
+	}
+	threadID, turnID, ok := strings.Cut(generation, ":")
+	return ok && strings.TrimSpace(threadID) != "" && strings.TrimSpace(turnID) != ""
 }
 
 // outputHashTTL returns the active TTL for the output-hash dedup layer. The
@@ -497,7 +521,23 @@ func transitionEventOutputHash(inst *Instance) string {
 	if inst == nil {
 		return ""
 	}
+	if signal := codexCompletionTurnSignal(inst); signal != "" {
+		return signal
+	}
 	return transitionContentSignal(inst)
+}
+
+// codexCompletionTurnSignal snapshots the retained hook evidence under the
+// instance lock. codexCompletionConverged is the fail-closed authority check:
+// only matching start/completion generations for the session currently bound
+// to this Instance may identify a completed turn.
+func codexCompletionTurnSignal(inst *Instance) string {
+	inst.mu.RLock()
+	defer inst.mu.RUnlock()
+	if !inst.codexCompletionConverged() {
+		return ""
+	}
+	return codexTurnSignalPrefix + inst.codexCompletedGeneration
 }
 
 // transitionContentSignal returns a dedup signal derived from the child's


### PR DESCRIPTION
## What problem does this solve?

Fixes #2223.

Two distinct Codex turns that complete less than 90 seconds apart currently look like the same status transition, so the second completion never reaches the parent inbox.

## Why this change

The notifier already carries a stable `LastOutputHash` signal through every producer and the durable inbox. This change reuses that field for a namespaced `codex:<thread>:<turn>` identity, minted only when the instance's retained start and completion evidence converges for its bound Codex session. The 90-second guard is bypassed only when both identities are valid and distinct; same-turn retries still reach the existing output-hash and consumer-ledger deduplication.

## User impact

Parents receive every distinct completed Codex turn even when turns finish close together. Duplicate delivery for the same turn remains suppressed, including across daemon restarts and after the producer TTL.

## Evidence

An isolated real CLI loop drove `codex-notify`, a fresh `notify-daemon --once`, and durable inbox drains against a real tmux process fixture:

    v1.16.4 baseline counts: [1,0,0]
    patched counts:         [1,1,0]
    patched identities:     codex:thread-1:turn-a, codex:thread-1:turn-b

The focused regression tests fail on the base for the missing turn identity and suppressed distinct turn. They pass with this change under `-race`.

The changed `internal/session` package passes under `-race`. `go vet ./...` and `go build ./...` pass in the networkless isolated runner. The full module race run reaches unrelated SSH tests that require localhost networking and other pre-existing order-sensitive fixtures; each failure was reproduced against unchanged v1.16.4 in the same runner.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-6-astra

**Prompt / session log (optional):** Available from the author on request.

## What actually bothered you

My human asked: "Ok, lets do it"

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=gpt-6-astra intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Distinct Codex completion turns are now delivered reliably, even when they occur within a short deduplication window.
  * Codex turn identity persists across daemon restarts and remains valid only with trusted completion evidence.
  * Existing short-window deduplication behavior remains unchanged for non-Codex signals.
  * Invalid or expired Codex turn identity data is no longer used to suppress updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->