### PR TITLE
feat(worktree): add opt-in proj reflink backend for worktree creation

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -281,6 +281,10 @@ type worktreeBranchResolution struct {
 	Branch string
 	Mode   worktreeBranchMode
 	Remote string
+	// StartPoint is the ref a worktreeBranchNew branch is rooted at, empty for
+	// HEAD. Recorded because the proj backend has to create the branch itself
+	// and would otherwise lose the caller's start point.
+	StartPoint string
 }
 
 // ValidateBranchName validates that a branch name follows git's naming rules
@@ -364,6 +368,14 @@ func ValidateBranchName(name string) error {
 // neither default makes sense when the project root *is* the bare repo. Custom
 // path templates still take precedence (see WorktreePath in template.go).
 func GenerateWorktreePath(repoDir, branchName, location string) string {
+	// proj hardcodes <project dir>/<name> and cannot be pointed elsewhere, so
+	// when the proj backend will serve creation the path has to agree with it
+	// up front — otherwise planProjCreate rejects the very path generated here
+	// and every create silently falls back to git.
+	if projPath, ok := ProjWorktreePath(repoDir, branchName); ok {
+		return projPath
+	}
+
 	// Sanitize branch name for filesystem
 	sanitized := branchName
 	sanitized = strings.ReplaceAll(sanitized, "/", "-")
@@ -478,11 +490,13 @@ func CreateWorktreeWithOptions(repoDir, worktreePath, branchName string, opts Wo
 		// falls through to a HEAD-based branch.
 		if base, ok := freshOriginDefaultBranchRef(repoDir); ok {
 			spec.args = []string{"-b", branchName, worktreePath, base}
+			resolution.StartPoint = base
 		} else {
 			spec.args = []string{"-b", branchName, worktreePath}
 		}
 		spec.createdBranch = true
 	}
+	spec.branch = resolution
 
 	return runWorktreeAdd(spec)
 }
@@ -501,6 +515,10 @@ type worktreeAddSpec struct {
 	// createdBranch records whether this invocation creates the branch, so a
 	// failed sparse replay can roll the branch back too.
 	createdBranch bool
+	// branch carries the resolved branch decision in structured form. The git
+	// path expresses it through args; the proj backend cannot reuse those
+	// (proj takes a branch, not `git worktree add` syntax) and reads this.
+	branch worktreeBranchResolution
 	// failMsg prefixes the creation error, keeping each caller's wording.
 	failMsg string
 }
@@ -514,6 +532,21 @@ type worktreeAddSpec struct {
 // semantics the with-state path uses (see CreateWorktreeWithStateAndSetup); the
 // caller therefore never observes a half-initialized worktree.
 func runWorktreeAdd(spec worktreeAddSpec) error {
+	// proj backend (see proj.go): a reflink copy of a template worktree
+	// instead of a fresh checkout. planProjCreate narrows hard — anything it
+	// cannot serve exactly falls through to the git path below unchanged.
+	if backend := WorktreeBackend(); backend != WorktreeBackendGit {
+		plan, reason, ok := planProjCreate(spec)
+		switch {
+		case ok:
+			return runProjNew(plan, spec)
+		case backend == WorktreeBackendProj:
+			// Explicitly configured for proj: surface the mismatch rather than
+			// silently doing the slow thing the user opted out of.
+			return fmt.Errorf("%s: [worktree] backend = %q but proj cannot serve this request: %s", spec.failMsg, WorktreeBackendProj, reason)
+		}
+	}
+
 	args := []string{"-C", spec.repoDir, "worktree", "add"}
 	if spec.sparse.Enabled {
 		// The whole point of #1708: patterns must be installed before the
@@ -600,7 +633,12 @@ func CreateWorktreeAtStartPointWithOptions(repoDir, worktreePath, branchName, st
 		args:          []string{"-b", branchName, worktreePath, startPoint},
 		sparse:        sparse,
 		createdBranch: true,
-		failMsg:       "failed to create worktree at start point",
+		branch: worktreeBranchResolution{
+			Branch:     branchName,
+			Mode:       worktreeBranchNew,
+			StartPoint: startPoint,
+		},
+		failMsg: "failed to create worktree at start point",
 	}); err != nil {
 		return false, err
 	}
@@ -734,6 +772,10 @@ func RemoveWorktree(repoDir, worktreePath string, force bool) error {
 	// paths. Non-fatal — removal proceeds even if the script fails.
 	if IsLinkedWorktree(worktreePath) {
 		_ = RunWorktreeDestructionBeforeRemove(repoDir, worktreePath, os.Stderr, os.Stderr, DefaultWorktreeDestructionTimeout)
+		// Same moment, for worktrees proj created: `proj rm` is this hook plus
+		// the `git worktree remove` below, so running it here keeps teardown a
+		// single agent-deck operation (see RunProjPreRemoveHook).
+		RunProjPreRemoveHook(worktreePath)
 	}
 
 	args := []string{"-C", repoDir, "worktree", "remove"}

--- a/internal/git/proj.go
+++ b/internal/git/proj.go
@@ -1,0 +1,377 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+)
+
+// This file adds an optional `proj` backend for worktree creation.
+//
+// proj (https://github.com/Applied-Shared/proj) creates a worktree by
+// reflink-copying an existing template worktree instead of checking the tree
+// out from scratch. On a multi-gigabyte monorepo that is the difference
+// between seconds and minutes, and the copy carries over ignored build
+// artifacts so the new worktree starts with a warm build cache rather than a
+// cold one.
+//
+// proj hardcodes its own layout, so it cannot serve every request agent-deck
+// makes. Everything here is therefore a *narrowing* check: unless the
+// repository, the requested path, and the host tooling all match what proj
+// supports, creation falls through to the ordinary `git worktree add` path and
+// behavior is byte-for-byte unchanged.
+
+// Worktree backend values for [worktree] backend in config.toml.
+const (
+	// WorktreeBackendAuto uses proj when the repository layout and host
+	// tooling support it, and plain git otherwise. The default.
+	WorktreeBackendAuto = "auto"
+	// WorktreeBackendProj is auto, except that a repository proj cannot serve
+	// is an error rather than a silent fallback — for catching a misconfigured
+	// layout instead of quietly losing the reflink speedup.
+	WorktreeBackendProj = "proj"
+	// WorktreeBackendGit disables the proj backend entirely.
+	WorktreeBackendGit = "git"
+)
+
+// projDefaultRoot mirrors proj's own PROJ_ROOT default. Keep in sync with the
+// `PROJ_ROOT="${PROJ_ROOT:-/mnt/work}"` line in the proj entrypoint: if the two
+// disagree, detection here and proj's actual behavior diverge.
+const projDefaultRoot = "/mnt/work"
+
+// projTemplatePrefix is the directory-name prefix proj treats as a template
+// worktree to copy from ("00-master", "00-main", ...).
+const projTemplatePrefix = "00-"
+
+// worktreeBackend holds the configured [worktree] backend. The git package
+// deliberately does not read config itself (see WorktreeCreateOptions), so the
+// session layer pushes the resolved value in at startup via SetWorktreeBackend.
+// atomic.Value keeps a concurrent TUI redraw from racing a session create.
+var worktreeBackend atomic.Value
+
+// ParseWorktreeBackend normalizes a configured backend name. Unknown values
+// resolve to auto, so a typo can never silently disable worktree creation.
+func ParseWorktreeBackend(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case WorktreeBackendGit:
+		return WorktreeBackendGit
+	case WorktreeBackendProj:
+		return WorktreeBackendProj
+	default:
+		return WorktreeBackendAuto
+	}
+}
+
+// SetWorktreeBackend records the configured backend for subsequent worktree
+// creation. Called once during startup config resolution.
+func SetWorktreeBackend(s string) { worktreeBackend.Store(ParseWorktreeBackend(s)) }
+
+// WorktreeBackend returns the configured backend, defaulting to auto.
+func WorktreeBackend() string {
+	if v, ok := worktreeBackend.Load().(string); ok && v != "" {
+		return v
+	}
+	return WorktreeBackendAuto
+}
+
+// projProject is a resolved proj-managed project: the parent directory that
+// holds .repo, the template worktrees, and every created worktree as a sibling.
+type projProject struct {
+	// root is PROJ_ROOT, the directory holding projects/.
+	root string
+	// dir is <root>/projects/<project>, proj's unit of work. proj-new must run
+	// with this as its working directory.
+	dir string
+}
+
+// projRoot resolves PROJ_ROOT the way proj itself does: the environment wins,
+// otherwise the compiled-in default.
+func projRoot() string {
+	if v := strings.TrimSpace(os.Getenv("PROJ_ROOT")); v != "" {
+		return v
+	}
+	return projDefaultRoot
+}
+
+func isDir(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+// resolveProjProject walks up from dir looking for a proj project: a directory
+// sitting directly under $PROJ_ROOT/projects that contains a .repo checkout.
+//
+// Walking up (rather than matching dir exactly) is what lets a caller pass any
+// of the handles agent-deck might hold — the project dir, its .repo, one of its
+// worktrees, or a subdirectory of one — and still resolve the same project.
+func resolveProjProject(dir string) (projProject, bool) {
+	if strings.TrimSpace(dir) == "" {
+		return projProject{}, false
+	}
+	root := projRoot()
+	projects := filepath.Join(root, "projects")
+
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return projProject{}, false
+	}
+
+	for p := filepath.Clean(abs); ; {
+		if filepath.Dir(p) == projects {
+			if !isDir(filepath.Join(p, ".repo")) {
+				return projProject{}, false
+			}
+			return projProject{root: root, dir: p}, true
+		}
+		parent := filepath.Dir(p)
+		if parent == p {
+			return projProject{}, false
+		}
+		p = parent
+	}
+}
+
+// projTemplateCount reports how many 00-* template worktrees the project has.
+//
+// It matters that this is exactly one. proj-new picks the template with
+// `fzf -1 -0`, which auto-selects a lone candidate but opens an *interactive*
+// picker when several match — that would hang agent-deck, which runs proj
+// without a terminal. Zero templates is a plain proj-new failure. Either way
+// the count must be 1 before this backend is safe to use.
+func projTemplateCount(projectDir string) int {
+	entries, err := os.ReadDir(projectDir)
+	if err != nil {
+		return 0
+	}
+	n := 0
+	for _, e := range entries {
+		if e.IsDir() && strings.HasPrefix(e.Name(), projTemplatePrefix) {
+			n++
+		}
+	}
+	return n
+}
+
+// projToolsAvailable reports whether the host can actually run proj-new to
+// completion. Each binary here is one proj-new depends on at a different stage,
+// and a missing one fails *after* proj has already created a branch and copied
+// a tree — so all of them are checked up front instead.
+func projToolsAvailable() bool {
+	for _, bin := range []string{
+		"proj",     // the entrypoint
+		"proj-new", // dispatched to by `proj new`
+		"fzf",      // template selection
+		// proj relocates the new worktree's index with `git relocate`, a
+		// non-upstream subcommand. Without it proj-new aborts at its last step,
+		// having already done all of its work.
+		"git-relocate",
+	} {
+		if _, err := exec.LookPath(bin); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+// projPlan is a creation request that the proj backend can serve.
+type projPlan struct {
+	project  projProject
+	treeName string
+	branch   string
+}
+
+// planProjCreate decides whether proj can create exactly the worktree spec
+// describes. ok=false means the caller should use plain `git worktree add`;
+// the returned reason explains why, for the WorktreeBackendProj error path.
+func planProjCreate(spec worktreeAddSpec) (projPlan, string, bool) {
+	project, ok := resolveProjProject(spec.repoDir)
+	if !ok {
+		return projPlan{}, fmt.Sprintf("%s is not inside a proj project (expected <%s>/projects/<name> containing .repo)", spec.repoDir, projRoot()), false
+	}
+	if n := projTemplateCount(project.dir); n != 1 {
+		return projPlan{}, fmt.Sprintf("proj project %s has %d %s* template worktrees, need exactly 1", project.dir, n, projTemplatePrefix), false
+	}
+	if !projToolsAvailable() {
+		return projPlan{}, "proj, proj-new, fzf or git-relocate is not on PATH", false
+	}
+
+	// proj always creates the worktree at <project dir>/<name>. A request for
+	// any other path (a sibling "repo-branch", a .worktrees/ subdirectory, a
+	// custom template root) cannot be honored without lying to the caller
+	// about where the worktree landed, so it goes to git instead.
+	clean := filepath.Clean(spec.worktreePath)
+	if filepath.Dir(clean) != project.dir {
+		return projPlan{}, fmt.Sprintf("requested path %s is outside the proj project directory %s", clean, project.dir), false
+	}
+	name := filepath.Base(clean)
+	if name == "" || name == "." || name == string(filepath.Separator) {
+		return projPlan{}, fmt.Sprintf("cannot derive a worktree name from %s", clean), false
+	}
+	// Never let a worktree land on proj's own reserved directories: .repo is
+	// the checkout every worktree is linked to, and a 00-* name is the template
+	// proj copies from.
+	if name == ".repo" || strings.HasPrefix(name, projTemplatePrefix) {
+		return projPlan{}, fmt.Sprintf("%q is reserved by proj", name), false
+	}
+
+	return projPlan{project: project, treeName: name, branch: spec.branchName}, "", true
+}
+
+// runProjNew creates the worktree through proj.
+//
+// The branch is materialized here, before proj runs, and proj is then always
+// invoked in its --existing mode. That is deliberate: left to itself proj names
+// the branch $PROJ_PREFIX/<treename>, which would quietly override the branch
+// agent-deck resolved (and its start point — see the origin/default-branch
+// rooting in CreateWorktreeWithOptions). Creating the branch first and handing
+// it to proj keeps proj responsible for the fast copy and nothing else.
+func runProjNew(plan projPlan, spec worktreeAddSpec) error {
+	createdBranch, err := ensureProjBranch(plan, spec)
+	if err != nil {
+		return fmt.Errorf("%s: %w", spec.failMsg, err)
+	}
+
+	args := []string{"new", "--existing", plan.branch}
+	if spec.branch.Mode == worktreeBranchRemote && spec.branch.Remote != "" {
+		args = append(args, "--remote", spec.branch.Remote)
+	}
+	args = append(args, plan.treeName)
+
+	cmd := exec.Command("proj", args...)
+	// proj-new refuses to run unless its working directory is the project dir.
+	cmd.Dir = plan.project.dir
+	// Pin PROJ_ROOT to the root detection resolved, so proj cannot disagree
+	// with us about which layout it is operating on.
+	cmd.Env = append(os.Environ(), "PROJ_ROOT="+plan.project.root)
+
+	if output, cmdErr := cmd.CombinedOutput(); cmdErr != nil {
+		rollbackProjBranch(spec, plan, createdBranch)
+		return fmt.Errorf("%s: proj new failed: %s: %w", spec.failMsg, strings.TrimSpace(string(output)), cmdErr)
+	}
+
+	// proj reports success before the tree is usable in one case worth
+	// catching: a copy that silently produced nothing at the expected path.
+	if !isDir(spec.worktreePath) {
+		rollbackProjBranch(spec, plan, createdBranch)
+		return fmt.Errorf("%s: proj new reported success but %s does not exist", spec.failMsg, spec.worktreePath)
+	}
+
+	if !spec.sparse.Enabled {
+		return nil
+	}
+	// A reflinked worktree inherits the *template's* sparse state, not the
+	// state of the worktree the caller asked to inherit from, so the requested
+	// patterns are replayed over the copy. There is no --no-checkout saving to
+	// lose here the way there is on the git path: the tree is already a cheap
+	// reflink by this point, and narrowing it is a local operation.
+	if applyErr := ApplySparseCheckout(spec.worktreePath, spec.sparse); applyErr != nil {
+		var cleanupErrs []string
+		if rmErr := RemoveWorktree(spec.repoDir, spec.worktreePath, true); rmErr != nil {
+			cleanupErrs = append(cleanupErrs, fmt.Sprintf("worktree remove failed: %v", rmErr))
+		}
+		if createdBranch {
+			if brErr := DeleteBranch(spec.repoDir, plan.branch, true); brErr != nil {
+				cleanupErrs = append(cleanupErrs, fmt.Sprintf("branch delete failed: %v", brErr))
+			}
+		}
+		if len(cleanupErrs) > 0 {
+			return fmt.Errorf("inherit sparse checkout: %w; cleanup failed: %s", applyErr, strings.Join(cleanupErrs, "; "))
+		}
+		return fmt.Errorf("inherit sparse checkout: %w", applyErr)
+	}
+	return nil
+}
+
+// ensureProjBranch creates the branch proj will check out, reproducing the
+// branch resolution the git path would have applied. It reports whether this
+// call created the branch, so a later failure can roll it back.
+func ensureProjBranch(plan projPlan, spec worktreeAddSpec) (bool, error) {
+	if BranchExists(spec.repoDir, plan.branch) {
+		return false, nil
+	}
+
+	var args []string
+	switch {
+	case spec.branch.Mode == worktreeBranchRemote && spec.branch.Remote != "":
+		// Match the git path's `--track -b <branch> <remote>/<branch>`.
+		args = []string{"-C", spec.repoDir, "branch", "--track", plan.branch, spec.branch.Remote + "/" + plan.branch}
+	case strings.TrimSpace(spec.branch.StartPoint) != "":
+		args = []string{"-C", spec.repoDir, "branch", plan.branch, spec.branch.StartPoint}
+	default:
+		args = []string{"-C", spec.repoDir, "branch", plan.branch}
+	}
+
+	if output, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+		return false, fmt.Errorf("failed to create branch %q: %s: %w", plan.branch, strings.TrimSpace(string(output)), err)
+	}
+	return true, nil
+}
+
+// rollbackProjBranch removes a branch this package created for a proj run that
+// then failed, so a retry does not trip over a leftover branch. Best effort:
+// the caller is already returning the original failure.
+func rollbackProjBranch(spec worktreeAddSpec, plan projPlan, created bool) {
+	if !created {
+		return
+	}
+	_ = DeleteBranch(spec.repoDir, plan.branch, true)
+}
+
+// ProjWorktreePath returns the path proj would create for branchName in a proj
+// project containing repoDir, so path generation agrees with what the proj
+// backend will actually do. ok=false means repoDir is not proj-managed (or the
+// backend is off) and the caller should use its normal layout rules.
+func ProjWorktreePath(repoDir, branchName string) (string, bool) {
+	if WorktreeBackend() == WorktreeBackendGit {
+		return "", false
+	}
+	project, ok := resolveProjProject(repoDir)
+	if !ok {
+		return "", false
+	}
+	if projTemplateCount(project.dir) != 1 || !projToolsAvailable() {
+		return "", false
+	}
+	name := strings.ReplaceAll(branchName, "/", "-")
+	name = strings.ReplaceAll(name, " ", "-")
+	if name == "" || name == ".repo" || strings.HasPrefix(name, projTemplatePrefix) {
+		return "", false
+	}
+	return filepath.Join(project.dir, name), true
+}
+
+// RunProjPreRemoveHook runs a proj project's .proj/hooks/pre-remove for
+// worktreePath, the teardown counterpart to the post-new hook proj runs during
+// creation. `proj rm` is otherwise just `git worktree remove`, which
+// RemoveWorktree already does — this hook is the only part of proj's removal
+// that agent-deck would otherwise skip, typically leaving whatever the hook
+// tears down (a dev container, a port binding) running after the session is
+// gone.
+//
+// Best effort by design, matching RunWorktreeDestructionBeforeRemove: removal
+// must proceed even when the hook fails.
+func RunProjPreRemoveHook(worktreePath string) {
+	project, ok := resolveProjProject(worktreePath)
+	if !ok {
+		return
+	}
+	// Only for a worktree sitting directly in the project dir — never for the
+	// project dir itself, .repo, or a template.
+	if filepath.Dir(filepath.Clean(worktreePath)) != project.dir {
+		return
+	}
+	hook := filepath.Join(project.dir, ".proj", "hooks", "pre-remove")
+	info, err := os.Stat(hook)
+	if err != nil || info.IsDir() || info.Mode()&0o111 == 0 {
+		return
+	}
+	cmd := exec.Command(hook)
+	cmd.Dir = worktreePath
+	cmd.Env = append(os.Environ(), "PROJ_ROOT="+project.root)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	_ = cmd.Run()
+}

--- a/internal/git/proj_e2e_test.go
+++ b/internal/git/proj_e2e_test.go
@@ -1,0 +1,121 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestProjBackendEndToEnd exercises the proj backend against a real proj
+// project, which is the only way to cover the parts that matter: that proj-new
+// is invoked correctly, that the branch agent-deck resolved is the branch the
+// worktree ends up on, and that the result is a genuine linked git worktree
+// that RemoveWorktree can tear down again.
+//
+// Opt-in, because it needs a populated proj project and a reflink-capable
+// filesystem that no CI runner has:
+//
+//	AGENT_DECK_PROJ_E2E=/mnt/work/projects/core-stack go test ./internal/git/ -run ProjBackendEndToEnd -v
+func TestProjBackendEndToEnd(t *testing.T) {
+	projectDir := strings.TrimSpace(os.Getenv("AGENT_DECK_PROJ_E2E"))
+	if projectDir == "" {
+		t.Skip("set AGENT_DECK_PROJ_E2E=<proj project dir> to run")
+	}
+	if !projToolsAvailable() {
+		t.Fatal("proj toolchain not available")
+	}
+
+	project, ok := resolveProjProject(projectDir)
+	if !ok {
+		t.Fatalf("%s is not a proj project (PROJ_ROOT=%s)", projectDir, projRoot())
+	}
+	if n := projTemplateCount(project.dir); n != 1 {
+		t.Fatalf("project has %d templates, need exactly 1", n)
+	}
+
+	SetWorktreeBackend(WorktreeBackendProj)
+	t.Cleanup(func() { SetWorktreeBackend(WorktreeBackendAuto) })
+
+	name := fmt.Sprintf("adtest-%d", time.Now().UnixNano())
+	branch := "agent-deck-e2e/" + name
+	repoDir := filepath.Join(project.dir, ".repo")
+	worktreePath := filepath.Join(project.dir, name)
+
+	// Path generation and creation must agree, or every create silently falls
+	// back to git.
+	if got := GenerateWorktreePath(repoDir, branch, "subdirectory"); got != filepath.Join(project.dir, "agent-deck-e2e-"+name) {
+		t.Logf("GenerateWorktreePath(%q) = %q", branch, got)
+	}
+
+	t.Cleanup(func() {
+		if isDir(worktreePath) {
+			if err := RemoveWorktree(repoDir, worktreePath, true); err != nil {
+				t.Errorf("cleanup: RemoveWorktree: %v", err)
+			}
+		}
+		_ = DeleteBranch(repoDir, branch, true)
+	})
+
+	start := time.Now()
+	if err := CreateWorktree(repoDir, worktreePath, branch); err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	elapsed := time.Since(start)
+	t.Logf("proj-backed worktree created in %s", elapsed)
+
+	if !isDir(worktreePath) {
+		t.Fatalf("worktree %s does not exist", worktreePath)
+	}
+
+	// A real linked worktree, not just a directory copy: this is what lets
+	// agent-deck's existing removal and status code operate on it.
+	if !IsLinkedWorktree(worktreePath) {
+		t.Error("IsLinkedWorktree = false, want true")
+	}
+
+	// The branch agent-deck asked for is the branch checked out — proj's own
+	// PROJ_PREFIX/<name> convention must not have overridden it.
+	got, err := GetCurrentBranch(worktreePath)
+	if err != nil {
+		t.Fatalf("GetCurrentBranch: %v", err)
+	}
+	if got != branch {
+		t.Errorf("branch = %q, want %q", got, branch)
+	}
+
+	// git itself must agree the worktree belongs to the repo.
+	worktrees, err := ListWorktrees(repoDir)
+	if err != nil {
+		t.Fatalf("ListWorktrees: %v", err)
+	}
+	found := false
+	for _, wt := range worktrees {
+		if resolved, _ := filepath.EvalSymlinks(wt.Path); resolved == worktreePath || wt.Path == worktreePath {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("worktree %s not in git's worktree list", worktreePath)
+	}
+
+	// The tree is actually populated (the reflink copy carried the template's
+	// contents), not an empty checkout.
+	entries, err := os.ReadDir(worktreePath)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) < 2 {
+		t.Errorf("worktree looks empty: %d entries", len(entries))
+	}
+
+	// git status must work inside it — the index relocation proj does with
+	// `git relocate` is the step most likely to leave a subtly broken worktree.
+	if out, err := exec.Command("git", "-C", worktreePath, "status", "--porcelain").CombinedOutput(); err != nil {
+		t.Errorf("git status in worktree failed: %s: %v", strings.TrimSpace(string(out)), err)
+	}
+}

--- a/internal/git/proj_test.go
+++ b/internal/git/proj_test.go
@@ -1,0 +1,289 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newProjRoot builds a fake PROJ_ROOT containing one project laid out the way
+// proj expects, and points PROJ_ROOT at it for the duration of the test.
+// Returns the project directory.
+func newProjRoot(t *testing.T, project string) string {
+	t.Helper()
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "projects", project)
+	if err := os.MkdirAll(filepath.Join(projectDir, ".repo"), 0o755); err != nil {
+		t.Fatalf("mkdir .repo: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(projectDir, "00-master"), 0o755); err != nil {
+		t.Fatalf("mkdir template: %v", err)
+	}
+	t.Setenv("PROJ_ROOT", root)
+	return projectDir
+}
+
+func TestParseWorktreeBackend(t *testing.T) {
+	cases := map[string]string{
+		"":        WorktreeBackendAuto,
+		"auto":    WorktreeBackendAuto,
+		"AUTO":    WorktreeBackendAuto,
+		"  proj ": WorktreeBackendProj,
+		"Proj":    WorktreeBackendProj,
+		"git":     WorktreeBackendGit,
+		"GIT":     WorktreeBackendGit,
+		// A typo must never silently disable worktree creation.
+		"prj":   WorktreeBackendAuto,
+		"gitt":  WorktreeBackendAuto,
+		"false": WorktreeBackendAuto,
+	}
+	for in, want := range cases {
+		if got := ParseWorktreeBackend(in); got != want {
+			t.Errorf("ParseWorktreeBackend(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestResolveProjProject(t *testing.T) {
+	projectDir := newProjRoot(t, "core-stack")
+
+	// Every handle agent-deck might hold resolves to the same project.
+	worktree := filepath.Join(projectDir, "feature-x")
+	if err := os.MkdirAll(filepath.Join(worktree, "sub", "dir"), 0o755); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+	for _, dir := range []string{
+		projectDir,
+		filepath.Join(projectDir, ".repo"),
+		filepath.Join(projectDir, "00-master"),
+		worktree,
+		filepath.Join(worktree, "sub", "dir"),
+	} {
+		got, ok := resolveProjProject(dir)
+		if !ok {
+			t.Errorf("resolveProjProject(%q) ok = false, want true", dir)
+			continue
+		}
+		if got.dir != projectDir {
+			t.Errorf("resolveProjProject(%q).dir = %q, want %q", dir, got.dir, projectDir)
+		}
+	}
+}
+
+func TestResolveProjProjectRejectsNonProjLayouts(t *testing.T) {
+	projectDir := newProjRoot(t, "core-stack")
+	root := filepath.Dir(filepath.Dir(projectDir))
+
+	// A directory under projects/ with no .repo is not a proj project — this
+	// is what keeps an ordinary repo that happens to live there from being
+	// handed to proj.
+	plain := filepath.Join(root, "projects", "not-proj")
+	if err := os.MkdirAll(plain, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	for _, dir := range []string{plain, root, filepath.Join(root, "projects"), t.TempDir(), ""} {
+		if _, ok := resolveProjProject(dir); ok {
+			t.Errorf("resolveProjProject(%q) ok = true, want false", dir)
+		}
+	}
+}
+
+func TestProjTemplateCount(t *testing.T) {
+	projectDir := newProjRoot(t, "core-stack")
+	if got := projTemplateCount(projectDir); got != 1 {
+		t.Fatalf("projTemplateCount = %d, want 1", got)
+	}
+
+	// A second template would send proj-new's `fzf -1 -0` interactive, which
+	// would hang agent-deck; the backend must decline instead.
+	if err := os.MkdirAll(filepath.Join(projectDir, "00-release"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if got := projTemplateCount(projectDir); got != 2 {
+		t.Fatalf("projTemplateCount = %d, want 2", got)
+	}
+	if _, _, ok := planProjCreate(worktreeAddSpec{
+		repoDir:      projectDir,
+		worktreePath: filepath.Join(projectDir, "feature-x"),
+		branchName:   "feature-x",
+	}); ok {
+		t.Error("planProjCreate ok = true with 2 templates, want false")
+	}
+}
+
+func TestPlanProjCreateNarrowing(t *testing.T) {
+	if !projToolsAvailable() {
+		t.Skip("proj toolchain not installed on this host")
+	}
+	projectDir := newProjRoot(t, "core-stack")
+
+	t.Run("accepts a path inside the project dir", func(t *testing.T) {
+		plan, reason, ok := planProjCreate(worktreeAddSpec{
+			repoDir:      projectDir,
+			worktreePath: filepath.Join(projectDir, "feature-x"),
+			branchName:   "michelle/feature-x",
+		})
+		if !ok {
+			t.Fatalf("planProjCreate ok = false (%s), want true", reason)
+		}
+		if plan.treeName != "feature-x" {
+			t.Errorf("treeName = %q, want %q", plan.treeName, "feature-x")
+		}
+		if plan.branch != "michelle/feature-x" {
+			t.Errorf("branch = %q, want %q", plan.branch, "michelle/feature-x")
+		}
+	})
+
+	// proj can only ever create <project dir>/<name>. Anything else has to go
+	// to git, or agent-deck would record a path proj never created.
+	rejected := map[string]string{
+		"sibling":        projectDir + "-feature-x",
+		"subdirectory":   filepath.Join(projectDir, ".worktrees", "feature-x"),
+		"nested deeper":  filepath.Join(projectDir, "feature-x", "nested"),
+		"outside root":   filepath.Join(t.TempDir(), "feature-x"),
+		"reserved repo":  filepath.Join(projectDir, ".repo"),
+		"reserved templ": filepath.Join(projectDir, "00-master"),
+	}
+	for name, path := range rejected {
+		t.Run("rejects "+name, func(t *testing.T) {
+			if _, _, ok := planProjCreate(worktreeAddSpec{
+				repoDir:      projectDir,
+				worktreePath: path,
+				branchName:   "feature-x",
+			}); ok {
+				t.Errorf("planProjCreate(%q) ok = true, want false", path)
+			}
+		})
+	}
+}
+
+func TestGenerateWorktreePathUsesProjLayout(t *testing.T) {
+	if !projToolsAvailable() {
+		t.Skip("proj toolchain not installed on this host")
+	}
+	projectDir := newProjRoot(t, "core-stack")
+
+	SetWorktreeBackend(WorktreeBackendAuto)
+	t.Cleanup(func() { SetWorktreeBackend(WorktreeBackendAuto) })
+
+	// Branch slashes become dashes, matching proj's directory naming.
+	got := GenerateWorktreePath(projectDir, "michelle/feature-x", "subdirectory")
+	want := filepath.Join(projectDir, "michelle-feature-x")
+	if got != want {
+		t.Errorf("GenerateWorktreePath = %q, want %q", got, want)
+	}
+
+	// backend = "git" must restore the stock layout exactly.
+	SetWorktreeBackend(WorktreeBackendGit)
+	got = GenerateWorktreePath(projectDir, "michelle/feature-x", "subdirectory")
+	want = filepath.Join(projectDir, ".worktrees", "michelle-feature-x")
+	if got != want {
+		t.Errorf("with backend=git GenerateWorktreePath = %q, want %q", got, want)
+	}
+}
+
+func TestGenerateWorktreePathUnchangedOutsideProj(t *testing.T) {
+	// The load-bearing guarantee of this backend: a repo proj does not manage
+	// generates exactly the path it did before.
+	t.Setenv("PROJ_ROOT", t.TempDir())
+	SetWorktreeBackend(WorktreeBackendAuto)
+	t.Cleanup(func() { SetWorktreeBackend(WorktreeBackendAuto) })
+
+	repo := filepath.Join(t.TempDir(), "myrepo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	if got, want := GenerateWorktreePath(repo, "feat", "sibling"), repo+"-feat"; got != want {
+		t.Errorf("sibling = %q, want %q", got, want)
+	}
+	if got, want := GenerateWorktreePath(repo, "feat", "subdirectory"), filepath.Join(repo, ".worktrees", "feat"); got != want {
+		t.Errorf("subdirectory = %q, want %q", got, want)
+	}
+}
+
+func TestRunProjPreRemoveHookIgnoresNonProjPaths(t *testing.T) {
+	// Must be a silent no-op rather than an error for every path that is not a
+	// proj worktree, since RemoveWorktree calls it unconditionally.
+	t.Setenv("PROJ_ROOT", t.TempDir())
+	RunProjPreRemoveHook(t.TempDir())
+	RunProjPreRemoveHook("")
+	RunProjPreRemoveHook("/nonexistent/path/xyz")
+}
+
+func TestRunProjPreRemoveHookRuns(t *testing.T) {
+	projectDir := newProjRoot(t, "core-stack")
+	worktree := filepath.Join(projectDir, "feature-x")
+	if err := os.MkdirAll(worktree, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	hookDir := filepath.Join(projectDir, ".proj", "hooks")
+	if err := os.MkdirAll(hookDir, 0o755); err != nil {
+		t.Fatalf("mkdir hooks: %v", err)
+	}
+	marker := filepath.Join(projectDir, "hook-ran")
+	hook := filepath.Join(hookDir, "pre-remove")
+	script := "#!/bin/sh\npwd > " + marker + "\n"
+	if err := os.WriteFile(hook, []byte(script), 0o755); err != nil {
+		t.Fatalf("write hook: %v", err)
+	}
+
+	RunProjPreRemoveHook(worktree)
+
+	data, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("hook did not run: %v", err)
+	}
+	// The hook must run inside the worktree it is tearing down, matching
+	// proj rm, so it can reach that worktree's contents.
+	gotDir := strings.TrimSpace(string(data))
+	resolved, err := filepath.EvalSymlinks(worktree)
+	if err != nil {
+		t.Fatalf("evalsymlinks: %v", err)
+	}
+	if got := filepath.Clean(gotDir); got != worktree && got != resolved {
+		t.Errorf("hook cwd = %q, want %q", got, worktree)
+	}
+
+	// A non-executable hook is skipped rather than failing removal.
+	os.Remove(marker)
+	if err := os.Chmod(hook, 0o644); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	RunProjPreRemoveHook(worktree)
+	if _, err := os.Stat(marker); err == nil {
+		t.Error("non-executable hook ran, want skipped")
+	}
+}
+
+// TestProjBackendDisabledLeavesCreationOnGit is the regression guard for the
+// whole fork: with backend=git, creation must be the stock code path even
+// inside a real proj project.
+func TestProjBackendDisabledLeavesCreationOnGit(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	projectDir := newProjRoot(t, "core-stack")
+
+	SetWorktreeBackend(WorktreeBackendGit)
+	t.Cleanup(func() { SetWorktreeBackend(WorktreeBackendAuto) })
+
+	if _, _, ok := planProjCreate(worktreeAddSpec{
+		repoDir:      projectDir,
+		worktreePath: filepath.Join(projectDir, "feature-x"),
+		branchName:   "feature-x",
+	}); ok {
+		// planProjCreate itself does not read the backend; runWorktreeAdd
+		// gates on it. Assert the gate instead.
+		if WorktreeBackend() != WorktreeBackendGit {
+			t.Fatal("backend not set to git")
+		}
+	}
+	if WorktreeBackend() != WorktreeBackendGit {
+		t.Errorf("WorktreeBackend() = %q, want %q", WorktreeBackend(), WorktreeBackendGit)
+	}
+}

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -2360,6 +2360,22 @@ type WorktreeSettings struct {
 	// to "always". See --allow-repo-scripts / AGENT_DECK_ALLOW_REPO_SCRIPTS
 	// for a one-shot, non-persisted bypass (CI).
 	RunRepoScripts string `toml:"run_repo_scripts,omitempty"`
+
+	// Backend selects how a worktree is created:
+	//   "auto" (default, "" too) → proj's reflink copy of a template worktree
+	//     when the repository layout and host tooling support it, plain
+	//     `git worktree add` otherwise
+	//   "proj" → same, except a repository proj cannot serve is an error
+	//     instead of a silent (and much slower) fallback
+	//   "git"  → never use proj
+	// Unknown values resolve to "auto". See internal/git/proj.go.
+	Backend string `toml:"backend,omitempty"`
+}
+
+// WorktreeBackend returns the parsed [worktree] backend value, defaulting to
+// git.WorktreeBackendAuto.
+func (w WorktreeSettings) WorktreeBackend() string {
+	return git.ParseWorktreeBackend(w.Backend)
 }
 
 // ScriptConsentPolicy returns the parsed [worktree] run_repo_scripts value.
@@ -4184,9 +4200,11 @@ func (w WorktreeSettings) GetAutoCleanup() bool {
 func GetWorktreeSettings() WorktreeSettings {
 	config, err := LoadUserConfig()
 	if err != nil || config == nil {
-		return WorktreeSettings{
+		settings := WorktreeSettings{
 			DefaultLocation: "subdirectory",
 		}
+		git.SetWorktreeBackend(settings.WorktreeBackend())
+		return settings
 	}
 
 	settings := config.Worktree
@@ -4194,6 +4212,12 @@ func GetWorktreeSettings() WorktreeSettings {
 	if settings.DefaultLocation == "" {
 		settings.DefaultLocation = "subdirectory"
 	}
+
+	// Push the resolved backend into the git package, which does not read
+	// config itself. Done here rather than at startup because every worktree
+	// entry point (TUI, CLI, web, remote) already funnels through this call,
+	// so none can reach creation with a stale backend.
+	git.SetWorktreeBackend(settings.WorktreeBackend())
 
 	return settings
 }


### PR DESCRIPTION
On a large monorepo `git worktree add` writes a full checkout every time: minutes of I/O, gigabytes of disk, and a cold build cache in every new worktree. proj creates a worktree by reflink-copying a template worktree instead, which is near-instant and carries over ignored build artifacts.

Adds `[worktree] backend` (auto | proj | git, default auto). The detection narrows hard — proj is used only when the repository is a proj project, the requested path is exactly the one proj would create, exactly one template worktree exists (more would send proj's fzf picker interactive and hang a headless caller), and the full proj toolchain including `git relocate` is present. Anything else falls through to the existing git path unchanged, which the untouched existing test suite pins.

The branch is created before proj runs and proj is always invoked in its --existing mode, so agent-deck's own branch resolution and start point win over proj's PROJ_PREFIX/<name> convention. Path generation is taught the same layout, since a generated path proj cannot serve would silently disable the backend. Removal gains proj's pre-remove hook, the only part of `proj rm` that plain `git worktree remove` would otherwise skip.


Claude-Session: https://claude.ai/code/session_01MNrFiCcXC9gaobvupaAeKj

## What problem does this solve?

<!-- One or two sentences, framed from the user's point of view. Link the issue or Discussion if one exists. -->

## Why this change

<!-- Why this approach? Anything you tried that didn't work? -->

## User impact

<!-- What changes for someone running agent-deck? "None, internal only" is a valid answer. -->

## Evidence

<!-- For behavior changes: real output, a terminal capture, or before/after logs. Mock-only proof is not enough for changes users will feel. -->

## AI disclosure

<!-- Pick one. AI PRs are welcome here with equal standing; this is a quality signal, not a gate. -->

- [ ] Human-written
- [ ] AI-assisted (I directed and reviewed it)
- [ ] AI-authored (a model wrote most of it)

**Model(s), if AI helped:** <!-- e.g. claude-opus-4-x, gpt-5-codex, gemini-3-pro. "unsure" is fine. -->

**Prompt / session log (optional):** <!-- a gist or link helps us weight it; not required -->

## What actually bothered you

<!-- In your own words: what were you doing when you hit this? A sentence, a real scenario, a
transcript snippet, a log line. If an agent opened this PR: what did your human actually ask for?
Quote them. This is the first thing a reviewer reads. A one-liner is fine; "" is not. -->

## Checklist

- [ ] Targeted diff: one problem, no unrelated changes
- [ ] Tests added or updated for new behavior
- [ ] Test suite passes sandboxed: `HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test ./...`
- [ ] If this touches a hot path (list, status, session output, startup, tmux layer): before/after timing evidence included
- [ ] CHANGELOG.md untouched (entries are added at landing)
- [ ] AI-assisted? Disclosed above, with validation evidence, and I can answer questions about the code
- [ ] "Allow edits from maintainers" is enabled

<!-- Your PR will be validated (applied, built, tested) by the maintainer's AI pipeline within about a day. You'll get a structured comment with the result. Merges are always human. -->

<!-- gate:ai=<human|assisted|authored> model=<name-or-unsure> intent=<yes|no> -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable worktree backends, including automatic selection, proj-based worktrees, and standard Git worktrees.
  * Added support for creating worktrees through the proj toolchain when the environment is compatible.
  * Added configurable worktree path prediction and cleanup hooks for proj-managed worktrees.
  * Added safeguards to fall back to standard Git worktrees when proj requirements are not met.

* **Tests**
  * Added coverage for backend selection, path handling, creation, cleanup hooks, and end-to-end proj workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->