### PR TITLE
fix: redact credential-bearing spawn failure diagnostics

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -2378,6 +2378,23 @@ func (i *Instance) buildCodexCommand(baseCommand string) string {
 //     would not be the subcommand's prompt.
 //
 // In each of those cases the caller keeps the existing behaviour unchanged.
+// redactEmbeddedSpawnPrompt removes a prompt that StartWithMessage deliberately
+// placed in a launch command. The process still receives the original command;
+// only the failure diagnostic uses this copy, so prompt delivery semantics stay
+// unchanged. Both current positional-prompt builders append shellescape.Quote.
+func redactEmbeddedSpawnPrompt(command, prompt string) string {
+	for _, candidate := range []string{prompt, strings.TrimSpace(prompt)} {
+		if candidate == "" {
+			continue
+		}
+		quoted := shellescape.Quote(candidate)
+		if strings.HasSuffix(command, " "+quoted) {
+			return strings.TrimSuffix(command, " "+quoted) + " '[prompt redacted]'"
+		}
+	}
+	return command
+}
+
 func (i *Instance) buildCodexCommandWithPrompt(baseCommand, prompt string) (string, bool) {
 	command := i.buildCodexCommand(baseCommand)
 	if strings.TrimSpace(prompt) == "" {
@@ -5269,13 +5286,17 @@ func (i *Instance) StartWithMessage(message string) error {
 		}
 	}
 
+	diagnosticCommand := command
+	if promptEmbeddedInCommand {
+		diagnosticCommand = redactEmbeddedSpawnPrompt(command, message)
+	}
 	var containerName string
 	var err error
 	command, containerName, err = i.prepareCommand(command)
 	if err != nil {
 		// #1924: leave a reason behind. Without this the session sits on
 		// StatusError with no tmux session and nothing to diagnose from.
-		i.recordPrepareFailure(command, err)
+		i.recordPrepareFailure(diagnosticCommand, err)
 		return err
 	}
 	if containerName != "" {
@@ -5300,13 +5321,13 @@ func (i *Instance) StartWithMessage(message string) error {
 	// Start the tmux session
 	if err := i.tmuxSession.Start(command); err != nil {
 		// #1580: persist the tmux-level failure (sister path to Start()).
-		i.recordTmuxStartFailure(command, err)
+		i.recordTmuxStartFailure(diagnosticCommand, err)
 		return fmt.Errorf("failed to start tmux session: %w", err)
 	}
 
 	// #1580: fast-death watcher (sister path to Start()).
 	if command != "" && !i.expectsFastExit() {
-		i.startFastDeathWatcher(command, i.tmuxSession, i.ID, i.Tool, sessionLog)
+		i.startFastDeathWatcher(diagnosticCommand, i.tmuxSession, i.ID, i.Tool, sessionLog)
 	}
 
 	// CFG-07: emit a single-shot log line documenting which priority level

--- a/internal/session/spawn_failure.go
+++ b/internal/session/spawn_failure.go
@@ -55,113 +55,82 @@ func writeSpawnFailureRecord(rec SpawnFailureRecord) error {
 	return writeSpawnFailureRecordTo(rec, spawnFailureDir())
 }
 
-// envExportPattern matches shell export statements with single-quoted values
-// (including the quote escape produced by buildEnvExports) so persisted
-// commands never carry credential values. Only the value is redacted; the key
-// stays visible for diagnosis.
-var envExportPattern = regexp.MustCompile(`export ([A-Za-z_][A-Za-z0-9_]*)='(?:[^']*(?:'\\''[^']*)*)'`)
+// shellValuePattern is deliberately bounded to shell argument forms. It is
+// not a general secret detector: it recognizes values attached to an explicitly
+// sensitive environment variable or option and leaves session IDs, paths, and
+// ordinary command arguments intact. The optional final quote handles malformed
+// command strings safely without allowing the value to escape redaction.
+const shellValuePattern = `'(?:[^']*(?:'\\''[^']*)*)'?|"(?:\\.|[^"])*"?|[^\s;&|]+`
 
-// redactEnvValues strips env values from a persisted command or error string.
-// A restart --env API_KEY=... that fails during prepare would otherwise write
-// the literal secret into a sidecar that session show exposes.
-func redactEnvValues(s string) string {
-	return envExportPattern.ReplaceAllString(s, "export $1='[redacted]'")
+var (
+	shellAssignmentPattern     = regexp.MustCompile(`(?is)(\b(?:export[ \t]+)?([A-Za-z_][A-Za-z0-9_]*)[ \t]*=[ \t]*)((?:` + shellValuePattern + `))`)
+	sensitiveOptionPattern     = regexp.MustCompile(`(?is)(--([A-Za-z][A-Za-z0-9_-]*)=?[ \t]*)((?:` + shellValuePattern + `))`)
+	authorizationHeaderPattern = regexp.MustCompile(`(?is)(\b(?:proxy-)?authorization["']?[ \t]*[:=][ \t]*)(["']?)(bearer|basic)[ \t]+([^ \t\r\n,;'"&|]+)(["']?)`)
+)
+
+// redactSpawnFailureDiagnostic removes common credential-bearing values before
+// they cross a persistence, display, lifecycle, or log boundary. It is bounded
+// to explicit secret-shaped names plus Authorization Bearer/Basic headers; it
+// intentionally does not attempt to identify arbitrary prose as a secret.
+func redactSpawnFailureDiagnostic(s string) string {
+	s = authorizationHeaderPattern.ReplaceAllString(s, `${1}${2}${3} [redacted]${5}`)
+	s = redactSensitiveValues(s, shellAssignmentPattern)
+	return redactSensitiveValues(s, sensitiveOptionPattern)
 }
 
-// redactSidecarBytes redacts every string field of an already-persisted sidecar,
-// returning (redacted, true) only when something actually changed.
-//
-// It works on the decoded fields rather than the raw JSON text on purpose: a
-// value containing a quote carries the shell quote escape, which JSON in turn
-// escapes the backslash of, and envExportPattern would only half-match that —
-// a regex sweep over the raw bytes would leave part of such a secret on disk.
-// Decoding into
-// json.RawMessage (not into SpawnFailureRecord) keeps numbers byte-exact and
-// preserves fields written by a newer or older version of the struct, so a
-// rewrite never silently drops a record's contents.
-func redactSidecarBytes(data []byte) ([]byte, bool) {
-	var fields map[string]json.RawMessage
-	if err := json.Unmarshal(data, &fields); err != nil {
-		return nil, false
-	}
-	changed := false
-	for key, raw := range fields {
-		var s string
-		if err := json.Unmarshal(raw, &s); err != nil {
-			continue // not a string: numbers and nested shapes stay verbatim
+func redactSensitiveValues(s string, pattern *regexp.Regexp) string {
+	return pattern.ReplaceAllStringFunc(s, func(match string) string {
+		parts := pattern.FindStringSubmatch(match)
+		if len(parts) != 4 || !isSensitiveDiagnosticName(parts[2]) {
+			return match
 		}
-		redacted := redactEnvValues(s)
-		if redacted == s {
-			continue
+		// The header pass has already reduced this Authorization value to a
+		// scheme plus marker. Preserve that useful failure identity rather than
+		// replacing the entire header value a second time.
+		if strings.EqualFold(parts[2], "authorization") && strings.Contains(parts[3], "[redacted]") {
+			return match
 		}
-		encoded, err := json.Marshal(redacted)
-		if err != nil {
-			continue
-		}
-		fields[key] = encoded
-		changed = true
-	}
-	if !changed {
-		return nil, false
-	}
-	out, err := json.MarshalIndent(fields, "", "  ")
-	if err != nil {
-		return nil, false
-	}
-	return out, true
+		return parts[1] + redactedShellValue(parts[3])
+	})
 }
 
-// ensureSpawnFailureDirSecure hardens a spawn-failure directory that already
-// exists. os.MkdirAll leaves an EXISTING directory's mode untouched, so an
-// install upgraded from a version that created the dir 0755 keeps it — and every
-// 0644 sidecar already in it, written before redaction existed — readable by
-// every other local user. Without this, the redaction above only ever protects
-// fresh installs, and the credentials that actually leaked stay leaked.
-//
-// So: tighten the directory, then sweep the sidecars already in it — chmod 0600
-// AND rewrite them through the redactor, so a stored credential is removed from
-// disk rather than merely hidden behind directory permissions.
-//
-// Best-effort by construction: every step ignores its error and moves on. This
-// runs on the spawn-failure path only (a handful of files, and only when a
-// session has already failed to start), and it must never be the reason a
-// failure record fails to be written.
-func ensureSpawnFailureDirSecure(dir string) {
-	info, err := os.Stat(dir)
-	if err != nil || !info.IsDir() {
+func isSensitiveDiagnosticName(name string) bool {
+	upper := strings.ToUpper(name)
+	compact := strings.NewReplacer("_", "", "-", "").Replace(upper)
+	if strings.Contains(compact, "APIKEY") || strings.Contains(compact, "TOKEN") ||
+		strings.Contains(compact, "SECRET") || strings.Contains(compact, "PASSWORD") ||
+		strings.Contains(compact, "PASSWD") || strings.Contains(compact, "CREDENTIAL") ||
+		strings.Contains(compact, "AUTHORIZATION") {
+		return true
+	}
+	if upper == "AUTH" || upper == "KEY" || strings.HasSuffix(upper, "_KEY") || strings.HasSuffix(upper, "-KEY") {
+		return true
+	}
+	// OTEL headers are a known source of Authorization values (#2216). Other
+	// header options retain their non-secret diagnostic identity; an embedded
+	// Authorization Bearer/Basic value is handled by the header pattern above.
+	return strings.Contains(upper, "OTEL") && strings.Contains(upper, "HEADER")
+}
+
+func redactedShellValue(value string) string {
+	if strings.HasPrefix(value, "'") {
+		return "'[redacted]'"
+	}
+	if strings.HasPrefix(value, `"`) {
+		return `"[redacted]"`
+	}
+	return "[redacted]"
+}
+
+// redactSpawnFailureRecord is used at every sidecar boundary. In particular,
+// reads sanitize legacy records in memory only: old evidence remains untouched
+// on disk while every current presentation is safe to copy into an issue.
+func redactSpawnFailureRecord(rec *SpawnFailureRecord) {
+	if rec == nil {
 		return
 	}
-	if info.Mode().Perm() != 0o700 {
-		_ = os.Chmod(dir, 0o700)
-	}
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return
-	}
-	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
-			continue
-		}
-		fi, err := entry.Info()
-		// Lstat semantics: a symlink is never a regular file here, so we can
-		// neither chmod nor rewrite through one into an unrelated target.
-		if err != nil || !fi.Mode().IsRegular() {
-			continue
-		}
-		path := filepath.Join(dir, entry.Name())
-		if fi.Mode().Perm() != 0o600 {
-			_ = os.Chmod(path, 0o600)
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			continue
-		}
-		redacted, changed := redactSidecarBytes(data)
-		if !changed {
-			continue
-		}
-		_ = safeio.SafeOverwrite(path, redacted, safeio.Options{Perm: 0o600, SkipBackup: true})
-	}
+	rec.Command = redactSpawnFailureDiagnostic(rec.Command)
+	rec.DyingOutput = redactSpawnFailureDiagnostic(rec.DyingOutput)
 }
 
 // writeSpawnFailureRecordTo is the path-explicit variant, used by
@@ -173,17 +142,17 @@ func writeSpawnFailureRecordTo(rec SpawnFailureRecord, dir string) error {
 	if rec.Timestamp == 0 {
 		rec.Timestamp = time.Now().Unix()
 	}
-	// Single choke point: every writer funnels through here, so redaction and
-	// tight permissions cannot be forgotten at a call site.
-	rec.Command = redactEnvValues(rec.Command)
-	rec.DyingOutput = redactEnvValues(rec.DyingOutput)
+	// Single choke point: every new sidecar is redacted before it reaches disk.
+	// Do not sweep or rewrite older records here: legacy evidence must remain
+	// intact, and readSpawnFailureRecord redacts it at presentation time.
+	redactSpawnFailureRecord(&rec)
 	path := filepath.Join(dir, rec.InstanceID+".json")
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return fmt.Errorf("create spawn-failure dir: %w", err)
 	}
-	// MkdirAll above only sets the mode on a directory it creates; upgraded
-	// installs come with a 0755 one full of world-readable pre-fix sidecars.
-	ensureSpawnFailureDirSecure(filepath.Dir(path))
+	if err := os.Chmod(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("secure spawn-failure dir: %w", err)
+	}
 	data, err := json.MarshalIndent(rec, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal spawn-failure record: %w", err)
@@ -208,6 +177,9 @@ func readSpawnFailureRecord(instanceID string) (*SpawnFailureRecord, error) {
 	if err := json.Unmarshal(data, &rec); err != nil {
 		return nil, err
 	}
+	// Legacy records can predate persistence redaction. Sanitize only the
+	// returned copy so existing evidence is not deleted or rewritten.
+	redactSpawnFailureRecord(&rec)
 	return &rec, nil
 }
 
@@ -235,13 +207,17 @@ func (r *SpawnFailureRecord) FormatForDisplay() string {
 	if r == nil {
 		return ""
 	}
+	// Callers can construct a record directly, bypassing the sidecar reader.
+	// Keep this presentation boundary safe without changing the caller's value.
+	rec := *r
+	redactSpawnFailureRecord(&rec)
 	var b strings.Builder
 	b.WriteString("⚠  session failed to start\n")
-	switch r.Reason {
+	switch rec.Reason {
 	case "tmux_start_failed":
 		b.WriteString("The terminal session could not be created.\n")
 	case "spawn_died_fast":
-		fmt.Fprintf(&b, "The command exited almost immediately (after %dms).\n", r.ElapsedMs)
+		fmt.Fprintf(&b, "The command exited almost immediately (after %dms).\n", rec.ElapsedMs)
 	case "prepare_failed":
 		// Nothing was launched, so the default arm's "ended unexpectedly
 		// during startup" would be actively misleading here.
@@ -249,12 +225,12 @@ func (r *SpawnFailureRecord) FormatForDisplay() string {
 	default:
 		b.WriteString("The session ended unexpectedly during startup.\n")
 	}
-	if r.Command != "" {
-		fmt.Fprintf(&b, "\ncommand: %s\n", r.Command)
+	if rec.Command != "" {
+		fmt.Fprintf(&b, "\ncommand: %s\n", rec.Command)
 	}
-	if strings.TrimSpace(r.DyingOutput) != "" {
+	if strings.TrimSpace(rec.DyingOutput) != "" {
 		b.WriteString("\nlast output before exit:\n")
-		b.WriteString(strings.TrimRight(r.DyingOutput, "\n"))
+		b.WriteString(strings.TrimRight(rec.DyingOutput, "\n"))
 		b.WriteString("\n")
 	} else {
 		b.WriteString("\n(no output was captured before the process exited)\n")
@@ -435,9 +411,9 @@ func (i *Instance) watchForFastDeath(command string, gen uint64, wake <-chan str
 		logger.Error("spawn_died_fast",
 			slog.String("instance_id", logging.SanitizeValue(id)),
 			slog.String("tool", logging.SanitizeValue(tool)),
-			slog.String("command", logging.SanitizeValue(command)),
+			slog.String("command", logging.SanitizeValue(redactSpawnFailureDiagnostic(command))),
 			slog.Int64("elapsed_ms", elapsed),
-			slog.String("dying_output", logging.SanitizeValue(lastSnapshot)))
+			slog.String("dying_output", logging.SanitizeValue(redactSpawnFailureDiagnostic(lastSnapshot))))
 		return
 	}
 }
@@ -455,15 +431,17 @@ func (i *Instance) recordPrepareFailure(command string, prepErr error) {
 	if prepErr == nil {
 		return
 	}
+	safeCommand := redactSpawnFailureDiagnostic(command)
+	safeError := redactSpawnFailureDiagnostic(prepErr.Error())
 	rec := SpawnFailureRecord{
 		InstanceID: i.ID,
 		Tool:       i.Tool,
-		Command:    command,
+		Command:    safeCommand,
 		Reason:     "prepare_failed",
 		// Reusing DyingOutput for the error string, as recordTmuxStartFailure
 		// already does: there is no pane to snapshot, so the error IS the
 		// diagnostic.
-		DyingOutput: prepErr.Error(),
+		DyingOutput: safeError,
 	}
 	if err := writeSpawnFailureRecord(rec); err != nil {
 		sessionLog.Warn("spawn_failure_record_write_failed",
@@ -475,7 +453,7 @@ func (i *Instance) recordPrepareFailure(command string, prepErr error) {
 		Tool:       i.Tool,
 		Action:     "spawn_failed",
 		Source:     "prepare_command",
-		Reason:     prepErr.Error(),
+		Reason:     safeError,
 	})
 }
 
@@ -484,12 +462,14 @@ func (i *Instance) recordPrepareFailure(command string, prepErr error) {
 // the fast-death path this has no pane to snapshot — the error string is the
 // diagnostic.
 func (i *Instance) recordTmuxStartFailure(command string, startErr error) {
+	safeCommand := redactSpawnFailureDiagnostic(command)
+	safeError := redactSpawnFailureDiagnostic(startErr.Error())
 	rec := SpawnFailureRecord{
 		InstanceID:  i.ID,
 		Tool:        i.Tool,
-		Command:     command,
+		Command:     safeCommand,
 		Reason:      "tmux_start_failed",
-		DyingOutput: startErr.Error(),
+		DyingOutput: safeError,
 	}
 	if err := writeSpawnFailureRecord(rec); err != nil {
 		sessionLog.Warn("spawn_failure_record_write_failed",
@@ -501,7 +481,7 @@ func (i *Instance) recordTmuxStartFailure(command string, startErr error) {
 		Tool:       i.Tool,
 		Action:     "spawn_failed",
 		Source:     "spawn_watcher",
-		Reason:     startErr.Error(),
+		Reason:     safeError,
 	})
 }
 

--- a/internal/session/spawn_failure.go
+++ b/internal/session/spawn_failure.go
@@ -73,7 +73,7 @@ var (
 // to explicit secret-shaped names plus Authorization Bearer/Basic headers; it
 // intentionally does not attempt to identify arbitrary prose as a secret.
 func redactSpawnFailureDiagnostic(s string) string {
-	s = authorizationHeaderPattern.ReplaceAllString(s, `${1}${2}${3} [redacted]${5}`)
+	s = authorizationHeaderPattern.ReplaceAllString(s, `${1}${2}${3} [redacted]${4}`)
 	s = redactSensitiveValues(s, shellAssignmentPattern)
 	return redactSensitiveValues(s, sensitiveOptionPattern)
 }

--- a/internal/session/spawn_failure.go
+++ b/internal/session/spawn_failure.go
@@ -65,7 +65,7 @@ const shellValuePattern = `'(?:[^']*(?:'\\''[^']*)*)'?|"(?:\\.|[^"])*"?|[^\s;&|]
 var (
 	shellAssignmentPattern     = regexp.MustCompile(`(?is)(\b(?:export[ \t]+)?([A-Za-z_][A-Za-z0-9_]*)[ \t]*=[ \t]*)((?:` + shellValuePattern + `))`)
 	sensitiveOptionPattern     = regexp.MustCompile(`(?is)(--([A-Za-z][A-Za-z0-9_-]*)=?[ \t]*)((?:` + shellValuePattern + `))`)
-	authorizationHeaderPattern = regexp.MustCompile(`(?is)(\b(?:proxy-)?authorization["']?[ \t]*[:=][ \t]*)(["']?)(bearer|basic)[ \t]+([^ \t\r\n,;'"&|]+)(["']?)`)
+	authorizationHeaderPattern = regexp.MustCompile(`(?is)(\b(?:proxy-)?authorization["']?[ \t]*[:=][ \t]*)(["']?)(bearer|basic)[ \t]+(?:'[^'\r\n]*'?|"[^"\r\n]*"?|[^ \t\r\n,;'"&|]+)(["']?)`)
 )
 
 // redactSpawnFailureDiagnostic removes common credential-bearing values before

--- a/internal/session/spawn_failure_redaction_test.go
+++ b/internal/session/spawn_failure_redaction_test.go
@@ -108,6 +108,30 @@ func TestRedactSpawnFailureDiagnostic_CoversBoundedCredentialForms(t *testing.T)
 			contains: `Authorization="Bearer [redacted]"`,
 		},
 		{
+			name:     "single quoted bearer authorization credential",
+			input:    `Authorization: Bearer 'single-quoted-bearer-marker' mytool`,
+			secret:   "single-quoted-bearer-marker",
+			contains: "Authorization: Bearer [redacted] mytool",
+		},
+		{
+			name:     "double quoted basic authorization credential",
+			input:    `Authorization: Basic "double-quoted-basic-marker" mytool`,
+			secret:   "double-quoted-basic-marker",
+			contains: "Authorization: Basic [redacted] mytool",
+		},
+		{
+			name:     "malformed single quoted authorization credential",
+			input:    "Authorization: Bearer 'unterminated-single-marker\nnormal diagnostic survives",
+			secret:   "unterminated-single-marker",
+			contains: "Authorization: Bearer [redacted]\nnormal diagnostic survives",
+		},
+		{
+			name:     "malformed double quoted authorization credential",
+			input:    "Authorization: Basic \"unterminated-double-marker\nnormal diagnostic survives",
+			secret:   "unterminated-double-marker",
+			contains: "Authorization: Basic [redacted]\nnormal diagnostic survives",
+		},
+		{
 			name:     "malformed quote remains safe",
 			input:    "export ACCESS_TOKEN='token-marker unterminated",
 			secret:   "token-marker",
@@ -127,6 +151,53 @@ func TestRedactSpawnFailureDiagnostic_CoversBoundedCredentialForms(t *testing.T)
 				t.Fatalf("redacted diagnostic = %q, missing %q", got, tc.contains)
 			}
 		})
+	}
+}
+
+// Quoted Authorization credentials must be redacted before persistence and
+// remain redacted when the saved record is rendered for display.
+func TestSpawnFailureRecord_RedactsQuotedAuthorizationAtPersistenceAndDisplay(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "runtime", "spawn-failure")
+	markers := []string{
+		"persisted-single-quoted-bearer-marker",
+		"persisted-double-quoted-basic-marker",
+		"persisted-unterminated-single-marker",
+		"persisted-unterminated-double-marker",
+	}
+	rec := SpawnFailureRecord{
+		InstanceID: "quoted-authorization",
+		Tool:       "generic",
+		Command:    "mytool --session-id session-keep",
+		Reason:     "prepare_failed",
+		DyingOutput: "Authorization: Bearer 'persisted-single-quoted-bearer-marker'\n" +
+			"Authorization: Basic \"persisted-double-quoted-basic-marker\"\n" +
+			"Authorization: Bearer 'persisted-unterminated-single-marker\n" +
+			"Authorization: Basic \"persisted-unterminated-double-marker",
+	}
+	if err := writeSpawnFailureRecordTo(rec, dir); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "quoted-authorization.json"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var got SpawnFailureRecord
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, marker := range markers {
+		if strings.Contains(string(data), marker) {
+			t.Fatalf("quoted credential marker leaked into sidecar: %s", marker)
+		}
+		if strings.Contains(got.FormatForDisplay(), marker) {
+			t.Fatalf("quoted credential marker leaked through display: %s", marker)
+		}
+	}
+	if !strings.Contains(got.Command, "--session-id session-keep") ||
+		!strings.Contains(got.FormatForDisplay(), "Authorization: Bearer [redacted]") ||
+		!strings.Contains(got.FormatForDisplay(), "Authorization: Basic [redacted]") {
+		t.Fatalf("redaction did not preserve normal diagnostics: %+v", got)
 	}
 }
 

--- a/internal/session/spawn_failure_redaction_test.go
+++ b/internal/session/spawn_failure_redaction_test.go
@@ -8,40 +8,50 @@ import (
 	"testing"
 )
 
-// Reproduction of the credential leak: a failed restart with --env used to
-// persist the literal `export API_KEY='secret'` into a 0644 sidecar exposed
-// by session show. The record writer must redact values and write 0600.
-func TestSpawnFailureRecord_RedactsEnvValuesAndTightensPerms(t *testing.T) {
-	// A child the writer has to create itself, so the 0700 directory mode is
-	// exercised rather than inherited from t.TempDir().
+// A spawn failure is later exposed by session show --json, so new sidecars must
+// never retain credential values even when the sidecar is already 0600.
+func TestSpawnFailureRecord_RedactsCredentialsAtPersistenceBoundary(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "runtime", "spawn-failure")
+	markers := []string{"otel-bearer-marker", "api-key-marker", "basic-marker", "token-marker"}
 	rec := SpawnFailureRecord{
-		InstanceID:  "leaktest",
-		Tool:        "generic",
-		Command:     `export API_KEY='sk-live-SECRET' && export NOTE='it'\''s quoted' && mytool run`,
+		InstanceID: "leaktest",
+		Tool:       "generic",
+		Command: "cd /safe/recovery && " +
+			"export OTEL_EXPORTER_OTLP_TRACES_HEADERS='Authorization=Bearer otel-bearer-marker' && " +
+			"mytool --api-key=\"api-key-marker\" --session-id session-keep",
 		Reason:      "prepare_failed",
-		DyingOutput: `prepare failed running: export API_KEY='sk-live-SECRET' && mytool`,
+		DyingOutput: "upstream rejected Authorization: Basic basic-marker\nexport ACCESS_TOKEN='token-marker'",
 	}
 	if err := writeSpawnFailureRecordTo(rec, dir); err != nil {
 		t.Fatalf("write: %v", err)
 	}
+
 	path := filepath.Join(dir, "leaktest.json")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
-	if strings.Contains(string(data), "sk-live-SECRET") || strings.Contains(string(data), "quoted") {
-		t.Fatalf("credential value leaked into sidecar: %s", data)
+	for _, marker := range markers {
+		if strings.Contains(string(data), marker) {
+			t.Fatalf("credential marker leaked into sidecar: %s", marker)
+		}
 	}
 	var got SpawnFailureRecord
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if !strings.Contains(got.Command, "export API_KEY='[redacted]'") {
-		t.Fatalf("key name must stay visible with redacted value, got: %s", got.Command)
+	if !strings.Contains(got.Command, "OTEL_EXPORTER_OTLP_TRACES_HEADERS='[redacted]'") ||
+		!strings.Contains(got.Command, `--api-key="[redacted]"`) {
+		t.Fatalf("credential-bearing command values were not redacted: %s", got.Command)
 	}
-	if !strings.Contains(got.Command, "mytool run") {
-		t.Fatalf("non-secret command tail must survive, got: %s", got.Command)
+	if !strings.Contains(got.Command, "cd /safe/recovery") ||
+		!strings.Contains(got.Command, "mytool") ||
+		!strings.Contains(got.Command, "--session-id session-keep") {
+		t.Fatalf("non-secret command identity did not survive: %s", got.Command)
+	}
+	if !strings.Contains(got.DyingOutput, "Authorization: Basic [redacted]") ||
+		!strings.Contains(got.DyingOutput, "ACCESS_TOKEN='[redacted]'") {
+		t.Fatalf("credential-bearing output was not redacted: %s", got.DyingOutput)
 	}
 	info, err := os.Stat(path)
 	if err != nil {
@@ -59,75 +69,86 @@ func TestSpawnFailureRecord_RedactsEnvValuesAndTightensPerms(t *testing.T) {
 	}
 }
 
-// Upgrade path (#1934 review): the directory and the sidecars in it already
-// exist from a version that wrote them 0755/0644 with unredacted credentials.
-// os.MkdirAll leaves an existing directory's mode alone, so without an explicit
-// sweep the fix above would only protect fresh installs while the credentials
-// that actually leaked stayed world-readable on disk.
-func TestSpawnFailureRecord_TightensExistingDirAndSweepsOldSidecars(t *testing.T) {
-	dir := filepath.Join(t.TempDir(), "spawn-failure")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
+func TestRedactSpawnFailureDiagnostic_CoversBoundedCredentialForms(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		secret    string
+		contains  string
+		unchanged bool
+	}{
+		{
+			name:      "normal command preserved",
+			input:     "cd /recovery/session-42 && codex resume session-keep",
+			contains:  "codex resume session-keep",
+			unchanged: true,
+		},
+		{
+			name:     "shell escaped API key",
+			input:    `export API_KEY='api-key-marker'\''suffix' && mytool run`,
+			secret:   "api-key-marker",
+			contains: "export API_KEY='[redacted]' && mytool run",
+		},
+		{
+			name:     "multiline token",
+			input:    "TOKEN='token-marker\nsecond-line'\nmytool run",
+			secret:   "token-marker",
+			contains: "TOKEN='[redacted]'",
+		},
+		{
+			name:     "basic authorization header",
+			input:    `-H 'Authorization: Basic basic-marker' mytool`,
+			secret:   "basic-marker",
+			contains: "Authorization: Basic [redacted]",
+		},
+		{
+			name:     "bearer authorization header",
+			input:    `Authorization="Bearer bearer-marker" mytool`,
+			secret:   "bearer-marker",
+			contains: `Authorization="Bearer [redacted]"`,
+		},
+		{
+			name:     "malformed quote remains safe",
+			input:    "export ACCESS_TOKEN='token-marker unterminated",
+			secret:   "token-marker",
+			contains: "ACCESS_TOKEN='[redacted]'",
+		},
 	}
-	if err := os.Chmod(dir, 0o755); err != nil { // defeat any umask narrowing
-		t.Fatalf("chmod dir: %v", err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := redactSpawnFailureDiagnostic(tc.input)
+			if tc.unchanged && got != tc.input {
+				t.Fatalf("normal command changed: got %q want %q", got, tc.input)
+			}
+			if tc.secret != "" && strings.Contains(got, tc.secret) {
+				t.Fatalf("credential marker leaked: %q", got)
+			}
+			if !strings.Contains(got, tc.contains) {
+				t.Fatalf("redacted diagnostic = %q, missing %q", got, tc.contains)
+			}
+		})
 	}
-	old := filepath.Join(dir, "old-session.json")
-	oldBody := `{
-  "instance_id": "old-session",
-  "tool": "generic",
-  "command": "export API_KEY='sk-live-OLDSECRET' && mytool run",
-  "reason": "prepare_failed",
-  "dying_output": "prepare failed running: export API_KEY='sk-live-OLDSECRET'",
-  "elapsed_ms": 0,
-  "ts": 1765400000
 }
-`
-	if err := os.WriteFile(old, []byte(oldBody), 0o644); err != nil {
-		t.Fatalf("write old sidecar: %v", err)
-	}
-	if err := os.Chmod(old, 0o644); err != nil {
-		t.Fatalf("chmod old sidecar: %v", err)
-	}
 
-	if err := writeSpawnFailureRecordTo(SpawnFailureRecord{
-		InstanceID: "new-session",
-		Tool:       "generic",
-		Reason:     "prepare_failed",
-	}, dir); err != nil {
-		t.Fatalf("write: %v", err)
+// Older sidecars are evidence and must not be rewritten or deleted. Their
+// presentation is still redacted before an operator can copy it into an issue.
+func TestSpawnFailureRecord_LegacyEvidenceIsUnchangedAndDisplayIsRedacted(t *testing.T) {
+	legacy := &SpawnFailureRecord{
+		InstanceID:  "legacy-session",
+		Command:     "mytool -H 'Authorization: Bearer legacy-bearer-marker'",
+		Reason:      "prepare_failed",
+		DyingOutput: "export API_KEY='legacy-key-marker' failed",
 	}
-
-	dirInfo, err := os.Stat(dir)
-	if err != nil {
-		t.Fatalf("stat dir: %v", err)
+	before := *legacy
+	display := legacy.FormatForDisplay()
+	if strings.Contains(display, "legacy-bearer-marker") || strings.Contains(display, "legacy-key-marker") {
+		t.Fatalf("legacy credential leaked through display: %s", display)
 	}
-	if dirInfo.Mode().Perm() != 0o700 {
-		t.Fatalf("existing dir perms = %o, want 700", dirInfo.Mode().Perm())
+	if !strings.Contains(display, "Authorization: Bearer [redacted]") ||
+		!strings.Contains(display, "API_KEY='[redacted]'") {
+		t.Fatalf("legacy display was not redacted: %s", display)
 	}
-	oldInfo, err := os.Stat(old)
-	if err != nil {
-		t.Fatalf("stat old sidecar: %v", err)
-	}
-	if oldInfo.Mode().Perm() != 0o600 {
-		t.Fatalf("old sidecar perms = %o, want 600", oldInfo.Mode().Perm())
-	}
-	data, err := os.ReadFile(old)
-	if err != nil {
-		t.Fatalf("read old sidecar: %v", err)
-	}
-	// Tight perms alone would only hide the credential; it must be gone.
-	if strings.Contains(string(data), "sk-live-OLDSECRET") {
-		t.Fatalf("pre-existing credential still on disk: %s", data)
-	}
-	var got SpawnFailureRecord
-	if err := json.Unmarshal(data, &got); err != nil {
-		t.Fatalf("rewritten sidecar is not valid JSON: %v (%s)", err, data)
-	}
-	if !strings.Contains(got.Command, "export API_KEY='[redacted]'") || !strings.Contains(got.Command, "mytool run") {
-		t.Fatalf("rewrite must redact the value and keep the rest, got: %s", got.Command)
-	}
-	if got.InstanceID != "old-session" || got.Reason != "prepare_failed" || got.Timestamp != 1765400000 {
-		t.Fatalf("rewrite lost non-secret fields: %+v", got)
+	if *legacy != before {
+		t.Fatalf("display mutated legacy evidence: got %+v want %+v", legacy, before)
 	}
 }


### PR DESCRIPTION
## Summary
Fixes #2216. Redact explicit credential-shaped command/header values at persistence, legacy-read, display and error boundaries. Cover OTEL headers, quoted and unterminated Bearer/Basic credentials; retain useful nonsecret diagnostics. Existing sidecar evidence is not rewritten or deleted; actual launch commands are unchanged.

## Evidence
Exact head 84c41136: focused Spawn/Redact/Diagnostic tests and internal/session vet passed in a sealed non-root Linux container, init reaper enabled, no mounts/network, isolated HOME/XDG/caches. No host Go tests.
Independent review passed the preceding quoted-credential patch. Parent tests then caught an incorrect regex replacement group; this head corrects group 5 to group 4, preserving closing quotes. The failed receipt is retained and the same tests now pass. Final-head approval/CI remains required; no full-suite or security-scan pass is claimed for this PR yet.

## Boundaries
Bounded recognition of explicitly sensitive names/Authorization headers, not a claim to detect every arbitrary secret. No fleet lifecycle or transcript changes. Scanner installer fix PR #2231 is a separate prerequisite for reliable security CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Sensitive prompts, credentials, API keys, tokens, and authorization headers are now redacted from failure diagnostics, logs, and displayed command output.
  * Existing failure records are sanitized when displayed without modifying their stored files.
* **Bug Fixes**
  * Prevented embedded launch prompts and credential-bearing command values from appearing in spawn failure details.
* **Tests**
  * Expanded coverage for quoted, multiline, malformed, and legacy credential formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->