### PR TITLE
fix(ui): show the account badge only with configured slots and refresh it on config changes

### DIFF
--- a/internal/ui/account_slot_gate_test.go
+++ b/internal/ui/account_slot_gate_test.go
@@ -1,0 +1,101 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/stretchr/testify/require"
+)
+
+// #2122 shipped the stored-slot badge ungated, so a machine with no
+// [profiles.<name>.claude].config_dir block got "[account:inherited]" on every
+// session row while the New/Edit Session dialogs correctly hid their account
+// rows (#2152 gates those on ConfiguredAccountNames). The badge must use the
+// same gate: no configured slots means the inherited badge carries no
+// information and costs title width on every row.
+func TestInheritedBadgeHiddenWithoutConfiguredSlots(t *testing.T) {
+	inst := &session.Instance{ID: "gate-inherited", Title: "no-slot-session", Tool: "shell", Status: session.StatusIdle}
+
+	for _, refreshed := range []bool{false, true} {
+		name := "fallback"
+		if refreshed {
+			name = "snapshot"
+		}
+		t.Run(name, func(t *testing.T) {
+			h := NewHome()
+			h.width, h.height = 240, 40
+			h.accountSlotsConfigured.Store(false)
+			if refreshed {
+				h.refreshSessionRenderSnapshot([]*session.Instance{inst})
+			}
+			for _, selected := range []bool{false, true} {
+				var b strings.Builder
+				h.renderSessionItem(&b, session.Item{Type: session.ItemTypeSession, Session: inst, Level: 1, Path: "work", IsLastInGroup: true}, selected, h.getSessionRenderSnapshot(), 240)
+				row := b.String()
+				require.NotContains(t, row, "[account:", "no configured slots means no account badge")
+				require.NotContains(t, row, "inherited")
+				require.Contains(t, row, "no-slot-session", "suppressing the badge must not disturb the title")
+				require.Equal(t, 1, strings.Count(row, "\n"))
+			}
+
+			card := h.renderSessionInfoCard(inst, 240, 40)
+			require.NotContains(t, card, "Account slot:", "the card drops the line rather than printing an empty value")
+			require.NotContains(t, card, "inherited")
+		})
+	}
+}
+
+// The gate is about the inherited label only. A session carrying an explicit
+// slot still reports it even when config.toml no longer declares that profile,
+// because the session really does run against that slot's config dir.
+func TestExplicitSlotStillRendersWithoutConfiguredSlots(t *testing.T) {
+	inst := &session.Instance{ID: "gate-explicit", Title: "slotted", Tool: "shell", Status: session.StatusIdle, Account: "work"}
+
+	h := NewHome()
+	h.width, h.height = 240, 40
+	h.accountSlotsConfigured.Store(false)
+	h.refreshSessionRenderSnapshot([]*session.Instance{inst})
+
+	var b strings.Builder
+	h.renderSessionItem(&b, session.Item{Type: session.ItemTypeSession, Session: inst, Level: 1, Path: "work", IsLastInGroup: true}, false, h.getSessionRenderSnapshot(), 240)
+	require.Contains(t, b.String(), `[account:"work"]`)
+	require.Contains(t, h.renderSessionInfoCard(inst, 240, 40), "Account slot:")
+}
+
+// With at least one slot configured the badge is meaningful again: "inherited"
+// then distinguishes a session following the conductor/group/env chain from one
+// pinned to a named slot, so it must come back for both.
+func TestBadgeReturnsWhenSlotsAreConfigured(t *testing.T) {
+	inherited := &session.Instance{ID: "gate-on-inherited", Title: "follows-chain", Tool: "shell", Status: session.StatusIdle}
+	pinned := &session.Instance{ID: "gate-on-pinned", Title: "pinned", Tool: "shell", Status: session.StatusIdle, Account: "personal"}
+
+	h := NewHome()
+	h.width, h.height = 240, 40
+	h.accountSlotsConfigured.Store(true)
+	h.refreshSessionRenderSnapshot([]*session.Instance{inherited, pinned})
+
+	for inst, want := range map[*session.Instance]string{
+		inherited: "[account:inherited]",
+		pinned:    `[account:"personal"]`,
+	} {
+		var b strings.Builder
+		h.renderSessionItem(&b, session.Item{Type: session.ItemTypeSession, Session: inst, Level: 1, Path: "work", IsLastInGroup: true}, false, h.getSessionRenderSnapshot(), 240)
+		require.Contains(t, b.String(), want)
+	}
+}
+
+// The gate is a pure function of the stored slot and the configured-slot flag;
+// pin it directly so a future refactor of the render path cannot quietly
+// reintroduce a zero-width badge that still reserves prefix width.
+func TestAccountPresentationGate(t *testing.T) {
+	hidden := newAccountPresentation("", false)
+	require.Equal(t, accountPresentation{}, hidden, "suppressed badge must be the zero value, not an empty-labelled one")
+	badge, width := hidden.fit(0)
+	require.Empty(t, badge)
+	require.Zero(t, width)
+
+	shown := newAccountPresentation("", true)
+	require.Equal(t, "inherited", shown.label)
+	require.Equal(t, " [account:inherited]", shown.badge)
+}

--- a/internal/ui/account_slot_label.go
+++ b/internal/ui/account_slot_label.go
@@ -21,7 +21,16 @@ type accountPresentation struct {
 	quoted bool
 }
 
-func newAccountPresentation(account string) accountPresentation {
+// slotsConfigured reports whether this machine has any named account slot. An
+// empty stored slot only carries information when it could have been something
+// else, so on a single-login machine the inherited badge is suppressed entirely
+// (zero value: no badge, no width). An explicit slot always renders — a session
+// can hold a slot whose profile was since removed from config.toml, and hiding
+// that would misreport which config dir the session actually runs on.
+func newAccountPresentation(account string, slotsConfigured bool) accountPresentation {
+	if account == "" && !slotsConfigured {
+		return accountPresentation{}
+	}
 	label := storedAccountLabel(account)
 	return accountPresentation{
 		label:  label,

--- a/internal/ui/account_slot_refresh_test.go
+++ b/internal/ui/account_slot_refresh_test.go
@@ -1,0 +1,118 @@
+package ui
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountSlotsConfigurationTransition(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		configured bool
+	}{
+		{name: "first account added", configured: true},
+		{name: "last account removed", configured: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &Home{width: 240, height: 40, cursor: 1}
+			h.accountSlotsConfigured.Store(!tc.configured)
+			inherited := &session.Instance{ID: "inherited", Title: "follows-chain", Tool: "shell", Status: session.StatusIdle}
+			unknown := &session.Instance{ID: "unknown", Title: "unknown-slot", Tool: "shell", Status: session.StatusIdle, Account: "unknown-slot"}
+			h.instances = []*session.Instance{inherited, unknown}
+			for _, inst := range h.instances {
+				h.flatItems = append(h.flatItems, session.Item{Type: session.ItemTypeSession, Session: inst, Level: 1, IsLastInGroup: true})
+			}
+			before := map[string]sessionRenderState{}
+			for _, inst := range h.instances {
+				before[inst.ID] = sessionRenderState{
+					status: session.StatusError, substate: session.SubstateModelUnavailable,
+					tool: "shell", title: "cached title", paneTitle: "cached pane title",
+					autoName: true, autoNameDesc: "cached description", account: inst.Account,
+					accountDisplay: newAccountPresentation(inst.Account, !tc.configured),
+				}
+			}
+			h.sessionRenderSnapshot.Store(before)
+
+			// This is the settings-save gate update, with an existing snapshot.
+			h.setAccountSlotsConfigured(tc.configured)
+
+			require.Equal(t, tc.configured, h.accountSlotsConfigured.Load())
+			require.Equal(t, 1, h.cursor)
+			require.Same(t, unknown, h.getSelectedSession())
+			require.Equal(t, []*session.Instance{inherited, unknown}, h.instances)
+			require.Equal(t, "follows-chain", inherited.GetTitleThreadSafe())
+			require.Equal(t, "unknown-slot", unknown.GetTitleThreadSafe())
+			require.Len(t, h.getSessionRenderSnapshot(), len(before))
+			for i, inst := range h.instances {
+				want := before[inst.ID]
+				want.accountDisplay = newAccountPresentation(inst.Account, tc.configured)
+				require.Equal(t, want, h.getSessionRenderState(inst), "only the account presentation may change")
+				require.Equal(t, newAccountPresentation(inst.Account, !tc.configured), before[inst.ID].accountDisplay,
+					"an already published snapshot must remain immutable")
+				require.Equal(t, before[inst.ID].account, inst.GetAccountThreadSafe())
+				require.Equal(t, session.StatusIdle, inst.GetStatusThreadSafe())
+				require.Equal(t, "shell", inst.GetToolThreadSafe())
+				require.Equal(t, h.flatItems[i].Session, inst)
+				for _, selected := range []bool{false, true} {
+					var row strings.Builder
+					h.renderSessionItem(&row, h.flatItems[i], selected, h.getSessionRenderSnapshot(), 240)
+					require.Contains(t, row.String(), "cached pane title")
+					if inst == inherited && !tc.configured {
+						require.NotContains(t, row.String(), "[account:")
+					} else {
+						require.Contains(t, row.String(), strings.TrimSpace(want.accountDisplay.badge))
+					}
+				}
+				card := h.renderSessionInfoCard(inst, 240, 40)
+				if inst == inherited && !tc.configured {
+					require.NotContains(t, card, "Account slot:")
+				} else {
+					require.Contains(t, card, "Account slot:")
+					require.Contains(t, card, want.accountDisplay.label)
+				}
+			}
+		})
+	}
+}
+
+func TestAccountSlotsConfigurationUnchangedKeepsSnapshot(t *testing.T) {
+	for _, configured := range []bool{false, true} {
+		h := &Home{}
+		h.accountSlotsConfigured.Store(configured)
+		before := map[string]sessionRenderState{"session": {title: "cached title"}}
+		h.sessionRenderSnapshot.Store(before)
+		h.setAccountSlotsConfigured(configured)
+		require.Equal(t, reflect.ValueOf(before).Pointer(), reflect.ValueOf(h.getSessionRenderSnapshot()).Pointer(),
+			"saving settings without a gate transition must not rebuild the snapshot")
+	}
+}
+
+func TestAccountSlotsConfigurationBeforeSnapshot(t *testing.T) {
+	h := &Home{}
+	inst := &session.Instance{ID: "new", Tool: "shell", Status: session.StatusIdle}
+	for _, configured := range []bool{true, false} {
+		h.setAccountSlotsConfigured(configured)
+		require.Nil(t, h.getSessionRenderSnapshot(), "do not create session data during a settings change")
+		require.Equal(t, newAccountPresentation("", configured), h.getSessionRenderState(inst).accountDisplay)
+	}
+}
+
+func TestAccountSnapshotPublicationUsesCurrentConfiguration(t *testing.T) {
+	for _, configured := range []bool{false, true} {
+		h := &Home{}
+		h.accountSlotsConfigured.Store(!configured)
+		// A background refresh started before the settings save and publishes later.
+		pending := map[string]sessionRenderState{
+			"session": {title: "fresh title", accountDisplay: newAccountPresentation("", !configured)},
+		}
+		h.setAccountSlotsConfigured(configured)
+		h.publishSessionRenderSnapshot(pending)
+		state := h.getSessionRenderSnapshot()["session"]
+		require.Equal(t, "fresh title", state.title)
+		require.Equal(t, newAccountPresentation("", configured), state.accountDisplay)
+	}
+}

--- a/internal/ui/account_slot_render_test.go
+++ b/internal/ui/account_slot_render_test.go
@@ -11,6 +11,8 @@ import (
 
 // These controls intentionally use only pre-existing rendering entry points.
 // They must reproduce missing stored-slot output on the unmodified baseline.
+// Slots are configured here so the inherited case stays covered; the
+// no-slots-configured gate lives in account_slot_gate_test.go.
 func TestStoredAccountRenderBaseline(t *testing.T) {
 	slots := []string{"personal", "work", "", "inherited", " 日本 e\u0301 🚀 ", "quote\"slash\\", "\x1b]0;injected\a\r\n\u0085\u202e"}
 	for _, account := range slots {
@@ -28,6 +30,7 @@ func TestStoredAccountRenderBaseline(t *testing.T) {
 				t.Run(name, func(t *testing.T) {
 					h := NewHome()
 					h.width, h.height = 240, 40
+					h.accountSlotsConfigured.Store(true)
 					if refreshed {
 						h.refreshSessionRenderSnapshot([]*session.Instance{inst})
 					}
@@ -43,6 +46,7 @@ func TestStoredAccountRenderBaseline(t *testing.T) {
 				})
 				t.Run(name+"_card", func(t *testing.T) {
 					h := NewHome()
+					h.accountSlotsConfigured.Store(true)
 					if refreshed {
 						h.refreshSessionRenderSnapshot([]*session.Instance{inst})
 					}

--- a/internal/ui/account_slot_width_test.go
+++ b/internal/ui/account_slot_width_test.go
@@ -18,7 +18,7 @@ func TestStoredAccountWidthMatrix(t *testing.T) {
 					h := NewHome()
 					h.width, h.height = width, 40
 					inst := &session.Instance{ID: "width", Title: strings.Repeat("Title日本e\u0301", 8), Tool: "shell", Status: session.StatusIdle, Account: slot}
-					state := sessionRenderState{status: session.StatusIdle, tool: "shell", title: inst.Title, account: slot, accountDisplay: newAccountPresentation(slot), autoName: auto, paneTitle: "pane subtitle", autoNameDesc: "description"}
+					state := sessionRenderState{status: session.StatusIdle, tool: "shell", title: inst.Title, account: slot, accountDisplay: newAccountPresentation(slot, true), autoName: auto, paneTitle: "pane subtitle", autoNameDesc: "description"}
 					for _, selected := range []bool{false, true} {
 						var b strings.Builder
 						h.renderSessionItem(&b, session.Item{Type: session.ItemTypeSession, Session: inst, Level: 1, Path: "work", IsLastInGroup: true}, selected, map[string]sessionRenderState{inst.ID: state}, width)

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -555,6 +555,16 @@ type Home struct {
 	// one. Cached here so all rows of a frame agree; reloaded after panel save.
 	showPaneTitles bool
 
+	// accountSlotsConfigured mirrors len(session.ConfiguredAccountNames(cfg)) > 0,
+	// the same gate the New/Edit Session dialogs use to hide their account rows
+	// (#2152). A machine with no [profiles.<name>.claude].config_dir block has
+	// one login, so "which slot is this session on" is not a question that can
+	// have two answers — the inherited badge would be dead width on every row.
+	// Atomic because refreshSessionRenderSnapshot reads it from the background
+	// refresher goroutine while the settings panel writes it from the Bubble Tea
+	// event loop. Explicit slots ignore this gate; see newAccountPresentation.
+	accountSlotsConfigured atomic.Bool
+
 	// Sessions/Preview split (issue #1092): percentage of width allocated to
 	// preview pane. Loaded from config.toml [ui] preview_pct, adjustable
 	// live via < and > keybindings, persisted back to config on adjustment.
@@ -1947,6 +1957,9 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 
 	// Hook-based status detection (Claude Code lifecycle hooks)
 	userConfig, _ := session.LoadUserConfig()
+	// Seed the account-badge gate from the same config read; the settings panel
+	// refreshes it on save so adding a slot lights the badges without a restart.
+	h.accountSlotsConfigured.Store(len(session.ConfiguredAccountNames(userConfig)) > 0)
 	hooksEnabled := userConfig == nil || userConfig.Claude.GetHooksEnabled()
 	if homeBackgroundWorkersEnabled && hooksEnabled {
 		configDir := session.GetClaudeConfigDir()
@@ -5506,6 +5519,7 @@ func (h *Home) refreshSessionRenderSnapshot(instances []*session.Instance) {
 
 	snap := make(map[string]sessionRenderState, len(instances))
 	accounts := make(map[string]accountPresentation)
+	slotsConfigured := h.accountSlotsConfigured.Load()
 	for _, inst := range instances {
 		if inst == nil {
 			continue
@@ -5526,7 +5540,7 @@ func (h *Home) refreshSessionRenderSnapshot(instances []*session.Instance) {
 		}
 		display, ok := accounts[state.account]
 		if !ok {
-			display = newAccountPresentation(state.account)
+			display = newAccountPresentation(state.account, slotsConfigured)
 			accounts[state.account] = display
 		}
 		state.accountDisplay = display
@@ -5574,7 +5588,7 @@ func (h *Home) getSessionRenderState(inst *session.Instance) sessionRenderState 
 		status:         inst.GetStatusThreadSafe(),
 		tool:           inst.GetToolThreadSafe(),
 		account:        account,
-		accountDisplay: newAccountPresentation(account),
+		accountDisplay: newAccountPresentation(account, h.accountSlotsConfigured.Load()),
 		title:          inst.GetTitleThreadSafe(),
 		autoName:       inst.GetAutoName(),
 		autoNameDesc:   inst.GetAutoNameDescription(),
@@ -9038,6 +9052,9 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 				h.reloadHotkeysFromConfig()
 				h.showSessionTimestamps = config.Display.ShowSessionTimestamps
 				h.showPaneTitles = config.Display.ShowPaneTitles
+				// A slot added here must light the badges now; the next snapshot
+				// refresh reads this flag.
+				h.accountSlotsConfigured.Store(len(session.ConfiguredAccountNames(config)) > 0)
 
 				// Apply theme changes live
 				h.stopThemeWatcher()
@@ -20361,9 +20378,12 @@ func (h *Home) renderSessionInfoCard(inst *session.Instance, width, height int) 
 	b.WriteString(fmt.Sprintf("%s %s\n", labelStyle.Render("Tool:"), valueStyle.Render(cardTool)))
 
 	// Use the same cached metadata as the row; no account/config resolution.
-	account := h.getSessionRenderState(inst).accountDisplay.label
-	account = cellTruncate(account, max(0, width-cellWidth("Account slot: ")), "…")
-	b.WriteString(fmt.Sprintf("%s %s\n", labelStyle.Render("Account slot:"), valueStyle.Render(account)))
+	// An empty label means the row suppressed the badge (single-login machine,
+	// inherited slot) — drop the whole line rather than print an empty value.
+	if account := h.getSessionRenderState(inst).accountDisplay.label; account != "" {
+		account = cellTruncate(account, max(0, width-cellWidth("Account slot: ")), "…")
+		b.WriteString(fmt.Sprintf("%s %s\n", labelStyle.Render("Account slot:"), valueStyle.Render(account)))
+	}
 
 	// Session ID (if available) - Claude, Gemini, OpenCode, or generic (Hermes/custom tools)
 	sessionID := inst.ClaudeSessionID

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -515,6 +515,8 @@ type Home struct {
 	navigationHotUntil atomic.Int64
 	// Snapshot of status/tool used by render path to avoid per-row lock contention.
 	sessionRenderSnapshot atomic.Value // map[string]sessionRenderState
+	// Serializes snapshot publication with account gate transitions. Readers stay lock-free.
+	sessionRenderSnapshotMu sync.Mutex
 
 	// Jump mode (vimium-style hint navigation)
 	jumpMode   bool   // True when jump mode is active
@@ -5509,6 +5511,51 @@ func (h *Home) getSessionRenderSnapshot() map[string]sessionRenderState {
 	return nil
 }
 
+// setAccountSlotsConfigured updates only inherited account presentations when
+// settings cross the configured/unconfigured boundary. Copy the snapshot so
+// active renderers keep an immutable view, without rereading session state.
+func (h *Home) setAccountSlotsConfigured(configured bool) {
+	h.sessionRenderSnapshotMu.Lock()
+	defer h.sessionRenderSnapshotMu.Unlock()
+	if h.accountSlotsConfigured.Swap(configured) == configured {
+		return
+	}
+	previous := h.getSessionRenderSnapshot()
+	if len(previous) == 0 {
+		return
+	}
+	snap := make(map[string]sessionRenderState, len(previous))
+	display := newAccountPresentation("", configured)
+	for id, state := range previous {
+		if state.account == "" {
+			state.accountDisplay = display
+		}
+		snap[id] = state
+	}
+	h.sessionRenderSnapshot.Store(snap)
+}
+
+// publishSessionRenderSnapshot takes ownership of snap. Resolve presentations
+// at publication so an in-flight refresh cannot restore an old settings gate.
+// Instance reads happen before this lock, keeping settings updates bounded to
+// cached render data even when a background status writer holds Instance.mu.
+func (h *Home) publishSessionRenderSnapshot(snap map[string]sessionRenderState) {
+	h.sessionRenderSnapshotMu.Lock()
+	defer h.sessionRenderSnapshotMu.Unlock()
+	accounts := make(map[string]accountPresentation)
+	slotsConfigured := h.accountSlotsConfigured.Load()
+	for id, state := range snap {
+		display, ok := accounts[state.account]
+		if !ok {
+			display = newAccountPresentation(state.account, slotsConfigured)
+			accounts[state.account] = display
+		}
+		state.accountDisplay = display
+		snap[id] = state
+	}
+	h.sessionRenderSnapshot.Store(snap)
+}
+
 func (h *Home) refreshSessionRenderSnapshot(instances []*session.Instance) {
 	if instances == nil {
 		h.instancesMu.RLock()
@@ -5518,8 +5565,6 @@ func (h *Home) refreshSessionRenderSnapshot(instances []*session.Instance) {
 	}
 
 	snap := make(map[string]sessionRenderState, len(instances))
-	accounts := make(map[string]accountPresentation)
-	slotsConfigured := h.accountSlotsConfigured.Load()
 	for _, inst := range instances {
 		if inst == nil {
 			continue
@@ -5538,12 +5583,6 @@ func (h *Home) refreshSessionRenderSnapshot(instances []*session.Instance) {
 			autoName:     inst.GetAutoName(),
 			autoNameDesc: inst.GetAutoNameDescription(),
 		}
-		display, ok := accounts[state.account]
-		if !ok {
-			display = newAccountPresentation(state.account, slotsConfigured)
-			accounts[state.account] = display
-		}
-		state.accountDisplay = display
 		// Look up pane title from the already-refreshed tmux cache.
 		// Only RefreshPaneInfoCache (called from backgroundStatusUpdate) keeps
 		// the cache fresh; processStatusUpdate and other rebuild paths run on
@@ -5568,7 +5607,7 @@ func (h *Home) refreshSessionRenderSnapshot(instances []*session.Instance) {
 		}
 		snap[inst.ID] = state
 	}
-	h.sessionRenderSnapshot.Store(snap)
+	h.publishSessionRenderSnapshot(snap)
 }
 
 func (h *Home) getSessionRenderState(inst *session.Instance) sessionRenderState {
@@ -9052,9 +9091,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 				h.reloadHotkeysFromConfig()
 				h.showSessionTimestamps = config.Display.ShowSessionTimestamps
 				h.showPaneTitles = config.Display.ShowPaneTitles
-				// A slot added here must light the badges now; the next snapshot
-				// refresh reads this flag.
-				h.accountSlotsConfigured.Store(len(session.ConfiguredAccountNames(config)) > 0)
+				h.setAccountSlotsConfigured(len(session.ConfiguredAccountNames(config)) > 0)
 
 				// Apply theme changes live
 				h.stopThemeWatcher()


### PR DESCRIPTION
## What problem does this solve?

Session rows show an inherited account badge even when no account slots are configured, taking space without adding useful information. Adding or removing the last configured slot can also leave badges and the info card showing stale cached account information.

## Why this change

This supersedes #2198 and carries @mineralinis's original contribution, cherry-picked from `bdc69ec4` with MV's original authorship intact. Thank you for the visibility fix. Explicit account slots remain visible even if their profile has been removed.

The follow-up fix refreshes inherited account presentations in an immutable copy of the existing render snapshot when configuration crosses the configured/unconfigured boundary. Snapshot publication and gate transitions share a mutex, and publication resolves account presentations using the current gate so an in-flight background refresh cannot restore stale badges. Render readers remain lock-free, and unrelated cached session state is preserved.

## User impact

Inherited account badges and the info card's account line disappear when no slots are configured and return after the first slot is configured. Settings saves update existing cached rows immediately. Explicit account assignments remain visible.

## Evidence

Validation on the combined branch based on `694fbcee`:

- `gofmt -l` on all changed Go files: no output.
- Host `go build ./...`: exit 0.
- Host `go vet ./...`: exit 0.
- Tests executed only in Docker with `--init -u 1000:1000 --network none --cap-drop ALL`, isolated HOME/cache, and the `golang:1.25` image: `go test ./internal/ui/... -run 'Badge|AccountSlot' -count=1`.

```text
ok  github.com/asheshgoplani/agent-deck/internal/ui  0.734s
```

The focused Docker command exited 0. The full suite has not been run locally; hosted full-suite CI remains a separate gate.

Regression coverage includes first-slot addition, last-slot removal, selected and unselected rows, info cards, snapshot immutability, unchanged settings, missing snapshots, and background publication after a configuration transition. No live-session visual capture or before/after timing benchmark was performed. Required hosted CI results will be linked from this PR's checks.

## AI disclosure

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** gpt-6-astra for the cache-refresh fix commit, originally `6b022859`. The contributor commit is retained with its original author and session reference.

## What actually bothered you

My human asked: "open ONE PR against main of asheshgoplani/agent-deck that lands the account-badge fix with contributor credit. Do NOT merge."

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [x] CHANGELOG.md untouched (entries are added at landing)
- [x] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [ ] "Allow edits from maintainers" is enabled

<!-- gate:ai=authored model=gpt-6-astra intent=yes -->
