### PR TITLE
ci: pin compatible govulncheck without changing the application toolchain

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -9,13 +9,17 @@ permissions:
 jobs:
   govulncheck:
     runs-on: ubuntu-latest
+    # govulncheck v1.8.0 requires Go 1.26. Keep this scan-only toolchain
+    # separate from the application's Go 1.25.13 floor in go.mod.
+    env:
+      GOTOOLCHAIN: local
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.25.13'
+          go-version: '1.26.0'
           check-latest: false
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.8.0
       - name: Run govulncheck (strict — fails on any reachable vuln)
         run: govulncheck ./...

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -9,17 +9,18 @@ permissions:
 jobs:
   govulncheck:
     runs-on: ubuntu-latest
-    # govulncheck v1.8.0 requires Go 1.26. Keep this scan-only toolchain
-    # separate from the application's Go 1.25.13 floor in go.mod.
+    # Keep the scan on the application's Go version so standard-library
+    # findings describe the shipped toolchain. v1.8.0 requires Go 1.26;
+    # v1.7.0 declares Go 1.25 and still reads the current vulnerability DB.
     env:
       GOTOOLCHAIN: local
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.0'
+          go-version: '1.25.13'
           check-latest: false
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.8.0
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
       - name: Run govulncheck (strict — fails on any reachable vuln)
         run: govulncheck ./...


### PR DESCRIPTION
## Problem
The security job fails before scanning: govulncheck@latest resolves to v1.8.0, which requires Go >=1.26.0; this repository uses Go1.25.13 with GOTOOLCHAIN=local. Observed in run34490755675/job102916560794, including PR2221.

## Change
Pin govulncheck v1.7.0, whose official go.mod requires Go1.25.0, and retain the application's Go1.25.13 scan toolchain. Keep GOTOOLCHAIN=local explicit. The live vulnerability database and strict reachable-vulnerability failure behavior are unchanged.

Using a different scan compiler alone could make standard-library findings describe a different toolchain from the shipped application.

## Validation
- Official v1.7.0 go.mod inspected.
- Scanner successfully built with Go1.25.13 in isolated HOME/XDG/cache/bin directories; build metadata confirms scanner v1.7.0 and Go1.25.13.
- git diff --check passed.
- No host Go tests run. Actual security scan and required CI remain pending; scanner installation success is not a clean scan.

## Scope
One workflow only. No application toolchain migration, disabled checks, ignored findings, secrets, session lifecycle or production-data changes. Independent review and required checks must pass before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Standardized vulnerability scanning to use the application’s configured Go toolchain.
  - Pinned the vulnerability scanner to version 1.7.0 for more consistent checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->