### PR TITLE
fix(web): size the shell by the measured viewport so iOS keeps the tab bar and the keyboard clear

### DIFF
--- a/internal/web/static/app/AppShell.js
+++ b/internal/web/static/app/AppShell.js
@@ -48,6 +48,7 @@ import { SettingsPanel } from './SettingsPanel.js'
 import { KeyboardShortcuts } from './KeyboardShortcuts.js'
 import { apiFetch, authHeaders } from './api.js'
 import { shortcutsOverlaySignal } from './state.js'
+import { installViewportInsets } from './viewportInsets.js'
 
 function WorkHead() {
   const { sessions } = menuModelSignal.value
@@ -124,6 +125,17 @@ export function AppShell() {
   const confirmData = confirmDialogSignal.value
   const groupNameData = groupNameDialogSignal.value
   const drawerOpen = infoDrawerOpenSignal.value
+
+  // Publish the visible viewport into --app-height / --keyboard-inset, which
+  // styles.src.css already consumes on `.app`. Without a producer the grid is
+  // sized by `100vh` -- the iOS large viewport -- so the mobile tab bar sits
+  // below the fold whenever Safari's toolbars show, and nothing moves when the
+  // software keyboard opens over the terminal.
+  useEffect(() => {
+    const controller = new AbortController()
+    installViewportInsets(window, document.documentElement, controller.signal)
+    return () => controller.abort()
+  }, [])
 
   // Hide the vanilla .app div from the legacy boot path (kept for back-compat
   // until we delete it).

--- a/internal/web/static/app/app.css
+++ b/internal/web/static/app/app.css
@@ -30,7 +30,7 @@ button { font: inherit; color: inherit; }
     "top top top"
     "side main rail"
     "foot foot foot";
-  height: 100vh;
+  height: var(--app-height, 100dvh);
 }
 body[data-rail="hidden"] .app { grid-template-columns: var(--sidebar-w) 1fr 0; }
 body[data-rail="hidden"] .rightrail { display: none; }
@@ -615,7 +615,7 @@ body[data-rail="hidden"] .rightrail { display: none; }
   background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius-lg);
   box-shadow: 0 40px 100px -20px rgba(0,0,0,0.6), 0 0 0 1px var(--accent-soft);
   display: flex; flex-direction: column;
-  max-height: calc(100vh - 80px);
+  max-height: calc(var(--app-height, 100dvh) - 80px);
   overflow: hidden;
 }
 .dialog .dh { display: flex; align-items: center; gap: 10px; padding: 12px 14px; border-bottom: 1px solid var(--border); }

--- a/internal/web/static/app/viewportInsets.js
+++ b/internal/web/static/app/viewportInsets.js
@@ -1,0 +1,62 @@
+// viewportInsets.js -- producer for the two layout variables styles.src.css
+// already consumes on `.app`:
+//
+//     height: var(--app-height);
+//     padding-bottom: calc(var(--keyboard-inset) + env(safe-area-inset-bottom));
+//
+// Both were declared in :root and never written, so `--app-height` stayed at its
+// `100vh` default and `--keyboard-inset` at `0px`. On iOS Safari `100vh` is the
+// *large* viewport -- the height the page would have with the toolbars hidden --
+// so while they are showing, an element sized to it runs off the bottom of the
+// screen and takes the mobile tab bar with it. `window.innerHeight` tracks the
+// toolbars, which is why it, and not `100vh`, is what `--app-height` should be.
+//
+// The software keyboard is a separate axis: it never changes the layout
+// viewport, only the visual one. `visualViewport.height` is what shrinks, and
+// `offsetTop` is how far iOS scrolled the visual viewport up to keep the focused
+// field in sight -- that shift is not keyboard, so it comes off the overlap:
+//
+//     inset = innerHeight - visualViewport.height - visualViewport.offsetTop
+//
+// clamped at zero because iOS reports a visual viewport taller than the layout
+// one during rubber-band overscroll.
+//
+// Measured on iPhone (iOS 18.7, Safari 26.5): innerHeight 660 throughout;
+// visualViewport.height 660 with the keyboard closed and 376 with it open, so
+// the inset is 284. `100dvh` also reads 660 in both states, which is why it can
+// only serve as the static fallback and cannot carry the keyboard on its own.
+
+export function applyViewportInsets(win, root) {
+  const layout = win.innerHeight
+
+  // A background tab, a bfcache restore, and the moment before first layout all
+  // report 0. Publishing it would flatten `.app` to zero height; holding the last
+  // good value leaves the CSS `100dvh` fallback in charge until a real
+  // measurement arrives.
+  if (!layout) return
+
+  const visual = win.visualViewport
+  const inset = visual ? Math.max(0, layout - visual.height - visual.offsetTop) : 0
+
+  root.style.setProperty('--app-height', `${layout}px`)
+  root.style.setProperty('--keyboard-inset', `${inset}px`)
+}
+
+// Publishes now and on every event that can move either number. Listeners are
+// registered with the caller's AbortSignal, the teardown convention the rest of
+// the web UI uses (one controller per mount, aborted on unmount).
+export function installViewportInsets(win, root, signal) {
+  const publish = () => applyViewportInsets(win, root)
+  const opts = { signal }
+
+  publish()
+
+  win.addEventListener('resize', publish, opts)
+  win.addEventListener('orientationchange', publish, opts)
+
+  const visual = win.visualViewport
+  if (visual) {
+    visual.addEventListener('resize', publish, opts)
+    visual.addEventListener('scroll', publish, opts)
+  }
+}

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#1a1b26" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />

--- a/tests/web/e2e/mobile.spec.js
+++ b/tests/web/e2e/mobile.spec.js
@@ -126,4 +126,35 @@ test.describe('mobile phone layout', () => {
     await expect(page.locator('.term-strip .tpath')).toContainText('sess-002')
     await expect(page.locator('[data-testid="empty-state-dashboard"]')).toHaveCount(0)
   })
+
+  test('the shell is sized by the measured viewport, not by 100vh', async ({ page }) => {
+    // app.css sized `.app` with `height: 100vh`. On iOS Safari that is the
+    // LARGE viewport -- the height the page would have with the toolbars
+    // hidden -- so while they show, the bottom grid row (this tab bar) lands
+    // under the fold. Chromium cannot reproduce that: here 100vh and
+    // innerHeight agree. What this case pins instead is the wiring the fix
+    // restores -- viewportInsets mounted in the shell, publishing a measured
+    // pixel height into the --app-height that styles.src.css and app.css both
+    // read. Without the producer the variable keeps its `100vh` token and the
+    // first assertion fails.
+    const m = await page.evaluate(() => {
+      const root = getComputedStyle(document.documentElement)
+      const app = document.querySelector('.app')
+      const bar = document.querySelector('[data-testid="mobile-tabs"]')
+      return {
+        appHeight: root.getPropertyValue('--app-height').trim(),
+        keyboardInset: root.getPropertyValue('--keyboard-inset').trim(),
+        innerHeight: window.innerHeight,
+        appBottom: Math.round(app.getBoundingClientRect().bottom),
+        barBottom: Math.round(bar.getBoundingClientRect().bottom),
+      }
+    })
+
+    expect(m.appHeight).toBe(`${m.innerHeight}px`)
+    // No software keyboard in a headless run, so the inset must be exactly 0.
+    expect(m.keyboardInset).toBe('0px')
+    // The consequence that matters on a phone: nothing hangs below the fold.
+    expect(m.appBottom).toBeLessThanOrEqual(m.innerHeight)
+    expect(m.barBottom).toBeLessThanOrEqual(m.innerHeight)
+  })
 })

--- a/tests/web/unit/viewportInsets.test.js
+++ b/tests/web/unit/viewportInsets.test.js
@@ -1,0 +1,145 @@
+// unit/viewportInsets.test.js -- viewportInsets publishes the phone-visible
+// viewport geometry into the two CSS custom properties styles.src.css already
+// consumes on `.app`:
+//
+//     height: var(--app-height);
+//     padding-bottom: calc(var(--keyboard-inset) + env(safe-area-inset-bottom));
+//
+// Both variables were declared in :root and never written by any module, so
+// `--app-height` stayed at its `100vh` default and `--keyboard-inset` at `0px`.
+// On iOS Safari `100vh` is the *large* viewport (toolbars hidden), so with the
+// toolbars showing the app box is taller than the screen and the bottom row --
+// the mobile tab bar -- is pushed under the fold. When the software keyboard
+// opens, nothing moves, so the caret sits behind the keyboard.
+//
+// `window.innerHeight` tracks the toolbars on iOS where `100vh` does not, and
+// `visualViewport` is what reports the keyboard. This module is the missing
+// producer for those two variables.
+
+import { describe, it, expect } from 'vitest'
+
+const modulePath = '../../../internal/web/static/app/viewportInsets.js'
+
+// A stand-in for `window` carrying only what the module reads. Listener
+// registration is recorded so the install test can fire events itself.
+const fakeWindow = ({ innerHeight, visual }) => {
+  const listeners = []
+  const visualViewport = visual
+    ? {
+        height: visual.height,
+        offsetTop: visual.offsetTop ?? 0,
+        addEventListener: (type, fn, opts) => listeners.push({ on: 'visual', type, fn, opts }),
+      }
+    : undefined
+  return {
+    innerHeight,
+    visualViewport,
+    addEventListener: (type, fn, opts) => listeners.push({ on: 'window', type, fn, opts }),
+    listeners,
+  }
+}
+
+const load = () => import(modulePath)
+
+const apply = async (win, root) => {
+  const { applyViewportInsets } = await load()
+  return applyViewportInsets(win, root)
+}
+
+describe('applyViewportInsets', () => {
+  it('publishes the layout viewport height as --app-height', async () => {
+    const root = document.createElement('div')
+
+    await apply(fakeWindow({ innerHeight: 812, visual: { height: 812 } }), root)
+
+    expect(root.style.getPropertyValue('--app-height')).toBe('812px')
+  })
+
+  it('publishes the height the software keyboard covers as --keyboard-inset', async () => {
+    const root = document.createElement('div')
+    // iPhone 13: 812pt layout viewport, keyboard leaves 476pt visible.
+    const win = fakeWindow({ innerHeight: 812, visual: { height: 476, offsetTop: 0 } })
+
+    await apply(win, root)
+
+    expect(root.style.getPropertyValue('--keyboard-inset')).toBe('336px')
+  })
+
+  it('subtracts the visual viewport offset so a scrolled-up page is not counted twice', async () => {
+    const root = document.createElement('div')
+    // iOS scrolls the visual viewport when the keyboard opens over a focused
+    // field near the bottom; offsetTop is that shift, not keyboard height.
+    const win = fakeWindow({ innerHeight: 812, visual: { height: 476, offsetTop: 100 } })
+
+    await apply(win, root)
+
+    expect(root.style.getPropertyValue('--keyboard-inset')).toBe('236px')
+  })
+
+  it('never publishes a negative inset when iOS overscroll reports a taller visual viewport', async () => {
+    const root = document.createElement('div')
+    const win = fakeWindow({ innerHeight: 812, visual: { height: 900, offsetTop: 0 } })
+
+    await apply(win, root)
+
+    expect(root.style.getPropertyValue('--keyboard-inset')).toBe('0px')
+  })
+
+  it('falls back to the layout viewport with no inset when visualViewport is absent', async () => {
+    const root = document.createElement('div')
+
+    await apply(fakeWindow({ innerHeight: 640, visual: null }), root)
+
+    expect(root.style.getPropertyValue('--app-height')).toBe('640px')
+    expect(root.style.getPropertyValue('--keyboard-inset')).toBe('0px')
+  })
+})
+
+describe('installViewportInsets', () => {
+  it('republishes the inset when the visual viewport resizes', async () => {
+    const { installViewportInsets } = await load()
+    const root = document.createElement('div')
+    const win = fakeWindow({ innerHeight: 812, visual: { height: 812, offsetTop: 0 } })
+
+    installViewportInsets(win, root, new AbortController().signal)
+    expect(root.style.getPropertyValue('--keyboard-inset')).toBe('0px')
+
+    // The keyboard opens: the browser shrinks the visual viewport, then fires.
+    win.visualViewport.height = 476
+    const resize = win.listeners.find((l) => l.on === 'visual' && l.type === 'resize')
+    resize.fn()
+
+    expect(root.style.getPropertyValue('--keyboard-inset')).toBe('336px')
+  })
+
+  it('registers every listener with the caller\'s abort signal so teardown is automatic', async () => {
+    const { installViewportInsets } = await load()
+    const root = document.createElement('div')
+    const win = fakeWindow({ innerHeight: 812, visual: { height: 812, offsetTop: 0 } })
+    const { signal } = new AbortController()
+
+    installViewportInsets(win, root, signal)
+
+    expect(win.listeners.length).toBeGreaterThan(0)
+    for (const l of win.listeners) {
+      expect(l.opts?.signal).toBe(signal)
+    }
+  })
+})
+
+describe('applyViewportInsets in a viewport that has no size yet', () => {
+  // A background tab, a bfcache restore, and the moment before first layout all
+  // report innerHeight 0. Publishing that flattens `.app` to zero height -- it is sized
+  // by --app-height -- so the whole UI disappears. Holding the previous value
+  // keeps the CSS `100dvh` fallback in charge until a real measurement arrives.
+  it('leaves the published values alone when the viewport reports zero height', async () => {
+    const root = document.createElement('div')
+    root.style.setProperty('--app-height', '812px')
+    root.style.setProperty('--keyboard-inset', '284px')
+
+    await apply(fakeWindow({ innerHeight: 0, visual: { height: 0, offsetTop: 0 } }), root)
+
+    expect(root.style.getPropertyValue('--app-height')).toBe('812px')
+    expect(root.style.getPropertyValue('--keyboard-inset')).toBe('284px')
+  })
+})


### PR DESCRIPTION

## What problem does this solve?

On an iPhone the web UI's bottom tab bar sits below the fold, and raising the software keyboard moves nothing, so the field being typed into can end up behind it. Fixes #2247.

## Why this change

`styles.src.css` already declares `--app-height` and `--keyboard-inset` and already consumes both on `.app`. Nothing has ever written them, so `--app-height` keeps its `100vh` token. This adds the missing producer rather than a second mechanism, and points the v1.8.0 grid's own `.app` rule in `app.css` at the same variable so it stops measuring the viewport with `100vh`.

The two numbers are separate axes, which is why one variable will not do:

- **Toolbars.** `100vh` on iOS is the large viewport, so an element sized to it runs off the bottom while the toolbars show. `window.innerHeight` tracks them.
- **Keyboard.** It never changes the layout viewport, only the visual one. Measured on the device: `innerHeight` stays 660 whether the keyboard is up or down, while `visualViewport.height` goes 660 → 376.

`100dvh` is the static fallback in the CSS but cannot do this job alone: it also reads 660 with the keyboard open, so it covers the toolbars and not the keyboard.

`index.html` gains `viewport-fit=cover` so the `env(safe-area-inset-bottom)` already present in the `.app` rule can resolve to something in standalone mode — the page opts into standalone via `apple-mobile-web-app-capable`, and without `viewport-fit` that inset is permanently 0.

## User impact

Phone users: the bottom tab bar stays on screen, and the shell lifts by exactly the keyboard's height when it opens.

Desktop and tablet: no visible change. `innerHeight` and `100vh` agree on those, so the published value is the same number the layout already used — the screenshot baselines are unchanged across all three Playwright projects.

## Evidence

**Device measurements** (iPhone, iOS 18.7, Safari 26.5.2), from an event-logging page with no agent-deck code involved:

```
keyboard closed:  innerHeight=660  visualViewport.height=660  offsetTop=0  100dvh=660
keyboard open:    innerHeight=660  visualViewport.height=376  offsetTop=0  100dvh=660
```

284px of keyboard that the layout viewport never sees. The unit tests use these exact numbers.

**Before / after on the device.** Same iPhone, same action — open a session, tap the
terminal, let the software keyboard come up. The stock build and the patched build
were running side by side, so this is one device comparing two binaries.

| | stock v1.16.4 | patched |
|---|---|---|
| bottom tab bar with the keyboard up | not on screen at all | on screen, directly above the keyboard |
| terminal frame | runs off the bottom, last lines unreachable | ends cleanly above the tab bar |

The tab bar is the tell: it is the grid's last row, so it is the first thing
`100vh` pushes past the fold, and with no `--keyboard-inset` nothing brings it back
when the keyboard opens. Screenshots of both states exist and I can add them if
they would help the review.

**The new e2e case fails without the fix.** Reverting only the AppShell wiring and re-running:

```
✘ mobile phone layout › the shell is sized by the measured viewport, not by 100vh
  Expected: "851px"
  Received: "100vh"
  1 failed, 5 passed
```

Restored, 6 passed. Chromium cannot reproduce the iOS bug itself — there `100vh` and `innerHeight` agree — so that case deliberately pins the wiring (the producer is mounted and publishing a measured pixel value) rather than claiming to reproduce the device behaviour. The arithmetic is covered by the unit tests.

**Suites:**

```
tests/web unit (vitest)      157 passed          (8 new)
tests/web e2e  (playwright)  605 passed, 0 failed, 117 skipped — incl. screenshot regression
go test ./...  (sandboxed)   ok, 57 packages, EXIT=0
make css-verify              clean (no styles.css drift)
```

## AI disclosure

- [x] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** claude-opus-5

## What actually bothered you

My human asked: "I use agent-deck a lot, but the web page was never built for a phone — can we improve that? On my iPhone it gets cut off and typing is hard." They drive their agent sessions from the phone over a private tunnel, and the bottom tab bar being off-screen means the Session/Fleet switch is unreachable without fighting the page.

(Separately they hit garbled Korean input in the terminal on iOS. That is a different defect with a different cause — iOS fires no composition events for Hangul, it emits `deleteContentBackward` + `insertText` pairs that xterm's `_inputEvent` only half-handles — and it is not in this PR.)

## Checklist

- [x] Targeted diff: one problem, no unrelated changes
- [x] Tests added or updated for new behavior
- [x] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`

<!-- gate:ai=authored model=claude-opus-5 intent=yes -->
