### PR TITLE
feat(inbox): manage dead-letter records from CLI and TUI

### DIFF
--- a/cmd/agent-deck/inbox_cmd.go
+++ b/cmd/agent-deck/inbox_cmd.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
@@ -149,6 +150,9 @@ func runInboxWithProfile(stdout io.Writer, args []string, explicitProfile string
 	if len(args) > 0 && args[0] == "writer-status" {
 		return runInboxWriterStatus(stdout, args[1:])
 	}
+	if len(args) > 0 && args[0] == "dead-letter" {
+		return runInboxDeadLetter(stdout, args[1:])
+	}
 
 	fs := flag.NewFlagSet("inbox", flag.ContinueOnError)
 	fs.Usage = func() {
@@ -156,6 +160,7 @@ func runInboxWithProfile(stdout io.Writer, args []string, explicitProfile string
 		fmt.Fprintln(stdout, "       agent-deck inbox drain [--json] <session-id>")
 		fmt.Fprintln(stdout, "       agent-deck inbox export [--json]")
 		fmt.Fprintln(stdout, "       agent-deck inbox writer-status [--json]")
+		fmt.Fprintln(stdout, "       agent-deck inbox dead-letter <list|show|retry|purge>")
 		fmt.Fprintln(stdout)
 		fmt.Fprintln(stdout, "Drain pending completion events from the parent's durable outbox.")
 		fmt.Fprintln(stdout, "The `drain` form (issue #1225) collapses last-wins per child and")
@@ -167,6 +172,8 @@ func runInboxWithProfile(stdout io.Writer, args []string, explicitProfile string
 		fmt.Fprintln(stdout, "The `writer-status` form reports whether a notify-daemon is")
 		fmt.Fprintln(stdout, "actually recording transitions here — without it, an empty export")
 		fmt.Fprintln(stdout, "cannot be told apart from a host where nothing has been watching.")
+		fmt.Fprintln(stdout, "The `dead-letter` family safely inspects, retries, or purges terminal")
+		fmt.Fprintln(stdout, "delivery failures; run `agent-deck inbox dead-letter help` for details.")
 	}
 	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
 		return err
@@ -183,6 +190,142 @@ func runInboxWithProfile(stdout io.Writer, args []string, explicitProfile string
 	}
 	printInboxEvents(stdout, events)
 	return nil
+}
+
+func runInboxDeadLetter(stdout io.Writer, args []string) error {
+	usage := func() {
+		fmt.Fprintln(stdout, "Usage: agent-deck inbox dead-letter <command>")
+		fmt.Fprintln(stdout)
+		fmt.Fprintln(stdout, "Commands:")
+		fmt.Fprintln(stdout, "  list [--json]                 List bounded record metadata")
+		fmt.Fprintln(stdout, "  show [--json] <record-id>     Show one record without raw content")
+		fmt.Fprintln(stdout, "  retry <record-id>             Re-resolve and redeliver one record")
+		fmt.Fprintln(stdout, "  purge --older-than <duration> Purge only records older than a bound")
+		fmt.Fprintln(stdout, "  purge --yes                   Purge every record with explicit consent")
+	}
+	if len(args) == 0 || args[0] == "help" || args[0] == "--help" || args[0] == "-h" {
+		usage()
+		return nil
+	}
+	switch args[0] {
+	case "list":
+		return runInboxDeadLetterList(stdout, args[1:])
+	case "show":
+		return runInboxDeadLetterShow(stdout, args[1:])
+	case "retry":
+		return runInboxDeadLetterRetry(stdout, args[1:])
+	case "purge":
+		return runInboxDeadLetterPurge(stdout, args[1:])
+	default:
+		usage()
+		return fmt.Errorf("unknown inbox dead-letter command %q", args[0])
+	}
+}
+
+func runInboxDeadLetterList(stdout io.Writer, args []string) error {
+	fs := flag.NewFlagSet("inbox dead-letter list", flag.ContinueOnError)
+	asJSON := fs.Bool("json", false, "emit a JSON array")
+	fs.SetOutput(stdout)
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("inbox dead-letter list accepts no arguments")
+	}
+	records, err := session.ListDeadLetters()
+	if err != nil {
+		return fmt.Errorf("list dead letters: %w", err)
+	}
+	if *asJSON {
+		if records == nil {
+			records = []session.DeadLetterRecord{}
+		}
+		return json.NewEncoder(stdout).Encode(records)
+	}
+	if len(records) == 0 {
+		fmt.Fprintln(stdout, "No dead-lettered events.")
+		return nil
+	}
+	fmt.Fprintln(stdout, "ID               AGE        REASON          CHILD")
+	for _, record := range records {
+		fmt.Fprintf(stdout, "%-16s %-10s %-15s %s\n", record.ID, formatDeadLetterAge(record.AgeSeconds), record.Reason, record.ChildSessionID)
+	}
+	return nil
+}
+
+func runInboxDeadLetterShow(stdout io.Writer, args []string) error {
+	fs := flag.NewFlagSet("inbox dead-letter show", flag.ContinueOnError)
+	asJSON := fs.Bool("json", false, "emit a JSON object")
+	fs.SetOutput(stdout)
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("usage: agent-deck inbox dead-letter show [--json] <record-id>")
+	}
+	record, err := session.GetDeadLetter(fs.Arg(0))
+	if err != nil {
+		return err
+	}
+	if *asJSON {
+		return json.NewEncoder(stdout).Encode(record)
+	}
+	fmt.Fprintf(stdout, "ID: %s\nChild: %s\n", record.ID, record.ChildSessionID)
+	if record.ChildTitle != "" {
+		fmt.Fprintf(stdout, "Title: %s\n", record.ChildTitle)
+	}
+	fmt.Fprintf(stdout, "Target: %s\nProfile: %s\nReason: %s\nAge: %s\nAttempts: %d\nPayload: %s\n",
+		record.TargetSessionID, record.Profile, record.Reason, formatDeadLetterAge(record.AgeSeconds), record.Attempts, record.PayloadSummary)
+	return nil
+}
+
+func runInboxDeadLetterRetry(stdout io.Writer, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("usage: agent-deck inbox dead-letter retry <record-id>")
+	}
+	target, err := session.RetryDeadLetter(args[0])
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "Delivered dead-letter record %s to inbox %s.\n", args[0], target)
+	return nil
+}
+
+func runInboxDeadLetterPurge(stdout io.Writer, args []string) error {
+	fs := flag.NewFlagSet("inbox dead-letter purge", flag.ContinueOnError)
+	olderThan := fs.Duration("older-than", 0, "purge records older than this duration")
+	yes := fs.Bool("yes", false, "confirm an unbounded purge")
+	fs.SetOutput(stdout)
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("inbox dead-letter purge accepts no arguments")
+	}
+	if *olderThan < 0 {
+		return fmt.Errorf("--older-than must be a positive duration")
+	}
+	var count int
+	var err error
+	if *olderThan > 0 {
+		count, err = session.PurgeDeadLettersOlderThan(time.Now().Add(-*olderThan))
+	} else if *yes {
+		count, err = session.PurgeAllDeadLetters()
+	} else {
+		return fmt.Errorf("refusing unbounded purge: pass --yes or a positive --older-than duration")
+	}
+	if err != nil {
+		return fmt.Errorf("purge dead letters: %w", err)
+	}
+	fmt.Fprintf(stdout, "Purged %d dead-letter record(s).\n", count)
+	return nil
+}
+
+func formatDeadLetterAge(seconds int64) string {
+	if seconds <= 0 {
+		return "now"
+	}
+	return (time.Duration(seconds) * time.Second).Round(time.Second).String()
 }
 
 // runInboxDrain is the issue #1225 consumer path: exactly-once-per-turn,

--- a/cmd/agent-deck/issue2062_deadletter_cli_test.go
+++ b/cmd/agent-deck/issue2062_deadletter_cli_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func seedDeadLetterCLIRecord(t *testing.T, child, reason string, at time.Time) string {
+	t.Helper()
+	path := session.DeadLetterPathFor(child)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	raw := `{"child_session_id":"` + child + `","child_title":"worker","profile":"default","target_session_id":"missing-parent","from_status":"running","to_status":"waiting","timestamp":"` + at.Format(time.RFC3339Nano) + `","attempts":5,"dead_letter_reason":"` + reason + `","done_summary":"secret payload that must not be printed in full"}` + "\n"
+	if err := os.WriteFile(path, []byte(raw), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestIssue2062DeadLetterListAndShow(t *testing.T) {
+	cliInboxTestHome(t)
+	seedDeadLetterCLIRecord(t, "dead-child", "parent_removed", time.Now().Add(-2*time.Hour))
+
+	var list bytes.Buffer
+	if err := runInbox(&list, []string{"dead-letter", "list", "--json"}); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !strings.Contains(list.String(), `"reason":"parent_removed"`) || !strings.Contains(list.String(), `"child_session_id":"dead-child"`) {
+		t.Fatalf("stable JSON omitted identity/reason: %s", list.String())
+	}
+	if strings.Contains(list.String(), "secret payload") {
+		t.Fatalf("list exposed payload: %s", list.String())
+	}
+
+	records, err := session.ListDeadLetters()
+	if err != nil || len(records) != 1 {
+		t.Fatalf("records=%+v err=%v", records, err)
+	}
+	var show bytes.Buffer
+	if err := runInbox(&show, []string{"dead-letter", "show", records[0].ID, "--json"}); err != nil {
+		t.Fatalf("show: %v", err)
+	}
+	if !strings.Contains(show.String(), `"age_seconds":`) || !strings.Contains(show.String(), `"payload_summary":`) {
+		t.Fatalf("show omitted bounded operator detail: %s", show.String())
+	}
+}
+
+func TestIssue2062RetryMissingTargetRetainsRecord(t *testing.T) {
+	cliInboxTestHome(t)
+	seedDeadLetterCLIRecord(t, "removed-child", "child_removed", time.Now())
+	records, _ := session.ListDeadLetters()
+
+	err := runInbox(&bytes.Buffer{}, []string{"dead-letter", "retry", records[0].ID})
+	if err == nil || !strings.Contains(err.Error(), "no longer exists") {
+		t.Fatalf("retry must fail honestly, got %v", err)
+	}
+	remaining, _ := session.ListDeadLetters()
+	if len(remaining) != 1 {
+		t.Fatalf("failed retry removed record: %+v", remaining)
+	}
+}
+
+func TestIssue2062SuccessfulRetryRemovesOnlyDeliveredRecord(t *testing.T) {
+	cliInboxTestHome(t)
+	parent := session.NewInstance("parent", t.TempDir())
+	parent.ID = "live-parent"
+	child := session.NewInstance("child", t.TempDir())
+	child.ID = "retry-child"
+	child.ParentSessionID = parent.ID
+	saveInboxResolutionSessions(t, "default", parent, child)
+	seedDeadLetterCLIRecord(t, child.ID, "parent_removed", time.Now())
+	seedDeadLetterCLIRecord(t, "leave-me", "orphan", time.Now())
+	records, _ := session.ListDeadLetters()
+	var retryID string
+	for _, record := range records {
+		if record.ChildSessionID == child.ID {
+			retryID = record.ID
+		}
+	}
+	if retryID == "" {
+		t.Fatal("retry record not found")
+	}
+	if err := runInbox(&bytes.Buffer{}, []string{"dead-letter", "retry", retryID}); err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+	delivered, err := session.DrainInboxForParent(parent.ID)
+	if err != nil || len(delivered) != 1 || delivered[0].ChildSessionID != child.ID {
+		t.Fatalf("delivered=%+v err=%v", delivered, err)
+	}
+	remaining, _ := session.ListDeadLetters()
+	if len(remaining) != 1 || remaining[0].ChildSessionID != "leave-me" {
+		t.Fatalf("retry removed the wrong records: %+v", remaining)
+	}
+	if err := runInbox(&bytes.Buffer{}, []string{"dead-letter", "retry", retryID}); err == nil {
+		t.Fatal("removed record was redelivered")
+	}
+}
+
+func TestIssue2062JSONDistinguishesPersistedReasons(t *testing.T) {
+	cliInboxTestHome(t)
+	reasons := []string{"child_removed", "parent_removed", "orphan", "unresolvable", "no_notify", "self_conductor"}
+	for i, reason := range reasons {
+		seedDeadLetterCLIRecord(t, "reason-child-"+reason, reason, time.Now().Add(time.Duration(-i)*time.Minute))
+	}
+	var out bytes.Buffer
+	if err := runInbox(&out, []string{"dead-letter", "list", "--json"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, reason := range reasons {
+		if !strings.Contains(out.String(), `"reason":"`+reason+`"`) {
+			t.Errorf("JSON did not distinguish %q: %s", reason, out.String())
+		}
+	}
+}
+
+func TestIssue2062PurgeRequiresConsentOrAgeBound(t *testing.T) {
+	cliInboxTestHome(t)
+	seedDeadLetterCLIRecord(t, "old-child", "orphan", time.Now().Add(-48*time.Hour))
+
+	if err := runInbox(&bytes.Buffer{}, []string{"dead-letter", "purge"}); err == nil {
+		t.Fatal("unconfirmed unbounded purge succeeded")
+	}
+	if records, _ := session.ListDeadLetters(); len(records) != 1 {
+		t.Fatal("unsafe purge deleted a record")
+	}
+	if err := runInbox(&bytes.Buffer{}, []string{"dead-letter", "purge", "--older-than", "24h"}); err != nil {
+		t.Fatalf("bounded purge: %v", err)
+	}
+	if records, _ := session.ListDeadLetters(); len(records) != 0 {
+		t.Fatalf("bounded purge retained old record: %+v", records)
+	}
+}
+
+func TestIssue2062HelpIsSideEffectFreeAndUnownedCanClear(t *testing.T) {
+	cliInboxTestHome(t)
+	event := session.TransitionNotificationEvent{
+		ChildSessionID:   "unowned-child",
+		Profile:          "default",
+		FromStatus:       "running",
+		ToStatus:         "waiting",
+		Timestamp:        time.Now().Add(-time.Hour),
+		DeadLetterReason: "orphan",
+	}
+	if err := session.WriteInboxEvent(session.UnownedInboxID, event); err != nil {
+		t.Fatal(err)
+	}
+	var help bytes.Buffer
+	if err := runInbox(&help, []string{"dead-letter", "help"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(help.String(), "show") || !strings.Contains(help.String(), "purge") {
+		t.Fatalf("subcommand help is not specific: %q", help.String())
+	}
+	records, err := session.ListDeadLetters()
+	if err != nil || len(records) != 1 || records[0].Store != "unowned" {
+		t.Fatalf("unowned record missing after help: %+v err=%v", records, err)
+	}
+	if err := runInbox(&bytes.Buffer{}, []string{"dead-letter", "purge", "--yes"}); err != nil {
+		t.Fatal(err)
+	}
+	if count, err := session.CountDeadLetterRecords(); err != nil || count != 0 {
+		t.Fatalf("warning could not be cleared: count=%d err=%v", count, err)
+	}
+	if err := session.WriteInboxEvent(session.UnownedInboxID, event); err != nil {
+		t.Fatal(err)
+	}
+	if count, err := session.CountDeadLetterRecords(); err != nil || count != 1 {
+		t.Fatalf("purge left stale dedup state: count=%d err=%v", count, err)
+	}
+}

--- a/internal/session/dead_letter_management.go
+++ b/internal/session/dead_letter_management.go
@@ -1,0 +1,348 @@
+package session
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// DeadLetterRecord is the bounded, operator-safe view of one persisted record.
+// It deliberately omits prompt/output content and the raw on-disk payload.
+type DeadLetterRecord struct {
+	ID              string    `json:"id"`
+	Store           string    `json:"store"`
+	ChildSessionID  string    `json:"child_session_id"`
+	ChildTitle      string    `json:"child_title,omitempty"`
+	TargetSessionID string    `json:"target_session_id,omitempty"`
+	Profile         string    `json:"profile,omitempty"`
+	Reason          string    `json:"reason"`
+	Timestamp       time.Time `json:"timestamp"`
+	AgeSeconds      int64     `json:"age_seconds"`
+	Attempts        int       `json:"attempts"`
+	PayloadSummary  string    `json:"payload_summary"`
+	Corrupt         bool      `json:"corrupt,omitempty"`
+}
+
+type deadLetterEntry struct {
+	record DeadLetterRecord
+	event  TransitionNotificationEvent
+	path   string
+	raw    []byte
+}
+
+func deadLetterRecordID(store string, raw []byte) string {
+	sum := sha256.Sum256(append(append([]byte(store), 0), raw...))
+	return hex.EncodeToString(sum[:])[:16]
+}
+
+func deadLetterPayloadSummary(event TransitionNotificationEvent) string {
+	if event.Kind == transitionKindFinished {
+		summary := fmt.Sprintf("completion status=%s", strings.TrimSpace(event.DoneStatus))
+		if event.DoneSummary != "" {
+			summary += fmt.Sprintf(" summary_bytes=%d", len(event.DoneSummary))
+		}
+		return summary
+	}
+	from, to := strings.TrimSpace(event.FromStatus), strings.TrimSpace(event.ToStatus)
+	if from == "" && to == "" {
+		return "transition metadata unavailable"
+	}
+	return fmt.Sprintf("transition %s -> %s", from, to)
+}
+
+func readDeadLetterEntries(now time.Time) ([]deadLetterEntry, error) {
+	dirEntries, err := os.ReadDir(DeadLetterDir())
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+		dirEntries = nil
+	}
+	var paths []string
+	for _, dirEntry := range dirEntries {
+		if dirEntry.IsDir() || !strings.HasSuffix(dirEntry.Name(), ".jsonl") {
+			continue
+		}
+		paths = append(paths, filepath.Join(DeadLetterDir(), dirEntry.Name()))
+	}
+	// _unowned is the discovery-only companion ledger counted by
+	// CountDeadLetterRecords. Include it so an operator can actually clear the
+	// warning rather than purging the forensic directory and still seeing it.
+	paths = append(paths, InboxPathFor(UnownedInboxID))
+	var out []deadLetterEntry
+	for _, path := range paths {
+		f, err := os.Open(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return nil, err
+		}
+		scanner := bufio.NewScanner(f)
+		scanner.Buffer(make([]byte, 0, 64*1024), maxInboxLineBytes)
+		for scanner.Scan() {
+			raw := append([]byte(nil), scanner.Bytes()...)
+			if len(strings.TrimSpace(string(raw))) == 0 {
+				continue
+			}
+			entry := deadLetterEntry{path: path, raw: raw}
+			entry.record.Store = "dead-letter"
+			if path == InboxPathFor(UnownedInboxID) {
+				entry.record.Store = "unowned"
+			}
+			entry.record.ID = deadLetterRecordID(entry.record.Store, raw)
+			if err := json.Unmarshal(raw, &entry.event); err != nil {
+				entry.record.ChildSessionID = strings.TrimSuffix(filepath.Base(path), ".jsonl")
+				entry.record.Reason = "corrupt"
+				entry.record.PayloadSummary = "record could not be decoded"
+				entry.record.Corrupt = true
+				out = append(out, entry)
+				continue
+			}
+			event := entry.event
+			entry.record.ChildSessionID = event.ChildSessionID
+			entry.record.ChildTitle = event.ChildTitle
+			entry.record.TargetSessionID = event.TargetSessionID
+			entry.record.Profile = event.Profile
+			entry.record.Reason = strings.TrimSpace(event.DeadLetterReason)
+			if entry.record.Reason == "" {
+				entry.record.Reason = deadLetterReasonUnresolvable
+			}
+			entry.record.Timestamp = event.Timestamp
+			if !event.Timestamp.IsZero() && now.After(event.Timestamp) {
+				entry.record.AgeSeconds = int64(now.Sub(event.Timestamp) / time.Second)
+			}
+			entry.record.Attempts = event.Attempts
+			entry.record.PayloadSummary = deadLetterPayloadSummary(event)
+			out = append(out, entry)
+		}
+		scanErr := scanner.Err()
+		closeErr := f.Close()
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		if closeErr != nil {
+			return nil, closeErr
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].record.Timestamp.Equal(out[j].record.Timestamp) {
+			return out[i].record.ID < out[j].record.ID
+		}
+		return out[i].record.Timestamp.After(out[j].record.Timestamp)
+	})
+	return out, nil
+}
+
+// ListDeadLetters returns stable, bounded metadata for every physical record.
+func ListDeadLetters() ([]DeadLetterRecord, error) {
+	entries, err := readDeadLetterEntries(time.Now())
+	if err != nil {
+		return nil, err
+	}
+	records := make([]DeadLetterRecord, len(entries))
+	for i := range entries {
+		records[i] = entries[i].record
+	}
+	return records, nil
+}
+
+func findDeadLetterEntry(id string) (deadLetterEntry, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return deadLetterEntry{}, errors.New("dead-letter record id is required")
+	}
+	entries, err := readDeadLetterEntries(time.Now())
+	if err != nil {
+		return deadLetterEntry{}, err
+	}
+	var matches []deadLetterEntry
+	for _, entry := range entries {
+		if entry.record.ID == id || strings.HasPrefix(entry.record.ID, id) {
+			matches = append(matches, entry)
+		}
+	}
+	if len(matches) == 0 {
+		return deadLetterEntry{}, fmt.Errorf("dead-letter record %q not found", id)
+	}
+	if len(matches) > 1 {
+		return deadLetterEntry{}, fmt.Errorf("dead-letter record id %q is ambiguous", id)
+	}
+	return matches[0], nil
+}
+
+// GetDeadLetter returns one operator-safe record by full ID or unique prefix.
+func GetDeadLetter(id string) (DeadLetterRecord, error) {
+	entry, err := findDeadLetterEntry(id)
+	return entry.record, err
+}
+
+func removeDeadLetterEntry(entry deadLetterEntry) error {
+	lock, err := AcquireConfigFileLock(entry.path)
+	if err != nil {
+		return fmt.Errorf("lock dead-letter record: %w", err)
+	}
+	defer lock.Release()
+	managesInboxCache := entry.path == InboxPathFor(UnownedInboxID)
+	if managesInboxCache {
+		// Match the normal inbox writer's lock order (file lock, then process
+		// mutex) and invalidate its fingerprint cache after removing a line.
+		// Otherwise a TUI purge in this long-lived process could make a later
+		// legitimate reappearance of the same event look already persisted.
+		inboxWriteMu.Lock()
+		defer inboxWriteMu.Unlock()
+	}
+
+	raw, err := os.ReadFile(entry.path)
+	if err != nil {
+		return err
+	}
+	var kept [][]byte
+	removed := false
+	for _, line := range strings.Split(string(raw), "\n") {
+		trimmed := []byte(strings.TrimSpace(line))
+		if len(trimmed) == 0 {
+			continue
+		}
+		if !removed && deadLetterRecordID(entry.record.Store, trimmed) == entry.record.ID {
+			removed = true
+			continue
+		}
+		kept = append(kept, trimmed)
+	}
+	if !removed {
+		return fmt.Errorf("dead-letter record %q changed or no longer exists", entry.record.ID)
+	}
+	if len(kept) == 0 {
+		if err := os.Remove(entry.path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		fsyncDir(filepath.Dir(entry.path))
+		if managesInboxCache {
+			delete(inboxFingerprintCache, entry.path)
+		}
+		return nil
+	}
+	data := append([]byte(strings.Join(byteLinesToStrings(kept), "\n")), '\n')
+	if err := writeFileDurable(entry.path, data, 0o644); err != nil {
+		return err
+	}
+	if managesInboxCache {
+		delete(inboxFingerprintCache, entry.path)
+	}
+	return nil
+}
+
+func byteLinesToStrings(lines [][]byte) []string {
+	out := make([]string, len(lines))
+	for i := range lines {
+		out[i] = string(lines[i])
+	}
+	return out
+}
+
+// RetryDeadLetter re-resolves the child's current parent, commits the event to
+// that durable inbox, and only then removes this one dead-letter record.
+func RetryDeadLetter(id string) (string, error) {
+	entry, err := findDeadLetterEntry(id)
+	if err != nil {
+		return "", err
+	}
+	if entry.record.Corrupt {
+		return "", fmt.Errorf("dead-letter record %q is corrupt and cannot be retried", entry.record.ID)
+	}
+	storage, err := NewStorageWithProfile(entry.event.Profile)
+	if err != nil {
+		return "", fmt.Errorf("open profile %q: %w", entry.event.Profile, err)
+	}
+	defer storage.Close()
+	instances, _, err := storage.LoadWithGroups()
+	if err != nil {
+		return "", fmt.Errorf("load profile %q: %w", entry.event.Profile, err)
+	}
+	byID := make(map[string]*Instance, len(instances))
+	for _, inst := range instances {
+		byID[inst.ID] = inst
+	}
+	child := byID[entry.event.ChildSessionID]
+	if child == nil {
+		return "", fmt.Errorf("retry failed: child target %q no longer exists; record retained", entry.event.ChildSessionID)
+	}
+	if child.NoTransitionNotify {
+		return "", fmt.Errorf("retry failed: child %q still has transition notifications disabled; record retained", child.ID)
+	}
+	parent := resolveParentNotificationTarget(child, byID)
+	if parent == nil {
+		target := strings.TrimSpace(child.ParentSessionID)
+		if target == "" {
+			target = entry.event.TargetSessionID
+		}
+		return "", fmt.Errorf("retry failed: parent target %q no longer exists or is not deliverable; record retained", target)
+	}
+	event := entry.event
+	event.TargetSessionID = parent.ID
+	event.DeadLetterReason = ""
+	event.Attempts = 0
+	event.DeliveryResult = transitionDeliveryCommitted
+	if err := CommitToInbox(parent.ID, event); err != nil {
+		return "", fmt.Errorf("retry delivery to %q failed; record retained: %w", parent.ID, err)
+	}
+	if err := removeDeadLetterEntry(entry); err != nil {
+		return "", fmt.Errorf("delivered to %q but could not remove dead-letter record: %w", parent.ID, err)
+	}
+	return parent.ID, nil
+}
+
+// PurgeDeadLetter removes exactly one selected record.
+func PurgeDeadLetter(id string) error {
+	entry, err := findDeadLetterEntry(id)
+	if err != nil {
+		return err
+	}
+	return removeDeadLetterEntry(entry)
+}
+
+// PurgeDeadLettersOlderThan removes only records with a valid timestamp older
+// than cutoff. Corrupt/undated records require explicit per-record or all purge.
+func PurgeDeadLettersOlderThan(cutoff time.Time) (int, error) {
+	entries, err := readDeadLetterEntries(time.Now())
+	if err != nil {
+		return 0, err
+	}
+	removed := 0
+	for _, entry := range entries {
+		if entry.record.Timestamp.IsZero() || !entry.record.Timestamp.Before(cutoff) {
+			continue
+		}
+		if err := removeDeadLetterEntry(entry); err != nil {
+			return removed, err
+		}
+		removed++
+	}
+	return removed, nil
+}
+
+// PurgeAllDeadLetters removes every selected physical record. Callers must
+// enforce explicit user confirmation before invoking this unbounded operation.
+func PurgeAllDeadLetters() (int, error) {
+	entries, err := readDeadLetterEntries(time.Now())
+	if err != nil {
+		return 0, err
+	}
+	removed := 0
+	for _, entry := range entries {
+		if err := removeDeadLetterEntry(entry); err != nil {
+			return removed, err
+		}
+		removed++
+	}
+	return removed, nil
+}

--- a/internal/ui/dead_letter_panel.go
+++ b/internal/ui/dead_letter_panel.go
@@ -1,0 +1,215 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// DeadLetterPanel is the TUI counterpart of `inbox dead-letter`: it lists and
+// inspects bounded metadata, retries one record, and purges one record only
+// after an in-panel confirmation.
+type DeadLetterPanel struct {
+	visible      bool
+	width        int
+	height       int
+	cursor       int
+	detail       bool
+	confirmPurge bool
+	records      []session.DeadLetterRecord
+	status       string
+	loadErr      string
+}
+
+func NewDeadLetterPanel() *DeadLetterPanel { return &DeadLetterPanel{} }
+
+func (p *DeadLetterPanel) Show() {
+	if p == nil {
+		return
+	}
+	p.visible = true
+	p.detail = false
+	p.confirmPurge = false
+	p.status = ""
+	p.refresh()
+}
+
+func (p *DeadLetterPanel) Hide() {
+	if p != nil {
+		p.visible = false
+	}
+}
+
+func (p *DeadLetterPanel) IsVisible() bool { return p != nil && p.visible }
+
+func (p *DeadLetterPanel) SetSize(width, height int) {
+	if p != nil {
+		p.width, p.height = width, height
+	}
+}
+
+func (p *DeadLetterPanel) refresh() {
+	records, err := session.ListDeadLetters()
+	if err != nil {
+		p.loadErr = err.Error()
+		return
+	}
+	p.loadErr = ""
+	p.records = records
+	if p.cursor >= len(p.records) {
+		p.cursor = len(p.records) - 1
+	}
+	if p.cursor < 0 {
+		p.cursor = 0
+	}
+}
+
+func (p *DeadLetterPanel) selected() *session.DeadLetterRecord {
+	if p == nil || p.cursor < 0 || p.cursor >= len(p.records) {
+		return nil
+	}
+	return &p.records[p.cursor]
+}
+
+func (p *DeadLetterPanel) Update(msg tea.Msg) (*DeadLetterPanel, tea.Cmd) {
+	if p == nil || !p.visible {
+		return p, nil
+	}
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return p, nil
+	}
+	if p.confirmPurge {
+		switch key.String() {
+		case "y", "Y":
+			record := p.selected()
+			p.confirmPurge = false
+			if record == nil {
+				return p, nil
+			}
+			if err := session.PurgeDeadLetter(record.ID); err != nil {
+				p.status = "Purge failed: " + err.Error()
+			} else {
+				p.status = "Purged " + record.ID
+				p.detail = false
+				p.refresh()
+			}
+		case "n", "N", "esc":
+			p.confirmPurge = false
+		}
+		return p, nil
+	}
+
+	switch key.String() {
+	case "esc", "q", "alt+d":
+		if p.detail {
+			p.detail = false
+		} else {
+			p.Hide()
+		}
+	case "j", "down", "ctrl+n":
+		if !p.detail && p.cursor+1 < len(p.records) {
+			p.cursor++
+		}
+	case "k", "up", "ctrl+p":
+		if !p.detail && p.cursor > 0 {
+			p.cursor--
+		}
+	case "enter", "l":
+		if p.selected() != nil {
+			p.detail = true
+		}
+	case "h", "backspace":
+		p.detail = false
+	case "r":
+		record := p.selected()
+		if record == nil {
+			return p, nil
+		}
+		target, err := session.RetryDeadLetter(record.ID)
+		if err != nil {
+			p.status = err.Error()
+		} else {
+			p.status = fmt.Sprintf("Delivered %s to %s", record.ID, target)
+			p.detail = false
+			p.refresh()
+		}
+	case "d":
+		if p.selected() != nil {
+			p.confirmPurge = true
+		}
+	}
+	return p, nil
+}
+
+func (p *DeadLetterPanel) View() string {
+	if p == nil || !p.visible {
+		return ""
+	}
+	width := p.width - 6
+	if width < 48 {
+		width = 48
+	}
+	title := lipgloss.NewStyle().Bold(true).Foreground(ColorYellow).Render("Dead-letter events")
+	dim := lipgloss.NewStyle().Foreground(ColorTextDim)
+	var b strings.Builder
+	b.WriteString(title)
+	b.WriteString("\n")
+	b.WriteString(dim.Render("Bounded metadata only — prompt and output content are never shown."))
+	b.WriteString("\n\n")
+	if p.loadErr != "" {
+		b.WriteString(lipgloss.NewStyle().Foreground(ColorRed).Render("Unable to read records: " + p.loadErr))
+	} else if len(p.records) == 0 {
+		b.WriteString("No dead-lettered events.\n")
+	} else if p.detail {
+		b.WriteString(p.renderDetail())
+	} else {
+		for i, record := range p.records {
+			cursor := "  "
+			if i == p.cursor {
+				cursor = "> "
+			}
+			age := "now"
+			if record.AgeSeconds > 0 {
+				age = (time.Duration(record.AgeSeconds) * time.Second).Round(time.Second).String()
+			}
+			line := fmt.Sprintf("%s%-16s %-15s %-9s %s", cursor, record.ID, record.Reason, age, record.ChildSessionID)
+			b.WriteString(truncateStr(line, width))
+			b.WriteByte('\n')
+		}
+	}
+	if p.status != "" {
+		b.WriteString("\n")
+		b.WriteString(truncateStr(p.status, width))
+		b.WriteString("\n")
+	}
+	if p.confirmPurge {
+		b.WriteString("\nPurge only this record? y confirm / n cancel\n")
+	}
+	b.WriteString("\n")
+	b.WriteString(dim.Render("j/k navigate  enter show  r retry  d purge  esc close"))
+
+	box := lipgloss.NewStyle().
+		Width(width).
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(ColorBorder).
+		Padding(1, 2).
+		Render(b.String())
+	return lipgloss.Place(p.width, p.height, lipgloss.Center, lipgloss.Center, box)
+}
+
+func (p *DeadLetterPanel) renderDetail() string {
+	record := p.selected()
+	if record == nil {
+		return "No record selected.\n"
+	}
+	return fmt.Sprintf("ID: %s\nStore: %s\nChild: %s\nTitle: %s\nTarget: %s\nProfile: %s\nReason: %s\nAge: %ds\nAttempts: %d\nPayload: %s\n",
+		record.ID, record.Store, record.ChildSessionID, record.ChildTitle,
+		record.TargetSessionID, record.Profile, record.Reason, record.AgeSeconds,
+		record.Attempts, record.PayloadSummary)
+}

--- a/internal/ui/dead_letter_panel_test.go
+++ b/internal/ui/dead_letter_panel_test.go
@@ -1,0 +1,59 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func TestIssue2062DeadLetterPanelListShowRetryAndConfirmedPurge(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	session.ClearUserConfigCache()
+
+	path := session.DeadLetterPathFor("gone-child")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	raw := `{"child_session_id":"gone-child","child_title":"worker","profile":"default","target_session_id":"gone-parent","timestamp":"` + time.Now().Add(-time.Hour).Format(time.RFC3339Nano) + `","attempts":5,"dead_letter_reason":"parent_removed","done_summary":"private prompt content"}` + "\n"
+	if err := os.WriteFile(path, []byte(raw), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	panel := NewDeadLetterPanel()
+	panel.SetSize(100, 30)
+	panel.Show()
+	view := panel.View()
+	if !strings.Contains(view, "gone-child") || !strings.Contains(view, "parent_removed") {
+		t.Fatalf("list missing record metadata: %q", view)
+	}
+	if strings.Contains(view, "private prompt") {
+		t.Fatalf("list exposed content: %q", view)
+	}
+
+	panel, _ = panel.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if detail := panel.View(); !strings.Contains(detail, "Payload:") || strings.Contains(detail, "private prompt") {
+		t.Fatalf("detail is missing or unsafe: %q", detail)
+	}
+	panel, _ = panel.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if !strings.Contains(panel.View(), "no longer exists") || len(panel.records) != 1 {
+		t.Fatalf("failed retry was not honest/retained: %q records=%d", panel.View(), len(panel.records))
+	}
+
+	panel, _ = panel.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	if !panel.confirmPurge {
+		t.Fatal("purge did not require confirmation")
+	}
+	panel, _ = panel.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if len(panel.records) != 0 {
+		t.Fatalf("confirmed selected purge retained records: %+v", panel.records)
+	}
+}

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -221,6 +221,7 @@ func (h *HelpOverlay) View() string {
 	worktreeSetupKey := h.key(hotkeyWorktreeSetup, "b")
 	worktreeKey := h.key(hotkeyWorktreeFinish, "W")
 	watcherPanelKey := h.key(hotkeyWatcherPanel, "w")
+	deadLettersKey := h.key(hotkeyDeadLetters, "alt+d")
 	agentsPanelKey := h.key(hotkeyAgentsPanel, "alt+a")
 	groupKey := h.key(hotkeyCreateGroup, "g")
 	undoKey := h.key(hotkeyUndoDelete, "Ctrl+Z")
@@ -323,6 +324,7 @@ func (h *HelpOverlay) View() string {
 			title: "WATCHERS",
 			items: [][2]string{
 				{watcherPanelKey, "Watcher panel"},
+				{deadLettersKey, "Dead-letter events"},
 			},
 		},
 		{

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -282,6 +282,7 @@ type Home struct {
 	feedbackSender       *feedback.Sender      // Sender constructed once in NewHome (Phase 3, per D-05)
 	watcherPanel         *WatcherPanel         // For showing watcher status and events
 	agentsPanel          *AgentsPanel          // Agents tab: adopted agents, grouped by machine
+	deadLetterPanel      *DeadLetterPanel      // Inspect, retry, and explicitly purge delivery failures
 	// agentsView is the last built fleet view; agentBySession indexes its
 	// rows by adopted session id so the session list can mark agent-owned
 	// rows and the preview pane can render their card. Both are empty for a
@@ -1510,6 +1511,7 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		feedbackSender:            feedback.NewSender(),
 		watcherPanel:              NewWatcherPanel(),
 		agentsPanel:               NewAgentsPanel(),
+		deadLetterPanel:           NewDeadLetterPanel(),
 		toolVisibilityPanel:       NewToolVisibilityPanel(),
 		insertBatchDuration:       defaultInsertBatchDuration,
 		insertOpenKeySender:       defaultInsertOpenKeySender,
@@ -5389,6 +5391,9 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.settingsPanel.SetSize(msg.Width, msg.Height)
 		h.watcherPanel.SetSize(msg.Width, msg.Height)
 		h.agentsPanel.SetSize(msg.Width, msg.Height)
+		if h.deadLetterPanel != nil {
+			h.deadLetterPanel.SetSize(msg.Width, msg.Height)
+		}
 		if h.toolVisibilityPanel != nil {
 			h.toolVisibilityPanel.SetSize(msg.Width, msg.Height)
 		}
@@ -7330,7 +7335,12 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return h, cmd
 		}
 
-		// Handle watcher panel (before settings panel)
+		// Handle delivery and watcher panels (before settings panel)
+		if h.deadLetterPanel != nil && h.deadLetterPanel.IsVisible() {
+			var cmd tea.Cmd
+			h.deadLetterPanel, cmd = h.deadLetterPanel.Update(msg)
+			return h, cmd
+		}
 		if h.agentsPanel.IsVisible() {
 			var cmd tea.Cmd
 			h.agentsPanel, cmd = h.agentsPanel.Update(msg)
@@ -8249,6 +8259,7 @@ func (h *Home) hasModalVisible() bool {
 		(h.toolVisibilityPanel != nil && h.toolVisibilityPanel.IsVisible()) ||
 		h.watcherPanel.IsVisible() || // hotkeyWatcherPanel overlay
 		h.agentsPanel.IsVisible() || // hotkeyAgentsPanel overlay
+		(h.deadLetterPanel != nil && h.deadLetterPanel.IsVisible()) || // hotkeyDeadLetters overlay
 		h.helpOverlay.IsVisible() || h.search.IsVisible() || h.globalSearch.IsVisible() ||
 		h.newDialog.IsVisible() || h.groupDialog.IsVisible() || h.forkDialog.IsVisible() ||
 		h.confirmDialog.IsVisible() || h.mcpDialog.IsVisible() || h.pluginDialog.IsVisible() || h.skillDialog.IsVisible() ||
@@ -9279,6 +9290,16 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		h.refreshWatcherPanel()
 		h.watcherPanel.Show()
 		h.watcherPanel.SetSize(h.width, h.height)
+		return h, nil
+
+	case defaultHotkeyBindings[hotkeyDeadLetters]:
+		// Dead-letter management is always available; an empty panel states that
+		// the warning is clear instead of making the shortcut mysteriously inert.
+		if h.deadLetterPanel == nil {
+			h.deadLetterPanel = NewDeadLetterPanel()
+		}
+		h.deadLetterPanel.Show()
+		h.deadLetterPanel.SetSize(h.width, h.height)
 		return h, nil
 
 	case defaultHotkeyBindings[hotkeyAgentsPanel]:
@@ -14543,7 +14564,10 @@ func (h *Home) renderFrame() string {
 		return h.setupWizard.View()
 	}
 
-	// Watcher panel is modal (before settings panel)
+	// Delivery and watcher panels are modal (before settings panel)
+	if h.deadLetterPanel != nil && h.deadLetterPanel.IsVisible() {
+		return h.deadLetterPanel.View()
+	}
 	if h.agentsPanel.IsVisible() {
 		return h.agentsPanel.View()
 	}

--- a/internal/ui/hotkeys.go
+++ b/internal/ui/hotkeys.go
@@ -50,6 +50,7 @@ const (
 	hotkeyReload           = "reload"
 	hotkeyDetach           = "detach"
 	hotkeyWatcherPanel     = "watcher_panel"
+	hotkeyDeadLetters      = "dead_letters"
 	// hotkeyAgentsPanel opens the Agents tab.
 	//
 	// The design mockup asks for "a". Every plain letter that reads as
@@ -127,6 +128,7 @@ var hotkeyActionOrder = []string{
 	hotkeyReload,
 	hotkeyDetach,
 	hotkeyWatcherPanel,
+	hotkeyDeadLetters,
 	hotkeyAgentsPanel,
 	hotkeySwitchSession,
 }
@@ -174,6 +176,7 @@ var defaultHotkeyBindings = map[string]string{
 	hotkeyReload:           "ctrl+r",
 	hotkeyDetach:           "ctrl+q",
 	hotkeyWatcherPanel:     "w",
+	hotkeyDeadLetters:      "alt+d",
 	hotkeyAgentsPanel:      "alt+a",
 	hotkeySwitchSession:    "ctrl+s",
 }

--- a/skills/agent-deck/SKILL.md
+++ b/skills/agent-deck/SKILL.md
@@ -63,6 +63,7 @@ What agent-deck does, at the noun level (independent of which surface — CLI / 
 | **Manage groups** | Move / delete groups; organize sessions hierarchically | CLI ✅ · TUI ✅ |
 | **Manage watchers** | Install / configure event-driven adapters (Gmail, GitHub, ntfy) — doorbell-not-messenger | CLI ✅ · TUI ✅ |
 | **Heartbeat orchestration** | Cron / ScheduleWakeup feeding the conductor periodic system-state nudges | CLI ✅ |
+| **Dead-letter triage** | `inbox dead-letter` list/show/retry/purge; `Alt+D` in the TUI | CLI + TUI ✅ |
 | **Worktree workflows** | `--worktree` to create isolated git-worktree-backed sessions for parallel branch work | CLI ✅ |
 | **Channel routing** | Telegram / Slack inbound delivery to the right conductor, with `--channels` per-session binding | CLI ✅ |
 | **Attach MCPs** | Per-session or global MCP plugin attach / detach / status, with optional pooling | CLI ✅ · TUI ✅ · Web UI ⚪ |

--- a/skills/agent-deck/references/cli-reference.md
+++ b/skills/agent-deck/references/cli-reference.md
@@ -14,6 +14,7 @@ Complete reference for all agent-deck CLI commands.
 - [Skill Commands](#skill-commands)
 - [Group Commands](#group-commands)
 - [Profile Commands](#profile-commands)
+- [Inbox Commands](#inbox-commands)
 - [Remote Commands](#remote-commands)
 - [Codex Hook Commands](#codex-hook-commands)
 - [DeepSeek Commands](#deepseek-commands)
@@ -592,6 +593,33 @@ agent-deck conductor list [--profile <name>]
 - Heartbeat sends use non-blocking `session send --no-wait -q` to avoid timeout churn when sessions are busy.
 - Bridge daemon is installed only when Telegram and/or Slack is configured in `[conductor]`.
 - Transition notifier daemon (`agent-deck notify-daemon`) is installed by setup and sends event nudges on `running -> waiting|error|idle` transitions (parent first, then conductor fallback).
+
+## Inbox Commands
+
+### dead-letter - Inspect and resolve terminal delivery failures
+
+```bash
+agent-deck inbox dead-letter list [--json]
+agent-deck inbox dead-letter show [--json] <record-id>
+agent-deck inbox dead-letter retry <record-id>
+agent-deck inbox dead-letter purge --older-than <duration>
+agent-deck inbox dead-letter purge --yes
+```
+
+`list` and `show` expose stable, bounded metadata only: record/session identity,
+reason, age, attempts, and a payload-type summary. They never print the raw
+record, prompt, completion summary, or pane output. IDs may be shortened to a
+unique prefix for `show` and `retry`.
+
+`retry` re-resolves the child's current parent and commits the event to that
+parent's durable inbox before removing exactly the delivered dead-letter record.
+If the child or parent no longer exists, or the target remains undeliverable,
+the command exits non-zero and retains the record.
+
+An unbounded purge requires `--yes`. `--older-than` is the non-interactive,
+bounded alternative; corrupt or undated records are never selected by an age
+bound. The command family also includes the `_unowned` discovery ledger so a
+successful triage can clear the warning reported by `inbox drain`.
 
 ## Remote Commands
 

--- a/skills/agent-deck/references/tui-reference.md
+++ b/skills/agent-deck/references/tui-reference.md
@@ -68,6 +68,7 @@ For remote group headers, `Enter`/`Tab` toggles collapse and `h`/Left collapses 
 | `Ctrl+R` | Manual refresh |
 | `Ctrl+Q` | Detach (keep tmux running) |
 | `$` | Cost Dashboard |
+| `Alt+D` | Dead-letter events (list, inspect, retry, confirmed selected purge) |
 | `q` / `Ctrl+C` | Quit |
 
 ## Local Status Indicators
@@ -83,6 +84,14 @@ For remote group headers, `Enter`/`Tab` toggles collapse and `h`/Left collapses 
 Federated remote rows currently carry coarse running/waiting/idle/error status; local Honest Status substates are not included in the remote payload.
 
 ## Dialogs
+
+### Dead-letter events (`Alt+D`)
+
+The panel mirrors `agent-deck inbox dead-letter`: `j`/`k` selects a record,
+`Enter` shows bounded metadata, `r` retries delivery, and `d` starts a selected
+record purge that must be confirmed with `y`. A retry that cannot resolve a live
+target reports the reason and retains the record. Raw prompt, output, and
+completion content are never rendered.
 
 ### New Session (`n`)
 


### PR DESCRIPTION
## What problem does this solve?

Fixes #2062. Operators can now inspect bounded dead-letter metadata, retry a record, and safely purge records from `agent-deck inbox`, including the `_unowned` discovery ledger that contributes to the warning count.

## Why this change

The durable records already exist, so the change adds an operator surface over the existing stores. Retry resolves the current child and parent, commits to the durable inbox, and removes only the delivered record; failed resolution retains the record. Unbounded deletion requires `--yes`, while `--older-than` is bounded. The TUI uses the same session APIs and requires confirmation for deletion.

## User impact

The permanent dead-letter warning is actionable from both CLI and TUI. Summaries omit raw prompt, completion, and pane content.

## Evidence

- Added CLI acceptance tests for list/show JSON safety, all persisted reason classes, honest missing-target retry, successful deduplicated retry, purge consent/age bounds, and `_unowned` warning clearing.
- Added TUI tests for bounded display, retry retention, and confirmed purge.
- `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...` passes.
- `gofmt` and `git diff --check` pass.
- Before this change there was no `inbox dead-letter` command family; the new tests fail to compile on the base revision because the APIs and commands are absent.

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [x] “Allow edits from maintainers” is enabled

<!-- gate:ai=authored model=gpt-5-codex intent=yes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added CLI tools to list, inspect, retry, and purge dead-letter events.
- Added a watcher-panel view for browsing event metadata, viewing details, retrying events, and confirming individual purges.
- Added the `Alt+D` shortcut and corresponding help entry for quick access.
- Added JSON output options and safeguards for retry and bulk purge operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->