### PR TITLE
fix: protect shared tmux servers from per-session unit teardown

### DIFF
--- a/.claude/release-tests.yaml
+++ b/.claude/release-tests.yaml
@@ -909,12 +909,12 @@ tests:
   added: '2026-04-18'
   task: v1721-scope-to-service
   file: internal/tmux/tmux_service_integration_test.go
-  test_name: TestTmuxService_ExplicitStopDoesNotTriggerRestart
-  purpose: 'Removal semantics. systemctl --user stop must be a CLEAN stop — Restart=on-failure must NOT fire. This guarantees `agent-deck remove` is truly terminal and not papered over by auto-restart.'
+  test_name: TestTmuxService_ExplicitStopDoesNotKillSharedServer
+  purpose: 'Removal safety. Stopping a service-mode unit must preserve both sessions on its shared tmux server, preventing per-session teardown from killing sibling work.'
   source: .planning/v1721-scope-to-service/PLAN.md
   manual: false
   run:
-    command: go test ./internal/tmux/ -run TestTmuxService_ExplicitStopDoesNotTriggerRestart -count=1 -timeout 60s -v
+    command: go test ./internal/tmux/ -run TestTmuxService_ExplicitStopDoesNotKillSharedServer -count=1 -timeout 60s -v
     expected: pass
 - id: v1721-tmux-settings-get-launch-as
   added: '2026-04-18'

--- a/.github/workflows/tmux-systemd-user-acceptance.yml
+++ b/.github/workflows/tmux-systemd-user-acceptance.yml
@@ -26,13 +26,13 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout exact candidate
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
 
@@ -111,7 +111,7 @@ jobs:
 
       - name: Preserve systemd-user acceptance receipts
         if: always()
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: tmux-systemd-user-acceptance-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ env.TMUX_SYSTEMD_ACCEPTANCE_ROOT }}/receipts

--- a/.github/workflows/tmux-systemd-user-acceptance.yml
+++ b/.github/workflows/tmux-systemd-user-acceptance.yml
@@ -1,0 +1,118 @@
+# Real systemd-user acceptance for the tmux shared-server safety contract.
+#
+# This is intentionally separate from ordinary Go tests: it bootstraps a user
+# manager only on a disposable Ubuntu hosted runner, then explicitly enables
+# the build-tagged fixture. Missing prerequisites and skipped controls fail.
+
+name: tmux systemd-user acceptance
+
+on:
+  pull_request:
+    paths:
+      - 'internal/tmux/**'
+      - 'internal/testutil/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/tmux-systemd-user-acceptance.yml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  shared-tmux-unit-safety:
+    name: shared tmux unit safety (real user manager)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout exact candidate
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Create isolated test paths and receipt directory
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/tmux-systemd-user-acceptance"
+          mkdir -p "$root/home" "$root/xdg-config" "$root/xdg-data" "$root/xdg-cache" "$root/receipts"
+          {
+            echo "TMUX_SYSTEMD_ACCEPTANCE_ROOT=$root"
+            echo "HOME=$root/home"
+            echo "XDG_CONFIG_HOME=$root/xdg-config"
+            echo "XDG_DATA_HOME=$root/xdg-data"
+            echo "XDG_CACHE_HOME=$root/xdg-cache"
+            echo "XDG_STATE_HOME=$root/xdg-state"
+            echo "TMUX_SYSTEMD_ACCEPTANCE_RECEIPTS=$root/receipts"
+          } >> "$GITHUB_ENV"
+
+      # Bootstrap is deliberately workflow-only. Tests merely require the
+      # already-running manager and fail if this setup was not effective.
+      - name: Bootstrap and require disposable systemd user manager
+        shell: bash
+        run: |
+          set -euo pipefail
+          receipt="$TMUX_SYSTEMD_ACCEPTANCE_RECEIPTS/systemd-user-preflight.txt"
+          for binary in systemctl systemd-run tmux jq; do
+            command -v "$binary" | tee -a "$receipt"
+          done
+          uid="$(id -u)"
+          runtime_dir="/run/user/$uid"
+          sudo loginctl enable-linger "$USER"
+          sudo systemctl start "user@${uid}.service"
+          test -d "$runtime_dir"
+          test -S "$runtime_dir/bus"
+          export XDG_RUNTIME_DIR="$runtime_dir"
+          export DBUS_SESSION_BUS_ADDRESS="unix:path=$runtime_dir/bus"
+          systemctl --user show-environment | tee -a "$receipt"
+          systemctl --user is-active default.target | tee -a "$receipt"
+          {
+            echo "XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR"
+            echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS"
+            echo "AGENT_DECK_SYSTEMD_USER_ACCEPTANCE=1"
+          } >> "$GITHUB_ENV"
+
+      - name: Run required real-manager controls
+        shell: bash
+        env:
+          AGENT_DECK_SYSTEMD_USER_ACCEPTANCE: '1'
+          GOTOOLCHAIN: go1.25.13
+        run: |
+          set -euo pipefail
+          receipt="$TMUX_SYSTEMD_ACCEPTANCE_RECEIPTS/go-test.json"
+          tests=(
+            TestTmuxSystemdUser_ExplicitScope_KillModeNonePreservesSharedServer
+            TestTmuxSystemdUser_Service_KillModeNonePreservesSharedServer
+            TestTmuxSystemdUser_ServiceFallbackScope_KillModeNonePreservesSharedServer
+          )
+          pattern="^($(IFS='|'; echo "${tests[*]}"))$"
+          go test -json -count=1 -timeout 3m -tags systemd_user_integration \
+            -run "$pattern" ./internal/tmux | tee "$receipt"
+          for test_name in "${tests[@]}"; do
+            if jq -e --arg test_name "$test_name" \
+              'select(.Action == "pass" and .Test == $test_name)' "$receipt" >/dev/null; then
+              echo "control passed: $test_name"
+            else
+              echo "required control did not pass: $test_name" >&2
+              exit 1
+            fi
+            if jq -e --arg test_name "$test_name" \
+              'select(.Action == "skip" and .Test == $test_name)' "$receipt" >/dev/null; then
+              echo "required control was skipped: $test_name" >&2
+              exit 1
+            fi
+          done
+
+      - name: Preserve systemd-user acceptance receipts
+        if: always()
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v4.6.2
+        with:
+          name: tmux-systemd-user-acceptance-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.TMUX_SYSTEMD_ACCEPTANCE_ROOT }}/receipts
+          if-no-files-found: error

--- a/.github/workflows/tmux-systemd-user-acceptance.yml
+++ b/.github/workflows/tmux-systemd-user-acceptance.yml
@@ -95,15 +95,15 @@ jobs:
           go test -json -count=1 -timeout 3m -tags systemd_user_integration \
             -run "$pattern" ./internal/tmux | tee "$receipt"
           for test_name in "${tests[@]}"; do
-            if jq -e --arg test_name "$test_name" \
-              'select(.Action == "pass" and .Test == $test_name)' "$receipt" >/dev/null; then
+            if jq -s -e --arg test_name "$test_name" \
+              'any(.[]; .Action == "pass" and .Test == $test_name)' "$receipt" >/dev/null; then
               echo "control passed: $test_name"
             else
               echo "required control did not pass: $test_name" >&2
               exit 1
             fi
-            if jq -e --arg test_name "$test_name" \
-              'select(.Action == "skip" and .Test == $test_name)' "$receipt" >/dev/null; then
+            if jq -s -e --arg test_name "$test_name" \
+              'any(.[]; .Action == "skip" and .Test == $test_name)' "$receipt" >/dev/null; then
               echo "required control was skipped: $test_name" >&2
               exit 1
             fi

--- a/cmd/agent-deck/main_test.go
+++ b/cmd/agent-deck/main_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
 	"github.com/asheshgoplani/agent-deck/internal/ui"
 )
 
@@ -19,6 +20,8 @@ func TestTmuxAvailable(t *testing.T) {
 }
 
 func TestHomeInit(t *testing.T) {
+	previousDB := statedb.GetGlobal()
+	t.Cleanup(func() { statedb.SetGlobal(previousDB) })
 	home := ui.NewHome()
 	if home == nil {
 		t.Fatal("NewHome() returned nil")
@@ -26,6 +29,8 @@ func TestHomeInit(t *testing.T) {
 }
 
 func TestHomeView(t *testing.T) {
+	previousDB := statedb.GetGlobal()
+	t.Cleanup(func() { statedb.SetGlobal(previousDB) })
 	home := ui.NewHome()
 	view := home.View()
 	if view == "" {

--- a/cmd/agent-deck/remote_agent_harden_test.go
+++ b/cmd/agent-deck/remote_agent_harden_test.go
@@ -377,6 +377,14 @@ func TestRemoteAgent_ConcurrencyCap(t *testing.T) {
 		t.Fatalf("only MaxConcurrent requests may run at once, got %d started", got)
 	}
 	h.send(remoteAgentRequest{ID: 5, Cancel: true})
+	// A successful pipe write only proves the agent reader received the line,
+	// not that its request loop processed it. Wait for a following ping ack,
+	// which is emitted only after the cancel has removed request 5, before
+	// freeing a semaphore slot for the queued requests.
+	h.send(remoteAgentRequest{ID: 6, Ping: true})
+	if r := h.next("cancel barrier"); r.ID != 6 || r.Code != 0 {
+		t.Fatalf("cancel barrier reply = %+v, want successful ping acknowledgement", r)
+	}
 	close(release)
 	ids := map[int64]bool{}
 	for i := 0; i < 4; i++ {

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -2665,9 +2665,10 @@ type TmuxSettings struct {
 
 	// LaunchAs selects the spawn form for new tmux servers (v1.7.21+).
 	// Valid values (case-insensitive, whitespace-trimmed):
-	//   "scope"   — systemd-run --user --scope (PR #467 legacy behavior)
+	//   "scope"   — systemd-run --user --scope with KillMode=none, so
+	//               stopping one per-session scope cannot kill a shared server.
 	//   "service" — systemd-run --user --unit <NAME>.service with
-	//               Type=forking + Restart=on-failure. Adds auto-restart
+	//               Type=forking + Restart=on-failure + KillMode=none. Adds auto-restart
 	//               if the tmux daemon dies unexpectedly (OOM, SIGKILL,
 	//               kernel signal). Opt-in defense-in-depth.
 	//   "direct"  — plain `tmux new-session` (no systemd isolation).
@@ -2680,8 +2681,9 @@ type TmuxSettings struct {
 	// LaunchInUserScope) so a config typo doesn't silently opt the user
 	// onto an unintended spawn path.
 	//
-	// This is additive — v1.7.20 users get zero behavior change until
-	// they explicitly set launch_as.
+	// Both systemd forms preserve SSH/logout isolation while avoiding a
+	// control-group teardown of a shared tmux server. This changes only units
+	// spawned after #2219; existing transient units are never migrated.
 	LaunchAs *string `toml:"launch_as,omitempty"`
 
 	// WindowStyleOverride sets the tmux window-style (and window-active-style) for

--- a/internal/tmux/service_unit_ownership.go
+++ b/internal/tmux/service_unit_ownership.go
@@ -86,6 +86,13 @@ const (
 	// UnitStopSkipProcessAlive: the unit still supervises a live process we
 	// cannot prove is exclusively ours.
 	UnitStopSkipProcessAlive = "unit_process_alive"
+	// UnitStopSkipOwnershipUnproven means the exact socket/PID/starttime/
+	// cgroup evidence does not bind the retired server to this unit.
+	UnitStopSkipOwnershipUnproven = "ownership_unproven"
+	// UnitStopSkipUnsafeKillMode means an existing unit can still kill its
+	// whole cgroup. It is never stopped by this path, even if it looks empty:
+	// a sibling may attach after the occupancy probe.
+	UnitStopSkipUnsafeKillMode = "unsafe_unit_kill_mode"
 )
 
 // ServiceUnitOwnership is the evidence a caller supplies to prove it may
@@ -106,6 +113,16 @@ type ServiceUnitOwnership struct {
 	// gate distinguish "our generation is somehow still alive" from
 	// "systemd already spawned a replacement generation".
 	RetiredServerPID int
+
+	// RetiredServerStartTime is field 22 from /proc/<pid>/stat. It binds the
+	// PID to one process incarnation so PID reuse can never turn a stale
+	// snapshot into ownership of an unrelated server.
+	RetiredServerStartTime string
+
+	// RetiredServerCgroup is the exact cgroup read from that PID before
+	// teardown. It must exactly match the derived unit's ControlGroup before
+	// the unit may be retired; a name-derived unit alone is never ownership.
+	RetiredServerCgroup string
 }
 
 // ServiceUnitDecision reports what the ownership gate decided.
@@ -123,6 +140,17 @@ type serviceUnitState struct {
 	ActiveState  string
 	MainPID      int
 	MainPIDAlive bool
+	ControlGroup string
+	KillMode     string
+}
+
+// serverProcessEvidence is the immutable identity and cgroup location of a
+// tmux server process. It deliberately contains no executable/process-name
+// heuristic: ownership comes only from the session's exact socket probe plus
+// PID start time and cgroup membership.
+type serverProcessEvidence struct {
+	StartTime string
+	Cgroup    string
 }
 
 // systemctlLookPath is a swappable seam so tests can simulate a host with
@@ -150,12 +178,45 @@ var unitPIDAlive = func(pid int) bool {
 // production always uses the bounded single `list-sessions` probe.
 var liveSessionsOnSocket = ListSessionNamesOnSocket
 
+// readServerProcessEvidence reads the cgroup-v2 location and immutable start
+// time for pid. It is a seam so tests can deterministically model PID reuse
+// and cgroup ownership without touching /proc.
+var readServerProcessEvidence = func(pid int) (serverProcessEvidence, error) {
+	stat, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
+	if err != nil {
+		return serverProcessEvidence{}, err
+	}
+	closeParen := strings.LastIndex(string(stat), ")")
+	if closeParen < 0 {
+		return serverProcessEvidence{}, os.ErrInvalid
+	}
+	// Fields after the final ')' begin at proc field 3, so starttime (field
+	// 22) is index 19. Parsing after the final ')' handles names containing
+	// spaces or parentheses without relying on the process name as identity.
+	fields := strings.Fields(string(stat[closeParen+1:]))
+	const startTimeIndex = 19
+	if len(fields) <= startTimeIndex || fields[startTimeIndex] == "" {
+		return serverProcessEvidence{}, os.ErrInvalid
+	}
+
+	cgroups, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/cgroup")
+	if err != nil {
+		return serverProcessEvidence{}, err
+	}
+	for _, line := range strings.Split(string(cgroups), "\n") {
+		if _, path, ok := strings.Cut(strings.TrimSpace(line), "0::"); ok && path != "" {
+			return serverProcessEvidence{StartTime: fields[startTimeIndex], Cgroup: path}, nil
+		}
+	}
+	return serverProcessEvidence{}, os.ErrInvalid
+}
+
 // readServiceUnitState reads ActiveState + MainPID for one unit. Returns
 // an error when systemctl cannot be consulted — an unknown unit is NOT an
 // error (systemd reports ActiveState=inactive / MainPID=0 for not-found).
 var readServiceUnitState = func(unit string) (serviceUnitState, error) {
 	out, err := execCommand("systemctl", "--user", "show", unit,
-		"-p", "ActiveState", "-p", "MainPID").Output()
+		"-p", "ActiveState", "-p", "MainPID", "-p", "ControlGroup", "-p", "KillMode").Output()
 	if err != nil {
 		return serviceUnitState{}, err
 	}
@@ -178,6 +239,10 @@ func parseServiceUnitState(out string) serviceUnitState {
 			if n, err := strconv.Atoi(strings.TrimSpace(value)); err == nil && n > 0 {
 				st.MainPID = n
 			}
+		case "ControlGroup":
+			st.ControlGroup = strings.TrimSpace(value)
+		case "KillMode":
+			st.KillMode = strings.ToLower(strings.TrimSpace(value))
 		}
 	}
 	st.MainPIDAlive = unitPIDAlive(st.MainPID)
@@ -193,6 +258,24 @@ func unitStartJobInFlight(activeState string) bool {
 		return true
 	}
 	return false
+}
+
+// serviceUnitOwnershipProof verifies that the pre-teardown server identity
+// belongs to this exact service cgroup. The socket is proven by ServerPID's
+// tmux display-message probe; PID + starttime prevent PID reuse; cgroup binds
+// that server to the unit. Missing evidence is intentionally a refusal.
+func serviceUnitOwnershipProof(own ServiceUnitOwnership, state serviceUnitState) (bool, string) {
+	if own.RetiredServerPID <= 0 || own.RetiredServerStartTime == "" || own.RetiredServerCgroup == "" ||
+		state.ControlGroup == "" || own.RetiredServerCgroup != state.ControlGroup ||
+		!strings.HasSuffix(state.ControlGroup, "/"+ServiceUnitName(own.SessionName)) {
+		return false, UnitStopSkipOwnershipUnproven
+	}
+	if state.KillMode != "none" {
+		// Units created before #2219 commonly report control-group here. Do
+		// not stop them: another session can attach after our socket listing.
+		return false, UnitStopSkipUnsafeKillMode
+	}
+	return true, UnitStopReasonExclusive
 }
 
 // evaluateServiceUnitOwnership is the pure ownership predicate: given the
@@ -228,7 +311,7 @@ func evaluateServiceUnitOwnership(
 		}
 		return false, UnitStopSkipProcessAlive
 	}
-	return true, UnitStopReasonExclusive
+	return serviceUnitOwnershipProof(own, state)
 }
 
 // StopServiceUnitOwned stops + resets-failed the transient systemd-user
@@ -295,11 +378,29 @@ func (s *Session) ServiceUnitOwnership() ServiceUnitOwnership {
 	if s == nil {
 		return ServiceUnitOwnership{}
 	}
-	return ServiceUnitOwnership{
-		SessionName:      s.Name,
-		SocketName:       s.SocketName,
-		RetiredServerPID: s.ServerPID(),
+	own := ServiceUnitOwnership{SessionName: s.Name, SocketName: s.SocketName}
+	pid := s.ServerPID() // exact Session.SocketName probe; no name matching.
+	if pid <= 0 {
+		return own
 	}
+
+	first, err := readServerProcessEvidence(pid)
+	if err != nil {
+		return own
+	}
+	// Re-read the server PID and its immutable evidence. If it changed while
+	// snapshotting, PID reuse or server replacement made ownership unprovable.
+	if s.ServerPID() != pid {
+		return own
+	}
+	second, err := readServerProcessEvidence(pid)
+	if err != nil || first != second {
+		return own
+	}
+	own.RetiredServerPID = pid
+	own.RetiredServerStartTime = first.StartTime
+	own.RetiredServerCgroup = first.Cgroup
+	return own
 }
 
 // ServerPID returns the pid of the tmux server hosting this session, or 0

--- a/internal/tmux/service_unit_ownership_test.go
+++ b/internal/tmux/service_unit_ownership_test.go
@@ -81,6 +81,20 @@ func systemctlStopCalls(calls [][]string) [][]string {
 	return stops
 }
 
+// provenServiceOwnership is deterministic fake command/cgroup evidence for
+// one server generation. No host process, tmux socket, or systemd manager is
+// used by these tests.
+func provenServiceOwnership(name string) (ServiceUnitOwnership, serviceUnitState) {
+	cgroup := "/user.slice/user-1000.slice/user@1000.service/app.slice/" + ServiceUnitName(name)
+	return ServiceUnitOwnership{
+		SessionName:            name,
+		SocketName:             "isolated-test-socket",
+		RetiredServerPID:       4242,
+		RetiredServerStartTime: "123456",
+		RetiredServerCgroup:    cgroup,
+	}, serviceUnitState{ControlGroup: cgroup, KillMode: "none"}
+}
+
 // --- gate #1: the shared unit is reachable in the first place -------------
 
 // TestServiceUnitName_TwoSessionsCanShareOneUnit is the precondition the
@@ -292,6 +306,39 @@ func TestStopServiceUnitOwned_NoSystemctl_IsANoOp(t *testing.T) {
 	assert.Empty(t, *calls)
 }
 
+// TestStopServiceUnitOwned_UnknownOwnership_IssuesNoStop proves a unit name
+// is never enough. This models an existing server whose socket gave us a PID
+// but whose cgroup cannot be bound to the derived unit; no stop is allowed.
+func TestStopServiceUnitOwned_UnknownOwnership_IssuesNoStop(t *testing.T) {
+	const name = "agentdeck_removed_a1a1a1a1"
+	own, state := provenServiceOwnership(name)
+	own.RetiredServerCgroup = "/user.slice/user-1000.slice/foreign.scope"
+	state.ActiveState = "inactive"
+	calls := withServiceUnitSeams(t, state, nil, liveSet(), nil)
+
+	dec := StopServiceUnitOwned(own)
+	assert.False(t, dec.Stopped)
+	assert.Equal(t, UnitStopSkipOwnershipUnproven, dec.Reason)
+	assert.Empty(t, systemctlStopCalls(*calls))
+}
+
+// TestStopServiceUnitOwned_ExistingControlGroupUnit_IssuesNoStop protects
+// servers created before #2219. They retain KillMode=control-group, so even
+// otherwise matching evidence must fail closed rather than race a sibling
+// attach and kill the shared server.
+func TestStopServiceUnitOwned_ExistingControlGroupUnit_IssuesNoStop(t *testing.T) {
+	const name = "agentdeck_removed_a1a1a1a1"
+	own, state := provenServiceOwnership(name)
+	state.ActiveState = "inactive"
+	state.KillMode = "control-group"
+	calls := withServiceUnitSeams(t, state, nil, liveSet(), nil)
+
+	dec := StopServiceUnitOwned(own)
+	assert.False(t, dec.Stopped)
+	assert.Equal(t, UnitStopSkipUnsafeKillMode, dec.Reason)
+	assert.Empty(t, systemctlStopCalls(*calls))
+}
+
 // --- gate #4: shutdown only once ownership is established ----------------
 
 // TestStopServiceUnitOwned_ExclusiveOwner_StopsAndResetsFailed: the server
@@ -300,14 +347,11 @@ func TestStopServiceUnitOwned_NoSystemctl_IsANoOp(t *testing.T) {
 // must not resurrect the session).
 func TestStopServiceUnitOwned_ExclusiveOwner_StopsAndResetsFailed(t *testing.T) {
 	const name = "agentdeck_removed_a1a1a1a1"
-	calls := withServiceUnitSeams(t,
-		serviceUnitState{ActiveState: "failed", MainPID: 0, MainPIDAlive: false},
-		nil,
-		liveSet(),
-		nil,
-	)
+	own, state := provenServiceOwnership(name)
+	state.ActiveState = "failed"
+	calls := withServiceUnitSeams(t, state, nil, liveSet(), nil)
 
-	dec := StopServiceUnitOwned(ServiceUnitOwnership{SessionName: name, RetiredServerPID: 4242})
+	dec := StopServiceUnitOwned(own)
 
 	require.True(t, dec.Stopped, "exclusive ownership must retire the unit")
 	assert.Equal(t, UnitStopReasonExclusive, dec.Reason)
@@ -322,17 +366,13 @@ func TestStopServiceUnitOwned_ExclusiveOwner_StopsAndResetsFailed(t *testing.T) 
 // unit's recorded main pid IS the generation we retired and it is dead.
 // Still exclusive — stop is allowed.
 func TestStopServiceUnitOwned_ExclusiveOwner_DeadOwnGeneration(t *testing.T) {
-	calls := withServiceUnitSeams(t,
-		serviceUnitState{ActiveState: "active", MainPID: 4242, MainPIDAlive: false},
-		nil,
-		liveSet(),
-		nil,
-	)
+	const name = "agentdeck_removed_a1a1a1a1"
+	own, state := provenServiceOwnership(name)
+	state.ActiveState = "active"
+	state.MainPID = 4242
+	calls := withServiceUnitSeams(t, state, nil, liveSet(), nil)
 
-	dec := StopServiceUnitOwned(ServiceUnitOwnership{
-		SessionName:      "agentdeck_removed_a1a1a1a1",
-		RetiredServerPID: 4242,
-	})
+	dec := StopServiceUnitOwned(own)
 
 	require.True(t, dec.Stopped)
 	assert.Equal(t, UnitStopReasonExclusive, dec.Reason)
@@ -405,9 +445,15 @@ func TestEvaluateServiceUnitOwnership_Table(t *testing.T) {
 			wantReason: UnitStopSkipProcessAlive,
 		},
 		{
-			name:       "exclusive owner",
-			own:        ServiceUnitOwnership{SessionName: self, RetiredServerPID: 1},
-			state:      serviceUnitState{ActiveState: "failed"},
+			name: "exclusive owner",
+			own: ServiceUnitOwnership{
+				SessionName: self, RetiredServerPID: 1, RetiredServerStartTime: "123456",
+				RetiredServerCgroup: "/user.slice/" + ServiceUnitName(self),
+			},
+			state: serviceUnitState{
+				ActiveState: "failed", KillMode: "none",
+				ControlGroup: "/user.slice/" + ServiceUnitName(self),
+			},
 			live:       liveSet(),
 			wantStop:   true,
 			wantReason: UnitStopReasonExclusive,

--- a/internal/tmux/systemd_reset_failed.go
+++ b/internal/tmux/systemd_reset_failed.go
@@ -1,11 +1,9 @@
 package tmux
 
-import "strings"
-
 // resetFailedReportsCollectedUnit recognizes only systemctl's complete reply
 // for the exact unit being absent after collection. All other reset-failed
 // errors, including manager and authorization failures, remain fatal.
 func resetFailedReportsCollectedUnit(output []byte, unit string) bool {
-	expected := "Failed to reset failed state of unit " + unit + ": Unit " + unit + " not loaded."
-	return strings.TrimSpace(string(output)) == expected
+	expected := "Failed to reset failed state of unit " + unit + ": Unit " + unit + " not loaded.\n"
+	return string(output) == expected
 }

--- a/internal/tmux/systemd_reset_failed.go
+++ b/internal/tmux/systemd_reset_failed.go
@@ -1,0 +1,11 @@
+package tmux
+
+import "strings"
+
+// resetFailedReportsCollectedUnit recognizes only systemctl's complete reply
+// for the exact unit being absent after collection. All other reset-failed
+// errors, including manager and authorization failures, remain fatal.
+func resetFailedReportsCollectedUnit(output []byte, unit string) bool {
+	expected := "Failed to reset failed state of unit " + unit + ": Unit " + unit + " not loaded."
+	return strings.TrimSpace(string(output)) == expected
+}

--- a/internal/tmux/systemd_reset_failed_test.go
+++ b/internal/tmux/systemd_reset_failed_test.go
@@ -18,6 +18,18 @@ func TestResetFailedReportsCollectedUnit(t *testing.T) {
 			want:   true,
 		},
 		{
+			name:   "unexpected leading whitespace is fatal",
+			output: " Failed to reset failed state of unit " + unit + ": Unit " + unit + " not loaded.\n",
+			unit:   unit,
+			want:   false,
+		},
+		{
+			name:   "extra newline is fatal",
+			output: "Failed to reset failed state of unit " + unit + ": Unit " + unit + " not loaded.\n\n",
+			unit:   unit,
+			want:   false,
+		},
+		{
 			name:   "different unit is not accepted",
 			output: "Failed to reset failed state of unit agentdeck-tmux-accept-other.scope: Unit agentdeck-tmux-accept-other.scope not loaded.",
 			unit:   unit,

--- a/internal/tmux/systemd_reset_failed_test.go
+++ b/internal/tmux/systemd_reset_failed_test.go
@@ -1,0 +1,47 @@
+package tmux
+
+import "testing"
+
+func TestResetFailedReportsCollectedUnit(t *testing.T) {
+	const unit = "agentdeck-tmux-accept-scope-1234.scope"
+
+	tests := []struct {
+		name   string
+		output string
+		unit   string
+		want   bool
+	}{
+		{
+			name:   "collected exact unit",
+			output: "Failed to reset failed state of unit agentdeck-tmux-accept-scope-1234.scope: Unit agentdeck-tmux-accept-scope-1234.scope not loaded.\n",
+			unit:   unit,
+			want:   true,
+		},
+		{
+			name:   "different unit is not accepted",
+			output: "Failed to reset failed state of unit agentdeck-tmux-accept-other.scope: Unit agentdeck-tmux-accept-other.scope not loaded.",
+			unit:   unit,
+			want:   false,
+		},
+		{
+			name:   "authorization failure containing absent text is fatal",
+			output: "Authorization failed while checking whether Unit agentdeck-tmux-accept-scope-1234.scope not loaded.",
+			unit:   unit,
+			want:   false,
+		},
+		{
+			name:   "manager failure is fatal",
+			output: "Failed to reset failed state of unit agentdeck-tmux-accept-scope-1234.scope: Access denied.",
+			unit:   unit,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resetFailedReportsCollectedUnit([]byte(tt.output), tt.unit); got != tt.want {
+				t.Errorf("resetFailedReportsCollectedUnit(%q, %q) = %t, want %t", tt.output, tt.unit, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1470,7 +1470,10 @@ func (s *Session) startCommandSpec(workDir, command string) (string, []string) {
 			"--property=RestartSec=5s",
 			"--property=StartLimitBurst=10",
 			"--property=StartLimitIntervalSec=60",
-			"--property=KillMode=control-group",
+			// A tmux server is shared by every session on its socket. A
+			// per-session unit must never kill that shared server (and its
+			// sibling panes) when the unit is stopped.
+			"--property=KillMode=none",
 			"--property=TimeoutStopSec=15s",
 			"tmux",
 		}
@@ -1478,10 +1481,13 @@ func (s *Session) startCommandSpec(workDir, command string) (string, []string) {
 		return "systemd-run", svcArgs
 
 	case launchModeScope:
-		// Legacy PR #467 shape — unchanged so existing users opting out
-		// of service mode with launch_as="scope" get identical semantics.
+		// The scope remains the SSH/logout-isolation compatibility path, but
+		// its cgroup can host the shared tmux server. KillMode=none prevents
+		// stopping this per-session scope from taking that server (and all
+		// sibling sessions) with it.
 		scopeArgs := []string{
-			"--user", "--scope", "--quiet", "--collect", "--unit", unitBase, "tmux",
+			"--user", "--scope", "--quiet", "--collect", "--unit", unitBase,
+			"--property=KillMode=none", "tmux",
 		}
 		scopeArgs = append(scopeArgs, tmuxArgs...)
 		return "systemd-run", scopeArgs
@@ -1497,7 +1503,11 @@ func (s *Session) startCommandSpec(workDir, command string) (string, []string) {
 // falling all the way back to direct tmux.
 func buildScopeArgsFromTmuxArgs(sessionName string, tmuxArgs []string) []string {
 	unitBase := serviceUnitBase(sessionName)
-	scopeArgs := []string{"--user", "--scope", "--quiet", "--collect", "--unit", unitBase, "tmux"}
+	// Keep the service → scope fallback just as safe as an explicitly
+	// selected scope. Otherwise a transient service failure would silently
+	// reintroduce a per-session cgroup that can kill a shared server.
+	scopeArgs := []string{"--user", "--scope", "--quiet", "--collect", "--unit", unitBase,
+		"--property=KillMode=none", "tmux"}
 	return append(scopeArgs, tmuxArgs...)
 }
 

--- a/internal/tmux/tmux_launch_as_test.go
+++ b/internal/tmux/tmux_launch_as_test.go
@@ -46,8 +46,8 @@ func TestStartCommandSpec_LaunchAs_Service_UsesServiceForm(t *testing.T) {
 	assert.Contains(t, joined, "--property=Restart=on-failure",
 		"Restart=on-failure is the entire point of v1.7.21 — its absence silently breaks the feature")
 	assert.Contains(t, joined, "--property=RestartSec=")
-	assert.Contains(t, joined, "--property=KillMode=control-group",
-		"KillMode=control-group ensures systemctl stop kills tmux cleanly via cgroup")
+	assert.Contains(t, joined, "--property=KillMode=none",
+		"a per-session service must not kill the shared tmux server's cgroup when stopped")
 
 	assert.NotContains(t, joined, "--scope",
 		"service mode MUST NOT include --scope (would conflict and produce an invalid unit)")
@@ -77,7 +77,8 @@ func TestStartCommandSpec_LaunchAs_Scope_UsesScopeForm(t *testing.T) {
 	require.GreaterOrEqual(t, len(args), 8)
 	assert.Equal(t, []string{"--user", "--scope", "--quiet", "--collect", "--unit"}, args[:5])
 	assert.Equal(t, "agentdeck-tmux-agentdeck-test-scope-1234abcd", args[5])
-	assert.Equal(t, "tmux", args[6])
+	assert.Equal(t, "--property=KillMode=none", args[6])
+	assert.Equal(t, "tmux", args[7])
 
 	joined := strings.Join(args, " ")
 	assert.NotContains(t, joined, "--property=Type=forking",
@@ -204,7 +205,7 @@ func TestStripSystemdRunPrefix_RecoversTmuxArgsFromServiceForm(t *testing.T) {
 		"--property=RestartSec=5s",
 		"--property=StartLimitBurst=10",
 		"--property=StartLimitIntervalSec=60",
-		"--property=KillMode=control-group",
+		"--property=KillMode=none",
 		"--property=TimeoutStopSec=15s",
 		"tmux",
 		"new-session", "-d", "-s", "name",

--- a/internal/tmux/tmux_service_integration_test.go
+++ b/internal/tmux/tmux_service_integration_test.go
@@ -1,3 +1,5 @@
+//go:build systemd_user_integration
+
 // Integration tests for the service-mode systemd invocation shape
 // produced by startCommandSpec (v1.7.21). These tests validate the REAL
 // systemd mechanism: spawn tmux as a transient service with the exact

--- a/internal/tmux/tmux_service_integration_test.go
+++ b/internal/tmux/tmux_service_integration_test.go
@@ -67,7 +67,7 @@ func spawnServiceModeTmux(t *testing.T, tmuxLName, tmuxSessName string) (unit st
 		"--property=RestartSec=2s", // shorter than production 5s for test speed
 		"--property=StartLimitBurst=10",
 		"--property=StartLimitIntervalSec=60",
-		"--property=KillMode=control-group",
+		"--property=KillMode=none",
 		"--property=TimeoutStopSec=15s",
 		// -L creates a test-isolated tmux socket so no default-socket server
 		// is contacted; this is the single necessary deviation from
@@ -100,9 +100,15 @@ func TestTmuxService_RestartsOnUnexpectedKill(t *testing.T) {
 	require.NoError(t, err, "service spawn must succeed on a systemd-user host")
 
 	t.Cleanup(func() {
-		_ = exec.Command("systemctl", "--user", "stop", unit).Run()
-		_ = exec.Command("systemctl", "--user", "reset-failed", unit).Run()
-		_ = exec.Command("tmux", "-L", tmuxLName, "kill-server").Run()
+		if err := exec.Command("systemctl", "--user", "stop", unit).Run(); err != nil {
+			t.Errorf("cleanup stop %s: %v", unit, err)
+		}
+		if err := exec.Command("tmux", "-L", tmuxLName, "kill-server").Run(); err != nil {
+			t.Errorf("cleanup kill isolated tmux server %s: %v", tmuxLName, err)
+		}
+		if err := exec.Command("systemctl", "--user", "reset-failed", unit).Run(); err != nil {
+			t.Errorf("cleanup reset-failed %s: %v", unit, err)
+		}
 	})
 
 	initialPID := waitForServicePID(t, unit, 5*time.Second)
@@ -134,11 +140,11 @@ func TestTmuxService_RestartsOnUnexpectedKill(t *testing.T) {
 		"NRestarts must be >=1 after SIGKILL; got %d", restarts)
 }
 
-// TestTmuxService_ExplicitStopDoesNotTriggerRestart: `systemctl --user
-// stop` on the service unit must be CLEAN — Restart=on-failure must NOT
-// fire. This is what guarantees `agent-deck remove` is truly terminal
-// and that a stopped service stays stopped.
-func TestTmuxService_ExplicitStopDoesNotTriggerRestart(t *testing.T) {
+// TestTmuxService_ExplicitStopDoesNotKillSharedServer verifies the #2219
+// safety contract in a disposable systemd-user fixture. The server is on an
+// exact private -L socket; stopping its per-session service must leave both
+// the original and a sibling tmux session alive.
+func TestTmuxService_ExplicitStopDoesNotKillSharedServer(t *testing.T) {
 	requireSystemdUserRun(t)
 	if _, err := exec.LookPath("tmux"); err != nil {
 		t.Skipf("tmux not available: %v", err)
@@ -150,24 +156,28 @@ func TestTmuxService_ExplicitStopDoesNotTriggerRestart(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		_ = exec.Command("systemctl", "--user", "stop", unit).Run()
-		_ = exec.Command("systemctl", "--user", "reset-failed", unit).Run()
-		_ = exec.Command("tmux", "-L", tmuxLName, "kill-server").Run()
+		if err := exec.Command("systemctl", "--user", "stop", unit).Run(); err != nil {
+			t.Errorf("cleanup stop %s: %v", unit, err)
+		}
+		if err := exec.Command("tmux", "-L", tmuxLName, "kill-server").Run(); err != nil {
+			t.Errorf("cleanup kill isolated tmux server %s: %v", tmuxLName, err)
+		}
+		if err := exec.Command("systemctl", "--user", "reset-failed", unit).Run(); err != nil {
+			t.Errorf("cleanup reset-failed %s: %v", unit, err)
+		}
 	})
 
-	pid := waitForServicePID(t, unit, 5*time.Second)
-	require.NotZero(t, pid)
+	require.NotZero(t, waitForServicePID(t, unit, 5*time.Second))
+	const sibling = "svcstop-sibling"
+	require.NoError(t, exec.Command("tmux", "-L", tmuxLName,
+		"new-session", "-d", "-s", sibling, "bash", "-c", "exec sleep 600").Run())
 
 	require.NoError(t, exec.Command("systemctl", "--user", "stop", unit).Run(),
 		"systemctl --user stop must succeed on an active unit")
-	_ = exec.Command("systemctl", "--user", "reset-failed", unit).Run()
-
-	// Give systemd a beat to finalize; then assert no new PID re-appears
-	// within a 4s window. Restart=on-failure must NOT fire on clean stop.
-	time.Sleep(4 * time.Second)
-	after := readServicePID(unit)
-	require.Zero(t, after,
-		"expected tmux daemon to stay dead after systemctl stop; got PID %d", after)
+	for _, name := range []string{tmuxSessName, sibling} {
+		require.NoError(t, exec.Command("tmux", "-L", tmuxLName, "has-session", "-t", name).Run(),
+			"stopping a per-session unit must not kill shared-server sibling %q", name)
+	}
 }
 
 // TestStopServiceUnitOwned_UnknownSessionNeverErrors: the teardown gate is

--- a/internal/tmux/tmux_systemd_user_acceptance_test.go
+++ b/internal/tmux/tmux_systemd_user_acceptance_test.go
@@ -1,0 +1,270 @@
+//go:build systemd_user_integration
+
+package tmux
+
+// This file is deliberately build-tagged. It launches real transient units and
+// tmux servers, so it is enabled only by the disposable GitHub Actions
+// acceptance job. Do not bootstrap a user manager from a test: the workflow
+// owns that privileged/disposable-host setup.
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const systemdUserAcceptanceEnv = "AGENT_DECK_SYSTEMD_USER_ACCEPTANCE"
+
+// requireSystemdUserAcceptance makes accidental local tagged runs fail closed.
+// The CI workflow sets the explicit opt-in only after it bootstraps and probes
+// a disposable user manager; missing binaries, runtime paths, or D-Bus are a
+// failure, never a Skip that could turn this acceptance gate green without
+// running its controls.
+func requireSystemdUserAcceptance(t *testing.T) {
+	t.Helper()
+	if os.Getenv(systemdUserAcceptanceEnv) != "1" {
+		t.Fatalf("%s=1 is required; this real systemd-user fixture is enabled only by its disposable CI workflow", systemdUserAcceptanceEnv)
+	}
+	for _, binary := range []string{"systemd-run", "systemctl", "tmux"} {
+		if _, err := exec.LookPath(binary); err != nil {
+			t.Fatalf("required acceptance prerequisite %q unavailable: %v", binary, err)
+		}
+	}
+	runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
+	if runtimeDir == "" {
+		t.Fatal("XDG_RUNTIME_DIR is required to address the disposable systemd user manager")
+	}
+	if info, err := os.Stat(runtimeDir); err != nil || !info.IsDir() {
+		t.Fatalf("XDG_RUNTIME_DIR=%q is not an accessible directory: %v", runtimeDir, err)
+	}
+	if os.Getenv("DBUS_SESSION_BUS_ADDRESS") == "" {
+		t.Fatal("DBUS_SESSION_BUS_ADDRESS is required; workflow must deliberately export the user-manager bus")
+	}
+	if out, err := exec.Command("systemctl", "--user", "show-environment").CombinedOutput(); err != nil {
+		t.Fatalf("systemd user manager is unavailable: %v\n%s", err, out)
+	}
+}
+
+// systemdUserTMuxFixture owns a unique socket directory and exactly one
+// transient unit. Cleanup addresses only that socket via -S: no PID/process
+// matching, no socket-name resolution, and never a global kill-server.
+type systemdUserTMuxFixture struct {
+	t           *testing.T
+	dir         string
+	socket      string
+	unit        string
+	unitStopped bool
+}
+
+func newSystemdUserTMuxFixture(t *testing.T, unit string) *systemdUserTMuxFixture {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "ad-systemd-user-")
+	require.NoError(t, err)
+	f := &systemdUserTMuxFixture{t: t, dir: dir, socket: filepath.Join(dir, "tmux.sock"), unit: unit}
+	t.Cleanup(f.cleanup)
+	return f
+}
+
+func (f *systemdUserTMuxFixture) command(name string, args ...string) *exec.Cmd {
+	cmd := exec.Command(name, args...)
+	// -S is authoritative, but also scrub inherited client-selection state so
+	// no command can be redirected toward a caller's tmux server.
+	var env []string
+	for _, kv := range os.Environ() {
+		if !strings.HasPrefix(kv, "TMUX") {
+			env = append(env, kv)
+		}
+	}
+	cmd.Env = env
+	return cmd
+}
+
+func (f *systemdUserTMuxFixture) spawnScope(t *testing.T, session string) {
+	t.Helper()
+	args := []string{
+		"--user", "--scope", "--quiet", "--collect", "--unit", strings.TrimSuffix(f.unit, ".scope"),
+		"--property=KillMode=none", "tmux", "-S", f.socket,
+		"new-session", "-d", "-s", session, "sh", "-c", "exec sleep 600",
+	}
+	out, err := f.command("systemd-run", args...).CombinedOutput()
+	require.NoErrorf(t, err, "explicit scope spawn failed: %s", out)
+	f.requireKillModeNone(t)
+	f.requireSession(t, session)
+}
+
+func (f *systemdUserTMuxFixture) spawnService(t *testing.T, session string) {
+	t.Helper()
+	args := []string{
+		"--user", "--unit", f.unit, "--quiet",
+		"--property=Type=forking",
+		"--property=Restart=on-failure",
+		"--property=RestartSec=2s",
+		"--property=StartLimitBurst=10",
+		"--property=StartLimitIntervalSec=60",
+		"--property=KillMode=none",
+		"--property=TimeoutStopSec=15s",
+		"tmux", "-S", f.socket,
+		"new-session", "-d", "-s", session, "sh", "-c", "exec sleep 600",
+	}
+	out, err := f.command("systemd-run", args...).CombinedOutput()
+	require.NoErrorf(t, err, "service spawn failed: %s", out)
+	f.requireKillModeNone(t)
+	f.requireSession(t, session)
+}
+
+func (f *systemdUserTMuxFixture) requireKillModeNone(t *testing.T) {
+	t.Helper()
+	out, err := f.command("systemctl", "--user", "show", f.unit, "-p", "KillMode", "--value").CombinedOutput()
+	require.NoErrorf(t, err, "could not inspect KillMode for %s: %s", f.unit, out)
+	require.Equal(t, "none", strings.TrimSpace(string(out)), "real user manager must apply KillMode=none to %s", f.unit)
+}
+
+func (f *systemdUserTMuxFixture) requireSession(t *testing.T, name string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var last []byte
+	for time.Now().Before(deadline) {
+		var err error
+		last, err = f.command("tmux", "-S", f.socket, "has-session", "-t", name).CombinedOutput()
+		if err == nil {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("session %q did not become reachable on exact socket %s: %s", name, f.socket, last)
+}
+
+func (f *systemdUserTMuxFixture) addSibling(t *testing.T, name string) {
+	t.Helper()
+	out, err := f.command("tmux", "-S", f.socket,
+		"new-session", "-d", "-s", name, "sh", "-c", "exec sleep 600").CombinedOutput()
+	require.NoErrorf(t, err, "sibling spawn failed on exact socket %s: %s", f.socket, out)
+	f.requireSession(t, name)
+}
+
+func (f *systemdUserTMuxFixture) stopUnit(t *testing.T) {
+	t.Helper()
+	out, err := f.command("systemctl", "--user", "stop", f.unit).CombinedOutput()
+	require.NoErrorf(t, err, "stop %s failed: %s", f.unit, out)
+	f.unitStopped = true
+}
+
+func (f *systemdUserTMuxFixture) cleanup() {
+	// If an assertion failed before the explicit stop, still retire only this
+	// exact transient unit. Continue to exact-socket teardown even if systemd
+	// reports an error so the server is never stranded.
+	if !f.unitStopped {
+		if out, err := f.command("systemctl", "--user", "stop", f.unit).CombinedOutput(); err != nil {
+			f.t.Errorf("cleanup stop %s: %v: %s", f.unit, err, out)
+		}
+	}
+
+	// KILL BEFORE REMOVE. A failure is reported and the directory is preserved:
+	// unlinking it after a failed kill-server would strand a live tmux server.
+	if out, err := f.command("tmux", "-S", f.socket, "kill-server").CombinedOutput(); err != nil {
+		f.t.Errorf("cleanup kill-server exact socket %s: %v: %s (socket directory preserved)", f.socket, err, out)
+		return
+	}
+	if out, err := f.command("tmux", "-S", f.socket, "has-session").CombinedOutput(); err == nil {
+		f.t.Errorf("cleanup kill-server reported success but exact socket %s remains reachable: %s (socket directory preserved)", f.socket, out)
+		return
+	}
+	if out, err := f.command("systemctl", "--user", "reset-failed", f.unit).CombinedOutput(); err != nil {
+		f.t.Errorf("cleanup reset-failed %s: %v: %s", f.unit, err, out)
+	}
+	if err := os.RemoveAll(f.dir); err != nil {
+		f.t.Errorf("cleanup remove socket directory %s after successful kill-server: %v", f.dir, err)
+	}
+}
+
+func acceptanceUnitBase(t *testing.T, kind string) string {
+	t.Helper()
+	return "agentdeck-tmux-accept-" + kind + "-" + randomServerSuffix(t)
+}
+
+// TestTmuxSystemdUser_ExplicitScope_... proves that a real user manager
+// accepts and applies KillMode=none to the explicit scope form. Stopping the
+// per-session scope must leave the owned and sibling sessions on the shared
+// exact socket alive.
+func TestTmuxSystemdUser_ExplicitScope_KillModeNonePreservesSharedServer(t *testing.T) {
+	requireSystemdUserAcceptance(t)
+	base := acceptanceUnitBase(t, "scope")
+	f := newSystemdUserTMuxFixture(t, base+".scope")
+	owner, sibling := "scope-owner", "scope-sibling"
+	f.spawnScope(t, owner)
+	f.addSibling(t, sibling)
+	f.stopUnit(t)
+	f.requireSession(t, owner)
+	f.requireSession(t, sibling)
+}
+
+// TestTmuxSystemdUser_Service_... covers the service form independently so a
+// passing scope test cannot mask a service property rejection or downgrade.
+func TestTmuxSystemdUser_Service_KillModeNonePreservesSharedServer(t *testing.T) {
+	requireSystemdUserAcceptance(t)
+	base := acceptanceUnitBase(t, "service")
+	f := newSystemdUserTMuxFixture(t, base+".service")
+	owner, sibling := "service-owner", "service-sibling"
+	f.spawnService(t, owner)
+	f.addSibling(t, sibling)
+	f.stopUnit(t)
+	f.requireSession(t, owner)
+	f.requireSession(t, sibling)
+}
+
+// TestTmuxSystemdUser_ServiceFallbackScope_... forces only the first service
+// invocation to fail at the launcher seam. Start then executes its real scope
+// retry against the real manager; the test inspects its applied property and
+// proves stopping that fallback scope cannot kill a sibling.
+func TestTmuxSystemdUser_ServiceFallbackScope_KillModeNonePreservesSharedServer(t *testing.T) {
+	requireSystemdUserAcceptance(t)
+
+	base := acceptanceUnitBase(t, "fallback")
+	dir, err := os.MkdirTemp("/tmp", "ad-systemd-fallback-")
+	require.NoError(t, err)
+	serverName := "fallback-" + randomServerSuffix(t)
+	socket := filepath.Join(dir, "tmux-"+strconv.Itoa(os.Getuid()), serverName)
+	// The fallback must exercise Start's real service→scope branch. Its -L
+	// server is still isolated because this test gives it a private TMUX_TMPDIR;
+	// cleanup resolves the resulting socket by this exact absolute path.
+	// systemd-run executes through the manager, which has its own environment.
+	// Set the private socket base on both sides so Start's -L probe and the
+	// manager's spawned tmux resolve to this fixture's one exact socket.
+	out, err := exec.Command("systemctl", "--user", "set-environment", "TMUX_TMPDIR="+dir).CombinedOutput()
+	require.NoErrorf(t, err, "set private manager TMUX_TMPDIR failed: %s", out)
+	t.Cleanup(func() {
+		if output, unsetErr := exec.Command("systemctl", "--user", "unset-environment", "TMUX_TMPDIR").CombinedOutput(); unsetErr != nil {
+			t.Errorf("cleanup unset manager TMUX_TMPDIR: %v: %s", unsetErr, output)
+		}
+	})
+	t.Setenv("TMUX_TMPDIR", dir)
+	f := &systemdUserTMuxFixture{t: t, dir: dir, socket: socket, unit: base + ".scope"}
+	t.Cleanup(f.cleanup)
+
+	originalExec := execCommand
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		if name == "systemd-run" && containsServiceUnitFlag(args) {
+			return exec.Command("false")
+		}
+		return originalExec(name, args...)
+	}
+	t.Cleanup(func() { execCommand = originalExec })
+
+	s := NewSession("accept-fallback-"+randomServerSuffix(t), "/tmp")
+	s.SocketName = serverName
+	s.LaunchAs = "service"
+	require.NoError(t, s.Start(""), "forced service failure must recover via real scope fallback")
+	f.unit = serviceUnitBase(s.Name) + ".scope"
+	f.requireKillModeNone(t)
+	f.requireSession(t, s.Name)
+	f.addSibling(t, "fallback-sibling")
+	f.stopUnit(t)
+	f.requireSession(t, s.Name)
+	f.requireSession(t, "fallback-sibling")
+}

--- a/internal/tmux/tmux_systemd_user_acceptance_test.go
+++ b/internal/tmux/tmux_systemd_user_acceptance_test.go
@@ -175,7 +175,7 @@ func (f *systemdUserTMuxFixture) cleanup() {
 		f.t.Errorf("cleanup kill-server reported success but exact socket %s remains reachable: %s (socket directory preserved)", f.socket, out)
 		return
 	}
-	if out, err := f.command("systemctl", "--user", "reset-failed", f.unit).CombinedOutput(); err != nil {
+	if out, err := f.command("systemctl", "--user", "reset-failed", f.unit).CombinedOutput(); err != nil && !resetFailedReportsCollectedUnit(out, f.unit) {
 		f.t.Errorf("cleanup reset-failed %s: %v: %s", f.unit, err, out)
 	}
 	if err := os.RemoveAll(f.dir); err != nil {

--- a/internal/tmux/tmux_systemd_user_acceptance_test.go
+++ b/internal/tmux/tmux_systemd_user_acceptance_test.go
@@ -231,28 +231,38 @@ func TestTmuxSystemdUser_ServiceFallbackScope_KillModeNonePreservesSharedServer(
 	serverName := "fallback-" + randomServerSuffix(t)
 	socket := filepath.Join(dir, "tmux-"+strconv.Itoa(os.Getuid()), serverName)
 	// The fallback must exercise Start's real service→scope branch. Its -L
-	// server is still isolated because this test gives it a private TMUX_TMPDIR;
-	// cleanup resolves the resulting socket by this exact absolute path.
-	// systemd-run executes through the manager, which has its own environment.
-	// Set the private socket base on both sides so Start's -L probe and the
-	// manager's spawned tmux resolve to this fixture's one exact socket.
-	out, err := exec.Command("systemctl", "--user", "set-environment", "TMUX_TMPDIR="+dir).CombinedOutput()
-	require.NoErrorf(t, err, "set private manager TMUX_TMPDIR failed: %s", out)
-	t.Cleanup(func() {
-		if output, unsetErr := exec.Command("systemctl", "--user", "unset-environment", "TMUX_TMPDIR").CombinedOutput(); unsetErr != nil {
-			t.Errorf("cleanup unset manager TMUX_TMPDIR: %v: %s", unsetErr, output)
-		}
-	})
+	// server is still isolated because Start's probe uses this test process's
+	// private TMUX_TMPDIR, while the real fallback scope receives the same base
+	// as a transient-unit-only environment. Do not alter the user manager's
+	// global environment: it may carry a value owned by the workflow or another
+	// test. Clearing TMUX in this unit prevents an inherited manager selection
+	// from overriding the private -L socket resolution.
 	t.Setenv("TMUX_TMPDIR", dir)
 	f := &systemdUserTMuxFixture{t: t, dir: dir, socket: socket, unit: base + ".scope"}
 	t.Cleanup(f.cleanup)
 
 	originalExec := execCommand
 	execCommand = func(name string, args ...string) *exec.Cmd {
-		if name == "systemd-run" && containsServiceUnitFlag(args) {
+		if name != "systemd-run" {
+			return originalExec(name, args...)
+		}
+		if containsServiceUnitFlag(args) {
 			return exec.Command("false")
 		}
-		return originalExec(name, args...)
+
+		// Keep the real scope retry intact, adding environment only to that
+		// transient unit before its command begins.
+		scopeArgs := make([]string, 0, len(args)+2)
+		inserted := false
+		for _, arg := range args {
+			if arg == "tmux" && !inserted {
+				scopeArgs = append(scopeArgs, "--setenv=TMUX=", "--setenv=TMUX_TMPDIR="+dir)
+				inserted = true
+			}
+			scopeArgs = append(scopeArgs, arg)
+		}
+		require.Truef(t, inserted, "scope fallback systemd-run invocation has no tmux command: %q", args)
+		return originalExec(name, scopeArgs...)
 	}
 	t.Cleanup(func() { execCommand = originalExec })
 

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -3099,7 +3099,7 @@ func TestStartCommandSpec_UserScope(t *testing.T) {
 	require.GreaterOrEqual(t, len(args), 8)
 	assert.Equal(t, []string{"--user", "--scope", "--quiet", "--collect", "--unit"}, args[:5])
 	assert.Equal(t, "agentdeck-tmux-agentdeck-test-session-1234abcd", args[5])
-	assert.Equal(t, []string{"tmux", "-u", "new-session", "-d", "-s", "agentdeck_test-session_1234abcd", "-c", "/tmp/project",
+	assert.Equal(t, []string{"--property=KillMode=none", "tmux", "-u", "new-session", "-d", "-s", "agentdeck_test-session_1234abcd", "-c", "/tmp/project",
 		"-x", "173", "-y", "41"}, args[6:])
 }
 


### PR DESCRIPTION
## Scope
Addresses #2219: per-session systemd service/scope/fallback commands use KillMode=none; Agent Deck refuses service cleanup with unsafe or unproven ownership. Bind server evidence to exact socket, PID/starttime and cgroup. Existing legacy unsafe units are NOT made safe against external stop by this patch.

## Acceptance
Real hosted user-manager acceptance covers explicit scope, service and forced service-to-scope fallback. Requires KillMode=none and owner/sibling survival; missing prerequisites and skipped controls fail. Cleanup targets the exact fixture socket and checks teardown before removing fixture paths. No global manager environment mutation: fallback environment is per-unit.

## Evidence
7aaf2b09 code independently reviewed PASS; parent focused Service/Scope/Systemd/Shared/Launch/Ownership/Spawn/Kill tests and affected-package vet passed in non-root, init-enabled, no-mount/no-network container. Integration controls requiring a real systemd manager are not claimed executed locally. Final workflow-only commit corrects JSON-lines receipt aggregation; four synthetic parser controls passed. Final-head CI/review required.

## Remaining gate
This PR is being published to EXECUTE real hosted systemd acceptance, not to claim it already passed. Full required CI, security scan (installer prerequisite #2231) and non-author approval remain. No live fleet cleanup or automatic migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved systemd user-session handling so stopping one tmux session no longer terminates shared servers or sibling sessions.
  - Added safety checks to avoid stopping units when ownership cannot be verified or termination settings are unsafe.
  - Applied consistent behavior across service, scope, and fallback launch modes.

- **Tests**
  - Added real systemd user-manager acceptance coverage for shared-server preservation.
  - Added automated verification for safe cleanup and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->