### PR TITLE
docs(tui): give the copy keys their own home and reconcile the shortcut reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,17 @@ agent-deck web                    # Start web UI on http://127.0.0.1:8420
 | `d` | Delete |
 | `b` | Re-run worktree setup script |
 | `E` | Container shell (sandboxed sessions) |
+| `c` / `C` | Copy last AI response / session info (repo, path, branch) |
+| `V` / `Y` | Copy visible terminal text / a fenced code block |
+| `Shift+drag` | Select text natively (`Option+drag` in iTerm2) — see below |
 | `?` | Full help |
+
+> **Why can't I drag-select text?** The TUI holds the terminal in mouse
+> reporting mode so clicks, wheel scrolling and the divider drag work, which
+> means your terminal never sees a drag as a selection. Hold `Shift` while
+> dragging (`Option` in iTerm2) to bypass it, or use the `c` / `C` / `V` / `Y`
+> copy keys above. Full detail in
+> [Terminal shortcuts](docs/terminal-shortcuts.md#text-selection-and-copying).
 
 See [TUI Reference](skills/agent-deck/references/tui-reference.md) for all shortcuts and [CLI Reference](skills/agent-deck/references/cli-reference.md) for all commands.
 

--- a/docs/terminal-shortcuts.md
+++ b/docs/terminal-shortcuts.md
@@ -4,6 +4,51 @@ This page documents keyboard shortcuts that interact with agent-deck's
 tmux-backed session model — and the small set of platform / terminal
 quirks that can surprise users.
 
+## Text selection and copying
+
+**Why dragging doesn't select text.** The agent-deck TUI starts with mouse
+reporting enabled (`tea.WithMouseCellMotion`, mouse mode 1002), so button
+presses, releases and drag motion are delivered to the application as escape
+sequences. That is what powers click-to-select a row, double-click to attach,
+wheel scrolling and dragging the preview divider — and it is also why your
+terminal never interprets a drag as a selection gesture. This is expected
+behavior, not a bug.
+
+There are two ways around it.
+
+**1. Bypass mouse reporting at the terminal level:**
+
+| Keystroke | Where |
+| --------- | ----- |
+| `Shift`+drag | Most Linux terminals, Windows Terminal, WSL2 |
+| `Option`+drag | iTerm2 |
+
+**2. Use the built-in copy keys**, which go through the system clipboard with an
+OSC 52 fallback so they also work over SSH:
+
+| Key | Copies |
+| --- | ------ |
+| `c` | Last AI response |
+| `C` | Session info — repo / path / branch |
+| `V` | Current visible terminal pane, links included |
+| `Y` | A fenced code block from output (picker when there are several) |
+
+`c` and `V` are rebindable under `[hotkeys]` as `copy_output` and `copy_pane`;
+`C` and `Y` are fixed.
+
+If your terminal has no selection bypass, you can disable tmux mouse mode for
+new and reconnected sessions — this trades away tmux scrolling, pane resizing
+and mouse copy mode:
+
+```toml
+[tmux]
+mouse = false
+```
+
+Note that this applies to **attached sessions only**. The agent-deck list view
+keeps its own mouse capture either way, so `Shift`+drag and the copy keys remain
+the route there.
+
 ## Detach from an attached session
 
 | Keystroke | What happens |

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -210,6 +210,7 @@ func (h *HelpOverlay) View() string {
 	promptSessionKey := h.key(hotkeyPromptSession, "o")
 	copyKey := h.key(hotkeyCopyOutput, "c")
 	copyPaneKey := h.key(hotkeyCopyPane, "V")
+	yoloKey := h.key(hotkeyToggleYolo, "y")
 	sendKey := h.key(hotkeySendOutput, "x")
 	execShellKey := h.key(hotkeyExecShell, "E")
 	openShellHereKey := h.key(hotkeyOpenShellHere, "h")
@@ -299,16 +300,30 @@ func (h *HelpOverlay) View() string {
 				{indentKeys, "Indent / outdent (in group)"},
 				{pinKeys, "Pin (cycle off→top→bottom→off)"},
 				{forkKeys, "Fork session (Claude/Pi)"},
-				{copyKey, "Copy output to clipboard"},
-				{"C", "Copy preview info (Repo / Path / Branch)"},
-				{"Y", "Copy a code block from output"},
-				{copyPaneKey, "Copy visible terminal text, including links"},
+				{yoloKey, "Toggle YOLO mode"},
 				{sendKey, "Send output to session"},
 				{execShellKey, "Exec shell in sandbox container"},
 				{openShellHereKey, "Open shell in session's worktree (split pane / window)"},
 				{editPathsKey, "Edit multi-repo paths"},
 				{editSessionKey, "Edit session settings (title/color/...)"},
 				{notesKey, "Edit notes"},
+			},
+		},
+		{
+			// The copy family used to sit mid-way down the 30-row SESSIONS list,
+			// where it went unfound: the recurring user question was "why can't I
+			// select text?" rather than "which key copies?". Its own section, with
+			// the Shift+drag row, answers that question where people look for it.
+			title: "COPY & TEXT SELECTION",
+			items: [][2]string{
+				{copyKey, "Copy last AI response"},
+				{"C", "Copy session info (repo / path / branch)"},
+				{copyPaneKey, "Copy visible terminal text, including links"},
+				{"Y", "Copy a fenced code block (picker if several)"},
+				// Not a binding: agent-deck holds the terminal in mouse mode 1002
+				// (tea.WithMouseCellMotion) so drags arrive as events and the
+				// terminal never renders a selection. Shift/Option bypasses that.
+				{"Shift+drag", "Native terminal selection (Option+drag in iTerm2)"},
 			},
 		},
 		{

--- a/internal/ui/help_test.go
+++ b/internal/ui/help_test.go
@@ -139,3 +139,53 @@ func TestWrapWithHangingIndent_ZeroOrNegativeWidth_ReturnsInput(t *testing.T) {
 		}
 	}
 }
+
+// The copy family (#1595, #1412, #791) was previously scattered through the
+// 30-row SESSIONS block, where nobody found it — the recurring user question
+// was "why can't I select text?". The keys now live in their own section that
+// also documents the terminal-level Shift+drag bypass of agent-deck's mouse
+// capture (tea.WithMouseCellMotion), which is the actual answer to that
+// question and is not a keybinding at all.
+func TestHelpOverlayShowsCopySection(t *testing.T) {
+	overlay := NewHelpOverlay()
+	overlay.SetSize(100, 200) // tall enough to render every section
+	overlay.Show()
+
+	view := overlay.View()
+
+	if !strings.Contains(view, "COPY & TEXT SELECTION") {
+		t.Fatalf("help overlay should carry a dedicated copy section, got %q", view)
+	}
+
+	for _, want := range []string{
+		"Copy last AI response",
+		"Copy session info (repo / path / branch)",
+		"Copy visible terminal text, including links",
+		"Copy a fenced code block (picker if several)",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("copy section missing description %q, got %q", want, view)
+		}
+	}
+
+	// The Shift+drag row is a terminal-level hint, not a binding: agent-deck
+	// holds mouse mode 1002 so the terminal never sees a drag as selection.
+	if !strings.Contains(view, "Shift+drag") {
+		t.Fatalf("copy section must document the Shift+drag selection bypass, got %q", view)
+	}
+	if !strings.Contains(view, "Option+drag in iTerm2") {
+		t.Fatalf("copy section must document the iTerm2 bypass, got %q", view)
+	}
+}
+
+// y is bound in defaultHotkeyBindings but appeared in neither the help overlay
+// nor any reference doc — the only fully undocumented shortcut in the keymap.
+func TestHelpOverlayShowsYoloToggle(t *testing.T) {
+	overlay := NewHelpOverlay()
+	overlay.SetSize(100, 200)
+	overlay.Show()
+
+	if view := overlay.View(); !strings.Contains(view, "Toggle YOLO mode") {
+		t.Fatalf("help overlay should document the yolo toggle, got %q", view)
+	}
+}

--- a/skills/agent-deck/SKILL.md
+++ b/skills/agent-deck/SKILL.md
@@ -379,7 +379,8 @@ Key constraints:
 | Key | Action |
 |-----|--------|
 | `n` | New session |
-| `r/R` | Restart (reloads MCPs) |
+| `r` | Rename session |
+| `R` | Restart session (reloads MCPs) |
 | `m` | MCP Manager |
 | `s` | Skills Manager |
 | `f/F` | Fork Claude/OpenCode/Pi/Codex session |
@@ -387,6 +388,18 @@ Key constraints:
 | `A` | Archive (stops tmux, hides from default list) |
 | `Shift+U` | Unarchive (does not auto-start tmux) |
 | `M` | Move to group |
+
+### Copy & Text Selection
+Mouse drag does not select text — the TUI holds the terminal in mouse reporting
+mode so clicks, scrolling and the divider drag work. Hold `Shift` while dragging
+(`Option` in iTerm2) for native selection, or use these:
+
+| Key | Copies |
+|-----|--------|
+| `c` | Last AI response |
+| `C` | Session info (repo / path / branch) |
+| `V` | Visible terminal text, links included |
+| `Y` | A fenced code block (picker if several) |
 
 ### Search & Filter
 | Key | Action |

--- a/skills/agent-deck/references/troubleshooting.md
+++ b/skills/agent-deck/references/troubleshooting.md
@@ -25,6 +25,11 @@ Option while dragging in iTerm2. Hold Shift while dragging in most Linux
 terminals and Windows Terminal, including WSL2. This bypasses application mouse
 reporting and lets the terminal perform native selection.
 
+The full explanation of why mouse capture blocks selection, plus the complete
+copy-key table (`c` / `C` / `V` / `Y`), lives in
+[Terminal shortcuts](../../../docs/terminal-shortcuts.md#text-selection-and-copying)
+and the [TUI Reference](tui-reference.md#copy--text-selection).
+
 If your terminal has no selection bypass, disable mouse mode for new and
 reconnected sessions:
 

--- a/skills/agent-deck/references/tui-reference.md
+++ b/skills/agent-deck/references/tui-reference.md
@@ -4,71 +4,169 @@ Complete reference for agent-deck Terminal UI features.
 
 ## Keyboard Shortcuts
 
+Reconciled against the in-app help overlay (`?`), which is the source of truth
+(`internal/ui/help.go`). Keys marked **rebindable** can be remapped under
+`[hotkeys]` in `config.toml`; the rest are fixed.
+
 ### Navigation
 
 | Key | Action |
 |-----|--------|
 | `j` / `↓` | Move down |
 | `k` / `↑` | Move up |
+| `Ctrl+u` / `Ctrl+d` | Half page up / down |
+| `PgUp` / `PgDn` | Half page up / down |
+| `Ctrl+f` / `Ctrl+b` | Full page up / down |
+| `Home` / `End` | Jump to first / last item |
+| `gg` | Jump to top |
+| `G` | Global search |
 | `h` / `←` | Collapse group / go to parent |
 | `l` / `→` / `Tab` | Toggle expand/collapse group |
 | `1-9` | Jump to Nth root group |
+| `Space` | Jump mode |
+| `Enter` | Attach to session OR toggle group |
+| `Shift+Enter` | Open session in new iTerm window (macOS) |
+
+### Group Navigation
+
+| Key | Action |
+|-----|--------|
+| `Alt+j` / `Alt+k` | Next / previous session in group |
+| `Alt+1` - `Alt+9` | Jump to Nth session in group |
+| `Alt+g` / `Alt+G` | First / last session in group |
+| `Alt+/` | Filter search within group |
 
 ### Session Actions
 
 | Key | Action |
 |-----|--------|
 | `Enter` | Attach to session OR toggle group |
-| `n` | New session (inherits current group) |
-| `r` | Rename session or group |
-| `R` | Restart session (reloads MCPs) |
-| `+` / `K` / `Shift+↑` | Move item up (auto-promotes a sub-session to top-level when at the parent's first child) |
-| `-` / `J` / `Shift+↓` | Move item down (auto-promotes a sub-session to top-level when at the parent's last child) |
+| `n` / `N` | New session / quick create (**rebindable**) |
+| `r` | Rename session or group (**rebindable**) |
+| `R` | Restart session, reloads MCPs (**rebindable**) |
+| `T` | Restart with a new session ID (**rebindable**) |
+| `d` | Delete session or group (**rebindable**) |
+| `D` | Close session process (**rebindable**) |
+| `Ctrl+Z` | Undo delete (**rebindable**) |
+| `A` | Archive session — stops tmux, hides from default list; conversations/metadata untouched (**rebindable**) |
+| `Shift+U` | Unarchive session; does NOT auto-start tmux (**rebindable**) |
+| `^` | Toggle archived view (**rebindable**) |
+| `M` | Move session to a different group (**rebindable**) |
+| `m` | MCP Manager (Claude/Gemini/Cursor) (**rebindable**) |
+| `L` | Plugin Manager (Claude) (**rebindable**) |
+| `s` | Skills Manager (**rebindable**) |
+| `$` | Cost Dashboard |
+| `v` | Cycle preview mode: output / stats / both (**rebindable**) |
+| `O` | Toggle preview orientation (right / below — portrait monitors) |
+| `<` / `>` | Shrink / grow preview pane by 5% (or drag the divider with the mouse) |
+| `u` | Mark unread, idle -> waiting (**rebindable**) |
+| `a` | Quick approve — sends `1` to Claude (**rebindable**) |
+| `o` | Prompt session — send a one-line prompt without attaching (**rebindable**) |
+| `y` | Toggle YOLO mode (**rebindable**) |
+| `+` / `K` / `Shift+↑` | Move item up (auto-promotes a sub-session to top-level at the parent's first child) |
+| `-` / `J` / `Shift+↓` | Move item down (auto-promotes a sub-session to top-level at the parent's last child) |
 | `Shift+→` / `Shift+←` | Indent / outdent within current group (single-level nesting) |
-| `M` | Move session to different group |
-| `m` | Open MCP Manager (Claude/Gemini) |
-| `s` | Open Skills Manager |
-| `d` | Delete session or group |
-| `A` | Archive session (stops tmux, hides from default list; conversations/metadata untouched) |
-| `Shift+U` | Unarchive session (restores to list; does NOT auto-start tmux) |
-| `b` | Re-run worktree setup script (`.agent-deck/worktree-setup.sh`) |
-| `u` | Mark unread (idle -> waiting) |
-| `f` | Quick fork (Claude/OpenCode/Pi/Codex) |
-| `F` | Fork with options (Claude/OpenCode/Pi/Codex) |
+| `,` | Pin (cycles off -> top -> bottom -> off) |
+| `f` / `F` | Quick fork / fork with options (Claude/OpenCode/Pi/Codex) (**rebindable**) |
+| `x` | Send output to another session (**rebindable**) |
+| `E` | Exec shell in sandbox container (**rebindable**) |
+| `H` | Open shell in session's worktree, split pane / window (**rebindable**) |
+| `p` | Edit multi-repo paths (**rebindable**) |
+| `P` | Edit session settings — title / color / ... (**rebindable**) |
+| `e` | Edit notes; hidden when notes are disabled (**rebindable**) |
+| `b` | Re-run worktree setup script `.agent-deck/worktree-setup.sh` (**rebindable**) |
+| `W` | Finish worktree — merge + cleanup (**rebindable**) |
+| `w` | Watcher panel (**rebindable**) |
 
 For remote group headers, `Enter`/`Tab` toggles collapse and `h`/Left collapses or moves to the parent. Remote-session reorder keys move only within the current remote group; the order is saved on the viewing machine, while remote group headers remain name-sorted.
+
+### Copy & Text Selection
+
+Dragging with the mouse does **not** select text: the TUI puts the terminal in
+mouse reporting mode (`tea.WithMouseCellMotion`) so that click-to-select,
+wheel scrolling and the divider drag work, which means the terminal never sees
+your drag as a selection gesture.
+
+| Key | Action |
+|-----|--------|
+| `c` | Copy last AI response (**rebindable**) |
+| `C` | Copy session info — repo / path / branch |
+| `V` | Copy visible terminal text, links included (**rebindable**) |
+| `Y` | Copy a fenced code block from output; opens a picker when there are several |
+| `Shift+drag` | Native terminal selection — bypasses mouse reporting |
+| `Option+drag` | Native terminal selection in iTerm2 |
+
+Note the family is only half-rebindable: `c` and `V` are `copy_output` and
+`copy_pane` under `[hotkeys]`, while `C` and `Y` are fixed.
+
+All four copy paths use the same clipboard chain, falling back to OSC 52 so they
+work over SSH. If your terminal offers no selection bypass at all, you can turn
+off tmux mouse mode for attached sessions — at the cost of tmux scrolling, pane
+resize and mouse copy mode:
+
+```toml
+[tmux]
+mouse = false
+```
+
+That setting affects **attached sessions only**; the agent-deck list view keeps
+its own mouse capture regardless.
 
 ### Group Actions
 
 | Key | Action |
 |-----|--------|
-| `g` | Create group (subgroup if on group) |
-| `r` | Rename group |
+| `g` | Create group (subgroup if on group) (**rebindable**) |
+| `r` | Rename group (**rebindable**) |
+| `Tab` | Toggle expand |
 
 ### Search & Filter
 
 | Key | Action |
 |-----|--------|
-| `/` | Local search (fuzzy) |
+| `/` | Local search, fuzzy (**rebindable**) |
 | `G` | Global search (all Claude conversations) |
 | `Tab` | Switch between local/global search |
 | `0` | Clear filter (show all) |
-| `!` | Filter: running only (toggle) |
-| `@` | Filter: waiting only (toggle) |
-| `#` | Filter: idle only (toggle) |
-| `&` | Filter: error only (toggle) |
+| `!` / `Shift+1` | Filter: running only (toggle) |
+| `@` / `Shift+2` | Filter: waiting only (toggle) |
+| `#` / `Shift+3` | Filter: idle only (toggle) |
+| `&` | Filter: errors only (toggle) |
+| `%` | Filter: open only, hides errors (toggle) |
 | `^` | Filter: view archived sessions (toggle) |
+| `t` | Cycle group view: active-on-top / populated-on-top (**rebindable**) |
+| `*` | Cycle time filter: today / 3 days / 7 days / all (**rebindable**) |
+
+Inside the search prompt, `/waiting`, `/running` and `/idle` filter by status.
 
 ### Global
 
 | Key | Action |
 |-----|--------|
-| `?` | Help overlay |
-| `i` | Import existing tmux sessions |
-| `Ctrl+R` | Manual refresh |
-| `Ctrl+Q` | Detach (keep tmux running) |
+| `?` | Help overlay (**rebindable**) |
+| `S` | Settings (**rebindable**) |
+| `i` | Import existing tmux sessions (**rebindable**) |
+| `Ctrl+R` | Manual refresh / reload from disk (**rebindable**) |
+| `Ctrl+Q` | Detach, keeps tmux running (**rebindable**) |
+| `Ctrl+S` | Switch session, here or attached — unbound by default (**rebindable**) |
+| `PageUp` | Scrollback pager, while attached |
+| `Alt+A` | Agents panel; appears once an agent is adopted (**rebindable**) |
 | `$` | Cost Dashboard |
-| `q` / `Ctrl+C` | Quit |
+| `q` / `Ctrl+C` | Quit (**rebindable**) |
+
+### Worktree Shortcuts
+
+| Key | Action |
+|-----|--------|
+| `n` -> `w` | Create session in a worktree |
+| `F` -> `w` | Fork session into a worktree |
+
+### Startup Flags
+
+| Flag | Action |
+|------|--------|
+| `--group <name>` | Launch scoped to a group |
+| `--profile <name>` | Use a specific profile |
 
 ## Local Status Indicators
 


### PR DESCRIPTION
## What

The recurring question is not *"which key copies?"* — it's *"why can't I select text?"*.

The TUI runs under `tea.WithMouseCellMotion` (mouse mode 1002), so drags arrive as application events and the terminal never renders a selection. The answer — **Shift+drag**, or the `c` / `C` / `V` / `Y` copy family — was split across three files, and the copy keys themselves sat mid-way down a 30-row `SESSIONS` block in the help overlay, where nobody found them.

## Changes

- **`internal/ui/help.go`** — lift `c`/`C`/`V`/`Y` into their own **COPY & TEXT SELECTION** section, with a `Shift+drag` row documenting the terminal-level bypass. That row is not a binding; it's the answer to the question people actually arrive with.
- **`internal/ui/help.go`** — add the `y` YOLO toggle. It was bound in `defaultHotkeyBindings` but appeared in neither the overlay nor any doc — the only shortcut in the keymap that was completely undocumented.
- **`skills/agent-deck/references/tui-reference.md`** — reconcile against `help.go`, which had drifted far ahead of it. Adds the Group Navigation (`Alt+*`) section, the `%` filter, and ~28 missing keys, and marks which keys are rebindable under `[hotkeys]`.
- **`README.md` / `skills/agent-deck/SKILL.md`** — surface the copy keys and the selection note, and split the `r`/`R` row: `r` **renames**, it does not restart.
- **`docs/terminal-shortcuts.md` / `skills/agent-deck/references/troubleshooting.md`** — one canonical explanation, cross-linked, instead of three partial ones.

## Note for reviewers

The copy family is only **half-rebindable**: `c` and `V` resolve through `copy_output` / `copy_pane`, while `C` and `Y` are fixed. This PR documents that rather than changing it — remapping them is a separate decision.

## Tests

`internal/ui/help_test.go` gains coverage for the new section and the previously undocumented `y` binding. `go test ./internal/ui/ -run 'Help|Hotkey|Shortcut' -count=1` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the help overlay with a dedicated **COPY & TEXT SELECTION** section.
  - Documented copy commands, native terminal selection with Shift+drag, and iTerm2 selection with Option+drag.
  - Added documentation for the YOLO-mode shortcut.
- **Tests**
  - Added coverage verifying the new copy and text-selection guidance.
  - Added coverage verifying the YOLO-mode shortcut appears in the help overlay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->