### PR TITLE
fix(notify-daemon): restart silently instead of re-notifying every parked child

### DIFF
--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -2052,6 +2052,15 @@ WantedBy=default.target
 // recycle onto the current binary, so the daemon can never run stale code even
 // if the in-process version watcher is somehow bypassed. The watcher recycles
 // promptly on upgrade; this is the backstop.
+//
+// The recycle is kept rather than dropped because it is what makes the stale-
+// binary guarantee unconditional. It used to be noisy (issue #2240): every
+// start replayed a transition for every parked child and woke every conductor
+// with an empty drain. The daemon now restarts statefully and silently instead
+// — it seeds its turn baseline from the registry against the persisted
+// last-notified state (TransitionDaemon.seedTurnBaseline) and withholds the
+// wake-nudge for a turn the parent has already consumed — so a daily recycle
+// costs nothing.
 const systemdTransitionNotifierServiceTemplate = `[Unit]
 Description=Agent Deck Transition Notifier
 After=network.target

--- a/internal/session/inbox_consumer.go
+++ b/internal/session/inbox_consumer.go
@@ -195,6 +195,20 @@ func WriteInboxEventIfUnseen(parentID string, event TransitionNotificationEvent)
 	return InboxEventAlreadyPresent, nil
 }
 
+// turnAlreadyConsumed reports whether the parent's consumed-turn ledger already
+// holds fp, i.e. the parent has acted on this turn and its next drain would drop
+// a fresh copy. Read-only; used by the producer to withhold the wake-nudge for
+// a record that cannot produce a non-empty drain.
+func turnAlreadyConsumed(parentID, fp string) bool {
+	if strings.TrimSpace(fp) == "" {
+		return false
+	}
+	consumedTurnsMu.Lock()
+	defer consumedTurnsMu.Unlock()
+	_, ok := loadConsumedTurnsLocked(parentID)[fp]
+	return ok
+}
+
 func saveConsumedTurnsLocked(parentID string, m map[string]int64) error {
 	// Prune expired entries on every save to bound growth.
 	cutoff := time.Now().Add(-consumedTurnsTTL).Unix()

--- a/internal/session/inbox_outbox.go
+++ b/internal/session/inbox_outbox.go
@@ -532,6 +532,16 @@ func (n *TransitionNotifier) commitEventToInbox(event TransitionNotificationEven
 		return false, true, ""
 	}
 	n.logEvent(event)
+	// A turn the parent's consumed-turn ledger already holds is dropped by its
+	// next drain, so waking it would cost one empty "[INBOX]" turn for nothing
+	// (issue #2240, notify-daemon restart re-delivery). The record itself is left
+	// as committed: ledger dedup semantics and delivery ordering are unchanged,
+	// only the nudge is withheld.
+	if turnAlreadyConsumed(parentID, event.TurnFingerprint) {
+		commsLog.Debug("wake_nudge_skipped_consumed_turn",
+			slog.String("parent", parentID), slog.String("turn", event.TurnFingerprint))
+		return true, false, ""
+	}
 	// Issue #1225 Tier-2: now that the record durably landed, wake an IDLE parent
 	// to drain it immediately instead of on its next ~14-min heartbeat. This is
 	// the event-driven trigger — fired the moment the completion is committed,

--- a/internal/session/issue2240_notifier_restart_redelivery_test.go
+++ b/internal/session/issue2240_notifier_restart_redelivery_test.go
@@ -1,0 +1,322 @@
+package session
+
+// Issue #2240: notify-daemon restart re-delivery regression tests.
+//
+// Field report (v1.16.5): every restart of `agent-deck notify-daemon` (the
+// systemd RuntimeMaxSec recycle, or the recycle after an auto-update) re-emitted
+// a running→waiting transition for EVERY child currently parked at a terminal
+// status, however old. The consumed-turn ledger collapsed the records on drain
+// (`inbox drain self` printed "No pending events"), but the [INBOX] wake-nudge
+// had already been typed into every conductor pane: one wasted turn per
+// conductor per restart.
+//
+// Two independent guards close it, each pinned here:
+//
+//  1. The daemon seeds its per-child turn baseline from the registry on its
+//     first pass, against the persisted last-notified state, so a restart
+//     notifies nothing until a REAL transition happens after start — while a
+//     child whose status changed WHILE the daemon was down is still notified
+//     once.
+//  2. The wake-nudge fires only when the committed record is one the parent's
+//     next drain would actually deliver, never for a turn the parent's
+//     consumed-turn ledger already holds.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// restartFixture is one profile with a parked child under a live parent, a
+// "live TUI" heartbeat (so syncProfile reads statuses from the DB rows rather
+// than probing tmux), and a spy wake-nudge wiring on the daemon's notifier.
+type restartFixture struct {
+	profile string
+	storage *Storage
+	child   *Instance
+	parent  *Instance
+
+	mu    sync.Mutex
+	nudge int
+}
+
+func newRestartFixture(t *testing.T, childStatus string) *restartFixture {
+	t.Helper()
+	const profile = "_test_notifier_restart"
+	_, storage := bootstrapDaemonProfile(t, profile)
+	ResetInboxFingerprintCacheForTest()
+	t.Cleanup(ResetInboxFingerprintCacheForTest)
+
+	now := time.Now()
+	f := &restartFixture{profile: profile, storage: storage}
+	f.child = &Instance{
+		ID:              "restart-child-1",
+		Title:           "worker",
+		ProjectPath:     "/tmp/restart-child-1",
+		GroupPath:       DefaultGroupPath,
+		ParentSessionID: "restart-parent-1",
+		Tool:            "claude",
+		Status:          Status(childStatus),
+		CreatedAt:       now,
+	}
+	f.parent = &Instance{
+		ID:          "restart-parent-1",
+		Title:       "orchestrator", // NOT "conductor-": resolve skips the tmux probe
+		ProjectPath: "/tmp/restart-parent-1",
+		GroupPath:   DefaultGroupPath,
+		Tool:        "claude",
+		Status:      StatusIdle,
+		CreatedAt:   now,
+	}
+	if err := storage.SaveWithGroups([]*Instance{f.child, f.parent}, nil); err != nil {
+		t.Fatalf("SaveWithGroups: %v", err)
+	}
+	db := storage.GetDB()
+	if err := db.RegisterInstance(false); err != nil {
+		t.Fatalf("RegisterInstance: %v", err)
+	}
+	f.setChildStatus(t, childStatus)
+	if err := db.WriteStatus(f.parent.ID, "idle", "claude"); err != nil {
+		t.Fatalf("WriteStatus parent: %v", err)
+	}
+	return f
+}
+
+func (f *restartFixture) setChildStatus(t *testing.T, status string) {
+	t.Helper()
+	if err := f.storage.GetDB().WriteStatus(f.child.ID, status, "claude"); err != nil {
+		t.Fatalf("WriteStatus child: %v", err)
+	}
+}
+
+// newDaemon models one daemon PROCESS: a fresh TransitionDaemon whose notifier
+// loads whatever state the previous process persisted. Instances here have no
+// tmux session, so the liveness probe is stubbed to true.
+func (f *restartFixture) newDaemon() *TransitionDaemon {
+	d := NewTransitionDaemon()
+	d.storages[f.profile] = f.storage
+	d.turnLiveCheck = func(*Instance) bool { return true }
+	d.notifier.wake = &wakeNudgeWiring{
+		nudger: NewWakeNudger(0),
+		now:    time.Now,
+		isIdle: func(*Instance) bool { return true },
+		send: func(*Instance, string) error {
+			f.mu.Lock()
+			f.nudge++
+			f.mu.Unlock()
+			return nil
+		},
+	}
+	return d
+}
+
+func (f *restartFixture) nudges() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.nudge
+}
+
+// ageNotifyRecord rewrites the persisted last-notified record for the child so
+// it looks `age` old. The report's phantom pings were for children long past
+// the 2h output-hash dedup window; anything younger is already silenced by the
+// existing isDuplicate layer, which is NOT the mechanism under test.
+func ageNotifyRecord(t *testing.T, childID string, age time.Duration) {
+	t.Helper()
+	path := transitionNotifyStatePath()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read notify state: %v", err)
+	}
+	var state transitionNotifyState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		t.Fatalf("decode notify state: %v", err)
+	}
+	rec, ok := state.Records[childID]
+	if !ok {
+		t.Fatalf("notify state has no record for %s: %s", childID, raw)
+	}
+	rec.At = time.Now().Add(-age).Unix()
+	state.Records[childID] = rec
+	out, _ := json.Marshal(state)
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		t.Fatalf("write notify state: %v", err)
+	}
+}
+
+// A brand-new install (no state file) must not publish every already-parked
+// child as a fresh completion on its first pass.
+func TestNotifierRestart_FirstEverStartDoesNotReplayParkedChildren(t *testing.T) {
+	f := newRestartFixture(t, "waiting")
+	if _, err := os.Stat(transitionNotifyStatePath()); !os.IsNotExist(err) {
+		t.Fatalf("precondition: no state file expected, stat err=%v", err)
+	}
+
+	d := f.newDaemon()
+	d.syncProfile(f.profile)
+
+	if got := readInboxLines(t, f.parent.ID); len(got) != 0 {
+		t.Fatalf("first-ever start replayed history into the parent inbox: %+v", got)
+	}
+	if n := f.nudges(); n != 0 {
+		t.Fatalf("first-ever start fired %d wake-nudges, want 0", n)
+	}
+}
+
+// The reported bug: a child notified long ago and still parked must NOT be
+// re-notified (and the parent must NOT be nudged) when the daemon restarts.
+func TestNotifierRestart_RestartDoesNotRenotifyStillParkedChild(t *testing.T) {
+	f := newRestartFixture(t, "running")
+
+	// Process 1 observes the real transition and notifies once.
+	d1 := f.newDaemon()
+	d1.syncProfile(f.profile)
+	f.setChildStatus(t, "waiting")
+	d1.syncProfile(f.profile)
+	if got := readInboxLines(t, f.parent.ID); len(got) != 1 {
+		t.Fatalf("real transition must commit exactly one record, got %+v", got)
+	}
+	if n := f.nudges(); n != 1 {
+		t.Fatalf("real transition must nudge once, got %d", n)
+	}
+	if _, err := DrainInboxForParent(f.parent.ID); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	ageNotifyRecord(t, f.child.ID, 3*time.Hour)
+
+	// Process 2 (the RuntimeMaxSec / auto-update recycle) starts with the child
+	// still parked at waiting.
+	d2 := f.newDaemon()
+	d2.syncProfile(f.profile)
+	d2.syncProfile(f.profile)
+
+	if got := readInboxLines(t, f.parent.ID); len(got) != 0 {
+		t.Fatalf("restart re-committed an already-notified turn: %+v", got)
+	}
+	if n := f.nudges(); n != 1 {
+		t.Fatalf("restart fired a phantom wake-nudge: total nudges %d, want 1", n)
+	}
+}
+
+// A child whose status changed while the daemon was down is still notified
+// exactly once after the restart: the seed compares the registry against the
+// persisted last-notified status, it does not blindly silence everything.
+func TestNotifierRestart_ChildChangedWhileDownIsNotifiedOnce(t *testing.T) {
+	f := newRestartFixture(t, "running")
+
+	d1 := f.newDaemon()
+	d1.syncProfile(f.profile)
+	f.setChildStatus(t, "idle")
+	d1.syncProfile(f.profile)
+	if got := readInboxLines(t, f.parent.ID); len(got) != 1 || got[0].ToStatus != "idle" {
+		t.Fatalf("precondition: one idle record expected, got %+v", got)
+	}
+	if _, err := DrainInboxForParent(f.parent.ID); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	ageNotifyRecord(t, f.child.ID, 3*time.Hour)
+
+	// Daemon down; the child finished another turn and parked at waiting.
+	f.setChildStatus(t, "waiting")
+
+	d2 := f.newDaemon()
+	d2.syncProfile(f.profile)
+	d2.syncProfile(f.profile)
+
+	got := readInboxLines(t, f.parent.ID)
+	if len(got) != 1 || got[0].ToStatus != "waiting" {
+		t.Fatalf("a status change during downtime must be notified exactly once, got %+v", got)
+	}
+	if n := f.nudges(); n != 2 {
+		t.Fatalf("expected exactly one nudge for the downtime transition (2 total), got %d", n)
+	}
+}
+
+// A corrupt state file is treated as a fresh seed: no replay, no crash, and
+// the daemon keeps notifying real transitions afterwards.
+func TestNotifierRestart_CorruptStateFileSeedsFresh(t *testing.T) {
+	f := newRestartFixture(t, "waiting")
+	path := transitionNotifyStatePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+		t.Fatalf("write corrupt state: %v", err)
+	}
+
+	d := f.newDaemon()
+	d.syncProfile(f.profile)
+	if got := readInboxLines(t, f.parent.ID); len(got) != 0 {
+		t.Fatalf("corrupt state must seed fresh, not replay: %+v", got)
+	}
+	if n := f.nudges(); n != 0 {
+		t.Fatalf("corrupt state fired %d nudges, want 0", n)
+	}
+
+	// A real transition after start still lands.
+	f.setChildStatus(t, "running")
+	d.syncProfile(f.profile)
+	f.setChildStatus(t, "waiting")
+	d.syncProfile(f.profile)
+	if got := readInboxLines(t, f.parent.ID); len(got) != 1 {
+		t.Fatalf("real transition after a corrupt-state start must still commit, got %+v", got)
+	}
+}
+
+// A real transition after start is still delivered and nudged: seeding must
+// not turn the daemon silent.
+func TestNotifierRestart_RealTransitionAfterStartStillNotifies(t *testing.T) {
+	f := newRestartFixture(t, "waiting")
+
+	d := f.newDaemon()
+	d.syncProfile(f.profile) // seeds the parked child silently
+	f.setChildStatus(t, "running")
+	d.syncProfile(f.profile)
+	f.setChildStatus(t, "waiting")
+	d.syncProfile(f.profile)
+
+	if got := readInboxLines(t, f.parent.ID); len(got) != 1 {
+		t.Fatalf("real transition after seed must commit once, got %+v", got)
+	}
+	if n := f.nudges(); n != 1 {
+		t.Fatalf("real transition after seed must nudge once, got %d", n)
+	}
+}
+
+// Guard 2, at the commit chokepoint: a record whose turn the parent has already
+// consumed is not nudged for, because the drain would be empty.
+func TestCommit_NoWakeNudgeForAlreadyConsumedTurn(t *testing.T) {
+	n, parentID, event := newWakeNudgeFixture(t)
+	sent := 0
+	n.wake = &wakeNudgeWiring{
+		nudger: NewWakeNudger(0),
+		now:    time.Now,
+		isIdle: func(*Instance) bool { return true },
+		send:   func(*Instance, string) error { sent++; return nil },
+	}
+
+	if res := n.NotifyFinished(event); res.DeliveryResult != transitionDeliveryCommitted {
+		t.Fatalf("first commit = %q", res.DeliveryResult)
+	}
+	if sent != 1 {
+		t.Fatalf("first commit must nudge once, got %d", sent)
+	}
+	delivered, err := DrainInboxForParent(parentID)
+	if err != nil || len(delivered) != 1 {
+		t.Fatalf("drain: delivered=%d err=%v", len(delivered), err)
+	}
+
+	// The same turn is committed again (a replay). The record may land, but the
+	// parent's next drain drops it, so no nudge may fire.
+	if res := n.NotifyFinished(event); res.DeliveryResult != transitionDeliveryCommitted {
+		t.Fatalf("replay commit = %q", res.DeliveryResult)
+	}
+	if sent != 1 {
+		t.Fatalf("replay of a consumed turn fired a wake-nudge: sent=%d, want 1", sent)
+	}
+	if delivered, _ := DrainInboxForParent(parentID); len(delivered) != 0 {
+		t.Fatalf("consumed-turn ledger semantics changed: drain delivered %+v", delivered)
+	}
+}

--- a/internal/session/transition_daemon.go
+++ b/internal/session/transition_daemon.go
@@ -487,6 +487,12 @@ func (d *TransitionDaemon) syncProfile(profile string) time.Duration {
 	// extra capture, no new goroutine (F3). Disabled-by-config → cheap no-op.
 	d.runSelfHealObservePass(profile, instances, statuses, hookStatuses, db, time.Now().UTC())
 
+	// A daemon PROCESS start (first pass for the profile) seeds the turn
+	// baseline from the registry against the persisted last-notified state, so
+	// a recycle does not republish every parked child. See seedTurnBaseline.
+	if !d.initialized[profile] {
+		d.seedTurnBaseline(profile, byID, statuses)
+	}
 	// Runs on EVERY pass, the first scan included — see the FIRST SCAN note on
 	// recordTerminalTurns for why suppressing it would recreate the field bug.
 	d.recordTerminalTurns(profile, byID, statuses, hookStatuses)
@@ -543,6 +549,73 @@ func (d *TransitionDaemon) syncProfile(profile string) time.Duration {
 
 	d.lastStatus[profile] = copyStatusMap(statuses)
 	return choosePollInterval(statuses)
+}
+
+// turnBaseline returns the per-instance completed-turn map for profile,
+// creating it on first use. Shared by seedTurnBaseline and recordTerminalTurns.
+func (d *TransitionDaemon) turnBaseline(profile string) map[string]string {
+	if d.lastTurn == nil {
+		d.lastTurn = map[string]map[string]string{}
+	}
+	if d.lastTurn[profile] == nil {
+		d.lastTurn[profile] = map[string]string{}
+	}
+	return d.lastTurn[profile]
+}
+
+// seedTurnBaseline runs once per profile, on the daemon's first pass, BEFORE
+// recordTerminalTurns. It marks every child already parked at a recordable
+// status as "seen" so the first pass publishes nothing for it — unless the
+// persisted last-notified state (transition-notify-state.json) says the child
+// was last notified at a DIFFERENT status or transcript signal, in which case
+// the turn happened while the daemon was down and recordTerminalTurns notifies
+// it once.
+//
+// Issue #2240 (field report, v1.16.5): the notify-daemon is recycled by its
+// systemd unit (RuntimeMaxSec) and after every auto-update, and on every start
+// it re-emitted a running→waiting record for EVERY parked child, however old.
+// The consumed-turn ledger collapsed the records on drain, so the conductor saw
+// "No pending events" — but the [INBOX] wake-nudge had already landed: one
+// wasted turn per conductor per restart. The FIRST SCAN note on
+// recordTerminalTurns leaned on that ledger to make the replay free; the nudge
+// made it not free.
+//
+// Rules, per child at a recordable status:
+//   - no persisted record (first-ever start, or a child never notified) → seed
+//     silently. This is deliberately the same on a brand-new install: a fresh
+//     daemon must not present every long-finished session as news.
+//   - persisted record equals the current (status, signal) → already
+//     notified, seed silently.
+//   - persisted record differs → leave unseeded so recordTerminalTurns records
+//     the turn that completed during the downtime, exactly once.
+//
+// A corrupt or unreadable state file loads as empty (logged by loadState), so
+// it degrades to the first-ever-start case rather than a replay storm.
+//
+// Children that appear AFTER this pass are not seeded and are recorded on first
+// sight, which is what keeps the field round-3 race (session launched and
+// finished between two polls) covered. The residual hole is narrow and
+// accepted: a child that had never been notified before and completed its
+// first turn inside the daemon's own restart window is seeded, not notified.
+func (d *TransitionDaemon) seedTurnBaseline(profile string, byID map[string]*Instance, statuses map[string]string) {
+	seen := d.turnBaseline(profile)
+	for id, to := range statuses {
+		if !isRecordableTurnStatus(to) {
+			continue
+		}
+		inst := byID[id]
+		if inst == nil {
+			continue
+		}
+		if _, known := seen[id]; known {
+			continue
+		}
+		signal := transitionEventOutputHash(inst)
+		if lastTo, lastHash, ok := d.notifier.lastNotifiedTurn(id); ok && (lastTo != to || lastHash != signal) {
+			continue // changed while down: recordTerminalTurns notifies it once
+		}
+		seen[id] = to + "|" + signal
+	}
 }
 
 // recordTerminalTurns records EVERY completed turn into the drainable ledgers,
@@ -605,13 +678,7 @@ func (d *TransitionDaemon) recordTerminalTurns(
 	hookStatuses map[string]*HookStatus,
 ) {
 	notifyEnabled := GetNotificationsSettings().GetTransitionEventsEnabled()
-	if d.lastTurn == nil {
-		d.lastTurn = map[string]map[string]string{}
-	}
-	if d.lastTurn[profile] == nil {
-		d.lastTurn[profile] = map[string]string{}
-	}
-	seen := d.lastTurn[profile]
+	seen := d.turnBaseline(profile)
 
 	for id, to := range statuses {
 		if !isRecordableTurnStatus(to) {

--- a/internal/session/transition_notifier.go
+++ b/internal/session/transition_notifier.go
@@ -3,6 +3,7 @@ package session
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -535,16 +536,40 @@ func (n *TransitionNotifier) markNotified(event TransitionNotificationEvent) {
 	_ = n.saveStateLocked()
 }
 
+// lastNotifiedTurn reports the persisted last-notified (to_status, output
+// hash) for a child, or ok=false when this child has never been notified. The
+// daemon's restart seed compares it against the child's current status so a
+// recycle re-notifies only a turn that actually happened while it was down.
+func (n *TransitionNotifier) lastNotifiedTurn(childID string) (to, outputHash string, ok bool) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	rec, ok := n.state.Records[strings.TrimSpace(childID)]
+	if !ok {
+		return "", "", false
+	}
+	return rec.To, rec.OutputHash, true
+}
+
+// loadState reads the persisted last-notified records. A missing file is the
+// first-ever start; an unreadable or corrupt file is logged and treated the same
+// way (fresh, empty state) so the daemon still comes up — the restart seed then
+// takes the registry as the baseline instead of replaying history.
 func (n *TransitionNotifier) loadState() {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 
 	data, err := os.ReadFile(n.statePath)
 	if err != nil {
+		if !os.IsNotExist(err) {
+			commsLog.Warn("transition_notify_state_unreadable",
+				slog.String("path", n.statePath), slog.String("error", err.Error()))
+		}
 		return
 	}
 	var state transitionNotifyState
 	if err := json.Unmarshal(data, &state); err != nil {
+		commsLog.Warn("transition_notify_state_corrupt",
+			slog.String("path", n.statePath), slog.String("error", err.Error()))
 		return
 	}
 	if state.Records == nil {


### PR DESCRIPTION
Closes #2240

## Problem

Every restart of `agent-deck notify-daemon` (the `agent-deck-transition-notifier.service` `RuntimeMaxSec` recycle, or the recycle after an auto-update) re-emitted a `running -> waiting` record for **every** child still parked at a terminal status, however old, and fired the `[INBOX]` wake-nudge at each conductor. The consumed-turn ledger dropped the records on drain, so `inbox drain self` printed "No pending events", but the nudge had already cost one conductor turn per restart. Reported by a remote conductor operator on v1.16.5; the same symptom is visible on macOS.

Root cause chain: `recordTerminalTurns` deliberately runs on the first pass with an empty in-memory baseline, `isDuplicate` only silences repeats inside the 2h output-hash window, and `commitEventToInbox` nudges unconditionally after a last-wins `CommitToInbox`, while dedup happens later at drain time.

## Fix

1. **Stateful, silent restart** (`TransitionDaemon.seedTurnBaseline`, called once per profile before the first `recordTerminalTurns`). Seeds the per-child turn baseline from the session list against the persisted last-notified `(to_status, output_hash)` in `runtime/transition-notify-state.json` (already written atomically by `markNotified`):
   - no persisted record, or record equals the current `(status, signal)` -> seeded silently;
   - record differs (status changed while the daemon was down) -> left unseeded so the turn is notified exactly once;
   - first-ever start (no state file) seeds fresh; a corrupt/unreadable state file is now logged (`transition_notify_state_corrupt` / `_unreadable`) and seeds fresh.
   Children that appear after the first pass are still recorded on first sight, so the field round-3 race (`TestFieldTalkback_FirstScanRecordsAnAlreadyParkedSession`) stays covered and green.
2. **Nudge only when the drain would be non-empty** (`commitEventToInbox`). The wake-nudge is withheld when the record's `turn_fingerprint` is already in the parent's consumed-turn ledger (`turnAlreadyConsumed`, read-only). The record still commits; ledger dedup semantics and delivery ordering are unchanged.
3. **`RuntimeMaxSec` kept** in the systemd unit template. It is the unconditional stale-binary backstop from #1214 (`TestSystemdTransitionNotifierHasRecycleBackstop` still guards it); the recycle is now stateful and silent, documented on the template.

Not touched: `isDuplicate`, `CommitToInbox`, `finalizeInboxDrain`, the #1349 rebind gate, the hook-candidate path.

Known residual hole, documented in code: a child that had never been notified before and finished its first turn inside the daemon's own restart window (a few seconds) is seeded rather than notified.

## Tests

`internal/session/issue2240_notifier_restart_redelivery_test.go`, written first; four of six fail on `main`:

- `TestNotifierRestart_FirstEverStartDoesNotReplayParkedChildren` (fails on main)
- `TestNotifierRestart_RestartDoesNotRenotifyStillParkedChild` (fails on main, the reported bug: record aged past 2h, restart re-committed and nudged)
- `TestNotifierRestart_ChildChangedWhileDownIsNotifiedOnce`
- `TestNotifierRestart_CorruptStateFileSeedsFresh` (fails on main)
- `TestNotifierRestart_RealTransitionAfterStartStillNotifies`
- `TestCommit_NoWakeNudgeForAlreadyConsumedTurn` (fails on main)

Verification: `gofmt`, `go build ./...`, `go vet`, golangci-lint v2 (0 issues) and `go test ./internal/... ./cmd/agent-deck/...` in a network-isolated container. The only container failures are tests that need a `tmux` binary the image lacks, and they fail identically on unmodified `main`; CI has tmux.

## AI disclosure

Investigation, tests and implementation were done with Claude (Claude Code) under operator direction; the operator reviewed the diff. No AI attribution trailers in commits.
